### PR TITLE
fix output of correspondence partners in the context pane

### DIFF
--- a/modules/app.xqm
+++ b/modules/app.xqm
@@ -627,20 +627,20 @@ declare %private function app:createLetterLink($teiDate as element(tei:date)?, $
 };
 
 (:~
- : Construct a name from a tei:persName or tei:name element wrapped in a <span> 
- : If a @key is given on persName the regularized form will be returned, otherwise the content of persName.
- : If persName is empty than "unknown" is returned.
+ : Construct a name from a tei:persName, tei:orgName, or tei:name element wrapped in a <span> 
+ : If a @key is given on the element the regularized form will be returned, otherwise the content of the element.
+ : If the element is empty than "unknown" is returned.
  : 
  : @author Peter Stadler
- : @param $persName the tei:persName element
+ : @param $persName the tei:persName, tei:orgName, or tei:name element
  : @param $lang the current language (de|en)
- : @param $order (sf|fs) whether to print "surname, forename" or "forename surname"
- : @return 
+ : @param $order (sf|fs|s) whether to print "surname, forename", or "forename surname", or just the surname
+ : @return a html:span element with the constructed name
  :)
-declare function app:printCorrespondentName($persName as element()?, $lang as xs:string, $order as xs:string) as element() {
+declare function app:printCorrespondentName($persName as element()?, $lang as xs:string, $order as xs:string) as element(xhtml:span) {
     if(exists($persName/@key)) then 
         if ($order eq 'fs') then app:createDocLink(crud:doc($persName/string(@key)), wega-util:print-forename-surname-from-nameLike-element($persName), $lang, ('class=' || config:get-doctype-by-id($persName/@key)))
-        else if ($order eq 's') then app:createDocLink(crud:doc($persName/string(@key)), substring-before(query:title($persName/@key),','), $lang, ('class=preview ' || concat($persName/@key, " ", config:get-doctype-by-id($persName/@key))))
+        else if ($order eq 's') then app:createDocLink(crud:doc($persName/string(@key)), functx:substring-before-if-contains(query:title($persName/@key), ', '), $lang, ('class=preview ' || concat($persName/@key, " ", config:get-doctype-by-id($persName/@key))))
         else app:createDocLink(crud:doc($persName/string(@key)), query:title($persName/@key), $lang, ('class=' || config:get-doctype-by-id($persName/@key)))
     else if(not(functx:all-whitespace($persName))) then 
         if ($order eq 'fs') then <xhtml:span class="noDataFound">{wega-util:print-forename-surname-from-nameLike-element($persName)}</xhtml:span>

--- a/testing/expected-results/letters/A041782.html
+++ b/testing/expected-results/letters/A041782.html
@@ -366,7 +366,7 @@
                                            <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A041743.html">1821-05-31</a>:  an  <a href="" class="preview A001002 persons"></a>
                                        </li>
                                             <li>
-                                           <a href="/exist/apps/WeGA-WebApp/de/A080005/Korrespondenz/A041712.html">1821-08-16</a>:  von  <a href="/exist/apps/WeGA-WebApp/de/A080005.html" class="preview A080005 orgs"></a>
+                                           <a href="/exist/apps/WeGA-WebApp/de/A080005/Korrespondenz/A041712.html">1821-08-16</a>:  von  <a href="/exist/apps/WeGA-WebApp/de/A080005.html" class="preview A080005 orgs">Theaterintendanz Karlsruhe</a>
                                        </li>
                                    </ul>
                                    <h4>Folgend</h4>

--- a/testing/expected-results/letters/A041797.html
+++ b/testing/expected-results/letters/A041797.html
@@ -367,7 +367,7 @@
                                            <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A041782.html">1821-09-17</a>:  an  <a href="" class="preview A000477 persons"></a>
                                        </li>
                                             <li>
-                                           <a href="/exist/apps/WeGA-WebApp/de/A080005/Korrespondenz/A041712.html">1821-08-16</a>:  von  <a href="/exist/apps/WeGA-WebApp/de/A080005.html" class="preview A080005 orgs"></a>
+                                           <a href="/exist/apps/WeGA-WebApp/de/A080005/Korrespondenz/A041712.html">1821-08-16</a>:  von  <a href="/exist/apps/WeGA-WebApp/de/A080005.html" class="preview A080005 orgs">Theaterintendanz Karlsruhe</a>
                                        </li>
                                    </ul>
                                    <h4>Folgend</h4>

--- a/testing/expected-results/letters/A041822.html
+++ b/testing/expected-results/letters/A041822.html
@@ -376,7 +376,7 @@
                                            <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A041797.html">1821-10-25</a>:  an  <a href="" class="preview A001898 persons"></a>
                                        </li>
                                             <li>
-                                           <a href="/exist/apps/WeGA-WebApp/de/A080005/Korrespondenz/A041712.html">1821-08-16</a>:  von  <a href="/exist/apps/WeGA-WebApp/de/A080005.html" class="preview A080005 orgs"></a>
+                                           <a href="/exist/apps/WeGA-WebApp/de/A080005/Korrespondenz/A041712.html">1821-08-16</a>:  von  <a href="/exist/apps/WeGA-WebApp/de/A080005.html" class="preview A080005 orgs">Theaterintendanz Karlsruhe</a>
                                        </li>
                                    </ul>
                                    <h4>Folgend</h4>

--- a/testing/expected-results/letters/A041890.html
+++ b/testing/expected-results/letters/A041890.html
@@ -367,7 +367,7 @@
                                            <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A041822.html">1821-12-17</a>:  an  <a href="" class="preview A001980 persons"></a>
                                        </li>
                                             <li>
-                                           <a href="/exist/apps/WeGA-WebApp/de/A080005/Korrespondenz/A041712.html">1821-08-16</a>:  von  <a href="/exist/apps/WeGA-WebApp/de/A080005.html" class="preview A080005 orgs"></a>
+                                           <a href="/exist/apps/WeGA-WebApp/de/A080005/Korrespondenz/A041712.html">1821-08-16</a>:  von  <a href="/exist/apps/WeGA-WebApp/de/A080005.html" class="preview A080005 orgs">Theaterintendanz Karlsruhe</a>
                                        </li>
                                    </ul>
                                    <h4>Folgend</h4>

--- a/testing/expected-results/letters/A041892.html
+++ b/testing/expected-results/letters/A041892.html
@@ -367,7 +367,7 @@
                                            <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A041890.html">1822-01-18</a>:  an  <a href="" class="preview A080002 orgs"></a>
                                        </li>
                                             <li>
-                                           <a href="/exist/apps/WeGA-WebApp/de/A080005/Korrespondenz/A041712.html">1821-08-16</a>:  von  <a href="/exist/apps/WeGA-WebApp/de/A080005.html" class="preview A080005 orgs"></a>
+                                           <a href="/exist/apps/WeGA-WebApp/de/A080005/Korrespondenz/A041712.html">1821-08-16</a>:  von  <a href="/exist/apps/WeGA-WebApp/de/A080005.html" class="preview A080005 orgs">Theaterintendanz Karlsruhe</a>
                                        </li>
                                    </ul>
                                    <h4>Folgend</h4>

--- a/testing/expected-results/letters/A041894.html
+++ b/testing/expected-results/letters/A041894.html
@@ -365,7 +365,7 @@
                                            <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A041892.html">1822-01-21</a>:  an  <a href="" class="preview A001693 persons"></a>
                                        </li>
                                             <li>
-                                           <a href="/exist/apps/WeGA-WebApp/de/A080005/Korrespondenz/A041712.html">1821-08-16</a>:  von  <a href="/exist/apps/WeGA-WebApp/de/A080005.html" class="preview A080005 orgs"></a>
+                                           <a href="/exist/apps/WeGA-WebApp/de/A080005/Korrespondenz/A041712.html">1821-08-16</a>:  von  <a href="/exist/apps/WeGA-WebApp/de/A080005.html" class="preview A080005 orgs">Theaterintendanz Karlsruhe</a>
                                        </li>
                                    </ul>
                                    <h4>Folgend</h4>

--- a/testing/expected-results/letters/A042166.html
+++ b/testing/expected-results/letters/A042166.html
@@ -374,7 +374,7 @@
                                            <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A042301.html">1824-05-26</a>:  an  <a href="" class="preview A000354 persons"></a>
                                        </li>
                                             <li>
-                                           <a href="/exist/apps/WeGA-WebApp/de/A080005/Korrespondenz/A042080.html">1823-12-04</a>:  von  <a href="/exist/apps/WeGA-WebApp/de/A080005.html" class="preview A080005 orgs"></a>
+                                           <a href="/exist/apps/WeGA-WebApp/de/A080005/Korrespondenz/A042080.html">1823-12-04</a>:  von  <a href="/exist/apps/WeGA-WebApp/de/A080005.html" class="preview A080005 orgs">Theaterintendanz Karlsruhe</a>
                                        </li>
                                    </ul>
                                 

--- a/testing/expected-results/letters/A045410.html
+++ b/testing/expected-results/letters/A045410.html
@@ -376,7 +376,7 @@
                                            <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A042166.html">1823-11-04</a>:  an  <a href="" class="preview A001848 persons"></a>
                                        </li>
                                             <li>
-                                           <a href="/exist/apps/WeGA-WebApp/de/A080005/Korrespondenz/A042080.html">1823-12-04</a>:  von  <a href="/exist/apps/WeGA-WebApp/de/A080005.html" class="preview A080005 orgs"></a>
+                                           <a href="/exist/apps/WeGA-WebApp/de/A080005/Korrespondenz/A042080.html">1823-12-04</a>:  von  <a href="/exist/apps/WeGA-WebApp/de/A080005.html" class="preview A080005 orgs">Theaterintendanz Karlsruhe</a>
                                        </li>
                                    </ul>
                                 


### PR DESCRIPTION
This PR fixes issue #474 where the names of correspondence partners were not output due to the fact that their (canonical) name did not contain a comma. This was especially true for orgNames where it surfaced.