### PR TITLE
add support for dynamically updating swagger.json, closes #265

### DIFF
--- a/modules/config.xqm
+++ b/modules/config.xqm
@@ -494,7 +494,7 @@ declare function config:set-swagger-option($key as xs:string*, $value as item()?
         case node() return parse-json(json:xml-to-json($value)) (: the output of json:xml-to-json() seems to be a string, not a map object :)
         case array(*) return $value
         case map(*) return $value
-        default return core:link-to-current-app('warn', 'config:set-swagger-option(): failed to convert value of ' || string-join($key, '.') || ' to a JSON object.')
+        default return core:logToFile('warn', 'config:set-swagger-option(): failed to convert value of ' || string-join($key, '.') || ' to a JSON object.')
     let $update := config:map-put-recursive($swagger.json, $key, $valueJSON)
     let $serialize-json := function($json as item()) as xs:string {
         serialize($json, <output:serialization-parameters><output:method>json</output:method></output:serialization-parameters>)

--- a/post-install.xql
+++ b/post-install.xql
@@ -27,7 +27,9 @@ declare function local:mkcol-recursive($collection, $components) {
 declare function local:set-options() as xs:string* {
     for $opt in available-environment-variables()[starts-with(., 'WEGA_WEBAPP_')]
     return
-        config:set-option(substring($opt, 13), string(environment-variable($opt)))
+        if(starts-with($opt, 'WEGA_WEBAPP_SWAGGER_'))
+        then config:set-swagger-option(substring($opt, 21), string(environment-variable($opt)))
+        else config:set-option(substring($opt, 13), string(environment-variable($opt)))
 };
 
 (: Helper function to recursively create a collection hierarchy. :)


### PR DESCRIPTION
* introduce new function `config:set-swagger-option($key as xs:string*, $value as item()?)`

* use this function within post-install script to set swagger options via environment variables