### PR TITLE
support HEAD method for html output

### DIFF
--- a/modules/controller.xqm
+++ b/modules/controller.xqm
@@ -86,6 +86,7 @@ declare variable $controller:projectNav :=
 declare function controller:forward-html($html-template as xs:string, $exist-vars as map(*)*) as element(exist:dispatch) {
     let $etag := controller:etag($exist-vars('exist:path'))
     let $modified := not(functx:substring-before-if-contains(request:get-header('If-None-Match'), '--') = $etag)
+    let $method := request:get-method()
     return (
         <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
             <forward url="{str:join-path-elements((map:get($exist-vars, 'exist:controller'), $html-template))}"/>
@@ -98,6 +99,8 @@ declare function controller:forward-html($html-template as xs:string, $exist-var
                 	}
                     <!-- Need to provoke 304 error in view-html.xql if unmodified -->
                     <set-attribute name="modified" value="{$modified cast as xs:string}"/>
+                    <!-- Forward original request method to view-html.xql -->
+                    <set-attribute name="method" value="{$method}"/>
                 </forward>
                 {if($modified) then 
                 <forward url="{str:join-path-elements((map:get($exist-vars, 'exist:controller'), 'modules/view-tidy.xql'))}">

--- a/modules/view-html.xql
+++ b/modules/view-html.xql
@@ -68,11 +68,10 @@ let $lookup := function($functionName as xs:string, $arity as xs:int) {
  : Run it through the templating system and return the result.
 ~:)
 let $content := request:get-data()
-let $modified := request:get-attribute('modified') = 'true'
+let $modified := $model?modified eq 'true'
 return 
-    if($modified) then (:wega-util:stopwatch(templates:apply#4, ($content, $lookup, $model, $config), ()):)
-        templates:apply($content, $lookup, $model, $config)
-    else ( 
-        (:util:log-system-out('cached ' || $model('docID')),:) 
-        response:set-status-code( 304 )
-    )
+    if($modified) then 
+        if($model?method eq 'HEAD') then <html/>
+        (:wega-util:stopwatch(templates:apply#4, ($content, $lookup, $model, $config), ()):)
+        else templates:apply($content, $lookup, $model, $config)
+    else response:set-status-code( 304 )

--- a/modules/view-json.xql
+++ b/modules/view-json.xql
@@ -18,11 +18,9 @@ declare option output:method "json";
 declare option output:media-type "application/json";
 
 
-let $content := request:get-data()
 let $docID := request:get-attribute('docID')
 let $sourceID := request:get-attribute('sourceID')
 let $type := request:get-attribute('type')
-let $image := request:get-attribute('image')
 let $setHeader5 := response:set-header('Access-Control-Allow-Origin', '*')
 return
     if($type eq 'manifest') then 


### PR DESCRIPTION
as documented in issue #422, a HEAD request would always return an error 400. This was due to `request:get-data()` 
https://github.com/Edirom/WeGA-WebApp/blob/af5743518bcd9a62c55cee516d107aebe53181c4/modules/view-html.xql#L70
returning an empty-sequence for HEAD requests, causing `templates:apply()` https://github.com/Edirom/WeGA-WebApp/blob/af5743518bcd9a62c55cee516d107aebe53181c4/modules/view-html.xql#L74 to fail. 

The remedy is to propagate the HEAD method to `view-html.xql` and have a dedicated conditional clause there.