### PR TITLE
remove 'no portrait available' tooltip from work icons

### DIFF
--- a/modules/img.xqm
+++ b/modules/img.xqm
@@ -477,8 +477,11 @@ declare
             return
                 element {node-name($node)} {
                     $node/@*[not(local-name(.) = ('src', 'title', 'alt'))],
-                    attribute title {$model('portrait')('caption')},
-                    attribute alt {$model('portrait')('caption')},
+                    if($model('portrait')('caption')) then (
+                        attribute title {$model('portrait')('caption')},
+                        attribute alt {$model('portrait')('caption')}
+                    )
+                    else attribute alt {'Preview Icon'},
                     attribute src {$url}
                 }
         else $node
@@ -491,9 +494,13 @@ declare %private function img:get-generic-portrait($model as map(*), $lang as xs
         else if($model('doc')//mei:term/data(@class) = 'http://d-nb.info/standards/elementset/gnd#MusicalWork') then 'musicalWork'
         else if(config:is-work($model('docID')) and not($model('doc')//mei:term/data(@class) = 'http://d-nb.info/standards/elementset/gnd#MusicalWork')) then 'otherWork'
         else $model('doc')//tei:sex/text()
+    let $caption :=
+        if(config:is-person($model('docID')))
+        then 'no portrait available'
+        else ()
     return
         map {
-            'caption' : 'no portrait available',
+            'caption' : $caption,
             'linkTarget' : (),
             'source' : 'Carl-Maria-von-Weber-Gesamtausgabe',
             'url' : function($size) {

--- a/testing/expected-results/orgs/A080005.html
+++ b/testing/expected-results/orgs/A080005.html
@@ -277,7 +277,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/orgs/A080033.html
+++ b/testing/expected-results/orgs/A080033.html
@@ -277,7 +277,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/orgs/A080043.html
+++ b/testing/expected-results/orgs/A080043.html
@@ -277,7 +277,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/orgs/A080052.html
+++ b/testing/expected-results/orgs/A080052.html
@@ -277,7 +277,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/orgs/A080059.html
+++ b/testing/expected-results/orgs/A080059.html
@@ -277,7 +277,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/orgs/A080114.html
+++ b/testing/expected-results/orgs/A080114.html
@@ -277,7 +277,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/orgs/A080124.html
+++ b/testing/expected-results/orgs/A080124.html
@@ -277,7 +277,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/orgs/A080126.html
+++ b/testing/expected-results/orgs/A080126.html
@@ -277,7 +277,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/orgs/A080135.html
+++ b/testing/expected-results/orgs/A080135.html
@@ -277,7 +277,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/orgs/A080146.html
+++ b/testing/expected-results/orgs/A080146.html
@@ -277,7 +277,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/orgs/A080158.html
+++ b/testing/expected-results/orgs/A080158.html
@@ -277,7 +277,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/orgs/A080219.html
+++ b/testing/expected-results/orgs/A080219.html
@@ -277,7 +277,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_orgs_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/places/A130291.html
+++ b/testing/expected-results/places/A130291.html
@@ -276,7 +276,7 @@
                 <div class="col-md-3 col-sm-6">
                     <div class="portrait large">
                         <div class="front">
-                            <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_places_gross.png" />
+                            <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_places_gross.png" />
                         </div>
                         <div class="back colored">
                             <h3>Bildquelle</h3>

--- a/testing/expected-results/works/A020002.html
+++ b/testing/expected-results/works/A020002.html
@@ -265,7 +265,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_musicalWorks_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_musicalWorks_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/works/A020010.html
+++ b/testing/expected-results/works/A020010.html
@@ -265,7 +265,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_musicalWorks_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_musicalWorks_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/works/A020034.html
+++ b/testing/expected-results/works/A020034.html
@@ -265,7 +265,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_musicalWorks_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_musicalWorks_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/works/A020072.html
+++ b/testing/expected-results/works/A020072.html
@@ -266,7 +266,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_musicalWorks_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_musicalWorks_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/works/A020081.html
+++ b/testing/expected-results/works/A020081.html
@@ -266,7 +266,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_musicalWorks_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_musicalWorks_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/works/A020209.html
+++ b/testing/expected-results/works/A020209.html
@@ -267,7 +267,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_musicalWorks_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_musicalWorks_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/works/A020456.html
+++ b/testing/expected-results/works/A020456.html
@@ -263,7 +263,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_musicalWorks_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_musicalWorks_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/works/A020772.html
+++ b/testing/expected-results/works/A020772.html
@@ -264,7 +264,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_musicalWorks_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_musicalWorks_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/works/A021059.html
+++ b/testing/expected-results/works/A021059.html
@@ -263,7 +263,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_works_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_works_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/works/A021447.html
+++ b/testing/expected-results/works/A021447.html
@@ -263,7 +263,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_musicalWorks_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_musicalWorks_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/works/A021531.html
+++ b/testing/expected-results/works/A021531.html
@@ -263,7 +263,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_musicalWorks_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_musicalWorks_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>

--- a/testing/expected-results/works/A021539.html
+++ b/testing/expected-results/works/A021539.html
@@ -263,7 +263,7 @@
                 
                 <div class="portrait large">
                     <div class="front">
-                        <img class="img-fluid" title="no portrait available" alt="no portrait available" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_musicalWorks_gross.png" />
+                        <img class="img-fluid" alt="Preview Icon" src="/exist/apps/WeGA-WebApp/resources/img/icons/icon_musicalWorks_gross.png" />
                     </div>
                     <div class="back colored">
                         <h3>Bildquelle</h3>


### PR DESCRIPTION
The default for preview icons without caption is now the empty sequence, and to remove the title attribute for those cases. Only for person preview icons the old default caption/alt text 'no portrait available' is kept. Closes #430