### PR TITLE
add place of sender and addressee to the backlinks

### DIFF
--- a/modules/wdt.xqm
+++ b/modules/wdt.xqm
@@ -1008,13 +1008,16 @@ declare function wdt:backlinks($item as item()*) as map(*) {
         },
         'filter-by-person' : function($personID as xs:string) as document-node()* {
             let $docsAuthor := 
-                (: currently, can't use core:getOrCreateColl() because of performance loss :)
-                crud:data-collection('letters')//tei:*[contains(@key, $personID)][ancestor::tei:correspAction][not(ancestor-or-self::tei:note)]/root() |
-                crud:data-collection('writings')//tei:author[@key = $personID][ancestor::tei:fileDesc]/root()  |
-                crud:data-collection('news')//tei:author[@key = $personID][ancestor::tei:fileDesc]/root()  |
-                crud:data-collection('thematicCommentaries')//tei:author[@key = $personID][ancestor::tei:fileDesc]/root()  |
-                crud:data-collection('documents')//tei:author[@key = $personID][ancestor::tei:fileDesc]/root() |
-                crud:data-collection('works')//mei:persName[@codedval = $personID][@role=('cmp', 'lbt', 'lyr', 'aut', 'trl')][ancestor::mei:fileDesc]/root()
+                if(wdt:personsPlus($personID)?check()) (: see https://github.com/Edirom/WeGA-WebApp/issues/466 :)
+                then
+                    (: currently, can't use core:getOrCreateColl() because of performance loss :)
+                    crud:data-collection('letters')//tei:*[contains(@key, $personID)][ancestor::tei:correspAction][not(ancestor-or-self::tei:note)]/root() |
+                    crud:data-collection('writings')//tei:author[@key = $personID][ancestor::tei:fileDesc]/root()  |
+                    crud:data-collection('news')//tei:author[@key = $personID][ancestor::tei:fileDesc]/root()  |
+                    crud:data-collection('thematicCommentaries')//tei:author[@key = $personID][ancestor::tei:fileDesc]/root()  |
+                    crud:data-collection('documents')//tei:author[@key = $personID][ancestor::tei:fileDesc]/root() |
+                    crud:data-collection('works')//mei:persName[@codedval = $personID][@role=('cmp', 'lbt', 'lyr', 'aut', 'trl')][ancestor::mei:fileDesc]/root()
+                else ()
             let $docsMentioned := 
                 crud:data-collection('letters')//tei:*[contains(@key,$personID)][not(ancestor::tei:publicationStmt)]/root() | 
                 crud:data-collection('diaries')//tei:*[contains(@key,$personID)]/root() |

--- a/testing/expected-results/diaries/A063855.html
+++ b/testing/expected-results/diaries/A063855.html
@@ -15,8 +15,8 @@
         <meta property="dc:creator" content="" />
         <meta property="dc:date" content="" />
         <meta property="dc:identifier" content="https://weber-gesamtausgabe.de/exist/apps/WeGA-WebApp/A063855" />
-        <meta property="dc:description" content="d: 29t mit Rosenbaum Gallerie im Belvedere gesehen Armbrustsche Ambraser Samlung 1. 8 – Mittag bei Schwarz. 2 Tücher für die Rosel und Mine gekauft 8 …" />
-        <meta name="description" content="d: 29t mit Rosenbaum Gallerie im Belvedere gesehen Armbrustsche Ambraser Samlung 1. 8 – Mittag bei Schwarz. 2 Tücher für die Rosel und Mine gekauft 8 …" />
+        <meta property="dc:description" content="d: 29t mit Rosenbaum Gallerie im Belvedere gesehen Ambraser Samlung 1. 8 – Mittag bei Schwarz. 2 Tücher für die Rosel und Mine gekauft 8 …" />
+        <meta name="description" content="d: 29t mit Rosenbaum Gallerie im Belvedere gesehen Ambraser Samlung 1. 8 – Mittag bei Schwarz. 2 Tücher für die Rosel und Mine gekauft 8 …" />
         <meta property="dc:subject" content="Tagebuch; Carl Maria von Weber" />
         <meta property="dc:language" content="de" />
         <meta property="dc:rights" content="https://creativecommons.org/licenses/by/4.0/" />
@@ -47,7 +47,7 @@
         <link rel="stylesheet" type="text/css" href="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/css/dataTables.bootstrap4.min.css" />
         <link rel="stylesheet" type="text/css" href="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-buttons-bs4/css/buttons.bootstrap4.min.css" />
         
-        <script type="application/ld+json">{"@context":"http://schema.org","@type":"CreativeWork","description":"d: 29t mit Rosenbaum Gallerie im Belvedere gesehen Armbrustsche Ambraser Samlung 1. 8 – Mittag bei Schwarz. 2 Tücher für die Rosel und Mine gekauft 8 …","publisher":{"name":"Carl-Maria-von-Weber-Gesamtausgabe","url":"https://weber-gesamtausgabe.de","@type":"Organization"},"name":"Carl Maria von Weber – Tagebucheintrag vom Mittwoch, 29. Oktober 1823 ()","@id":"https://weber-gesamtausgabe.de/exist/apps/WeGA-WebApp/A063855","license":"https://creativecommons.org/licenses/by/4.0/","url":"https://weber-gesamtausgabe.de/exist/apps/WeGA-WebApp/de/A002068/Tagebücher/A063855","author":[],"funder":{"name":"Akademie der Wissenschaften und der Literatur, Mainz","url":"http://adwmainz.de","@type":"Organization"}}</script>
+        <script type="application/ld+json">{"@context":"http://schema.org","@type":"CreativeWork","description":"d: 29t mit Rosenbaum Gallerie im Belvedere gesehen Ambraser Samlung 1. 8 – Mittag bei Schwarz. 2 Tücher für die Rosel und Mine gekauft 8 …","publisher":{"name":"Carl-Maria-von-Weber-Gesamtausgabe","url":"https://weber-gesamtausgabe.de","@type":"Organization"},"name":"Carl Maria von Weber – Tagebucheintrag vom Mittwoch, 29. Oktober 1823 ()","@id":"https://weber-gesamtausgabe.de/exist/apps/WeGA-WebApp/A063855","license":"https://creativecommons.org/licenses/by/4.0/","url":"https://weber-gesamtausgabe.de/exist/apps/WeGA-WebApp/de/A002068/Tagebücher/A063855","author":[],"funder":{"name":"Akademie der Wissenschaften und der Literatur, Mainz","url":"http://adwmainz.de","@type":"Organization"}}</script>
 
 
     </head>

--- a/testing/expected-results/diaries/A063855.html
+++ b/testing/expected-results/diaries/A063855.html
@@ -15,8 +15,8 @@
         <meta property="dc:creator" content="" />
         <meta property="dc:date" content="" />
         <meta property="dc:identifier" content="https://weber-gesamtausgabe.de/exist/apps/WeGA-WebApp/A063855" />
-        <meta property="dc:description" content="d: 29t mit Rosenbaum Gallerie im Belvedere gesehen Ambraser Samlung 1. 8 – Mittag bei Schwarz. 2 Tücher für die Rosel und Mine gekauft 8 …" />
-        <meta name="description" content="d: 29t mit Rosenbaum Gallerie im Belvedere gesehen Ambraser Samlung 1. 8 – Mittag bei Schwarz. 2 Tücher für die Rosel und Mine gekauft 8 …" />
+        <meta property="dc:description" content="d: 29t mit Rosenbaum Gallerie im Belvedere gesehen Ambraser Samlung 1. 8 – Mittag bei Schwarz. 2 Tücher für die Rosel und Mine gekauft 8. – – Abends …" />
+        <meta name="description" content="d: 29t mit Rosenbaum Gallerie im Belvedere gesehen Ambraser Samlung 1. 8 – Mittag bei Schwarz. 2 Tücher für die Rosel und Mine gekauft 8. – – Abends …" />
         <meta property="dc:subject" content="Tagebuch; Carl Maria von Weber" />
         <meta property="dc:language" content="de" />
         <meta property="dc:rights" content="https://creativecommons.org/licenses/by/4.0/" />
@@ -47,7 +47,7 @@
         <link rel="stylesheet" type="text/css" href="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/css/dataTables.bootstrap4.min.css" />
         <link rel="stylesheet" type="text/css" href="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-buttons-bs4/css/buttons.bootstrap4.min.css" />
         
-        <script type="application/ld+json">{"@context":"http://schema.org","@type":"CreativeWork","description":"d: 29t mit Rosenbaum Gallerie im Belvedere gesehen Ambraser Samlung 1. 8 – Mittag bei Schwarz. 2 Tücher für die Rosel und Mine gekauft 8 …","publisher":{"name":"Carl-Maria-von-Weber-Gesamtausgabe","url":"https://weber-gesamtausgabe.de","@type":"Organization"},"name":"Carl Maria von Weber – Tagebucheintrag vom Mittwoch, 29. Oktober 1823 ()","@id":"https://weber-gesamtausgabe.de/exist/apps/WeGA-WebApp/A063855","license":"https://creativecommons.org/licenses/by/4.0/","url":"https://weber-gesamtausgabe.de/exist/apps/WeGA-WebApp/de/A002068/Tagebücher/A063855","author":[],"funder":{"name":"Akademie der Wissenschaften und der Literatur, Mainz","url":"http://adwmainz.de","@type":"Organization"}}</script>
+        <script type="application/ld+json">{"@context":"http://schema.org","@type":"CreativeWork","description":"d: 29t mit Rosenbaum Gallerie im Belvedere gesehen Ambraser Samlung 1. 8 – Mittag bei Schwarz. 2 Tücher für die Rosel und Mine gekauft 8. – – Abends …","publisher":{"name":"Carl-Maria-von-Weber-Gesamtausgabe","url":"https://weber-gesamtausgabe.de","@type":"Organization"},"name":"Carl Maria von Weber – Tagebucheintrag vom Mittwoch, 29. Oktober 1823 ()","@id":"https://weber-gesamtausgabe.de/exist/apps/WeGA-WebApp/A063855","license":"https://creativecommons.org/licenses/by/4.0/","url":"https://weber-gesamtausgabe.de/exist/apps/WeGA-WebApp/de/A002068/Tagebücher/A063855","author":[],"funder":{"name":"Akademie der Wissenschaften und der Literatur, Mainz","url":"http://adwmainz.de","@type":"Organization"}}</script>
 
 
     </head>


### PR DESCRIPTION
this fixes #466 by constraining the variable `$docsAuthor` in `wdt:backlinks` to "real" authors. This in turn allows places and other entities to show up in the backlinks.

The updates to the expected results are actually *not* connected to this PR but are a aftermath of https://github.com/Edirom/WeGA-WebApp-lib/pull/14