### PR TITLE
Update crud:doc()

### DIFF
--- a/modules/crud.xqm
+++ b/modules/crud.xqm
@@ -26,17 +26,21 @@ import module namespace str="http://xquery.weber-gesamtausgabe.de/modules/str" a
  : @param $docID the ID of the document
  : @return the document node of the resource found for the specified ID
 :)
-declare function crud:doc($docID as xs:string) as document-node()? {
-    let $collectionPath := config:getCollectionPath($docID)
-    let $docURL := str:join-path-elements(($collectionPath, $docID)) || '.xml'
-    return 
-        if(doc-available($docURL)) then
-            let $doc := doc($docURL) 
-            return
-                if($doc/*/*:ref/@target) then crud:doc($doc/*/*:ref/@target)
-                else $doc
-        else if($config:isDevelopment) then wega-util:log-to-file('debug', 'crud:doc(): unable to open ' || $docID)
-        else ()
+declare function crud:doc($docID as xs:string?) as document-node()? {
+    if($docID)
+    then(
+        let $collectionPath := config:getCollectionPath($docID)
+        let $docURL := str:join-path-elements(($collectionPath, $docID)) || '.xml'
+        return 
+            if(doc-available($docURL)) then
+                let $doc := doc($docURL) 
+                return
+                    if($doc/*/*:ref/@target) then crud:doc($doc/*/*:ref/@target)
+                    else $doc
+            else if($config:isDevelopment) then wega-util:log-to-file('debug', 'crud:doc(): unable to open ' || $docID)
+            else ()
+    )
+    else()
 };
 
 (:~


### PR DESCRIPTION
crud:doc() can handle if the called ID doesn't exists, but the function fails if no ID is passed through. This occurs, e.g., if an element is read but not `@key` is available there. To avoid redundant conditionals for checking this, a conditional is implemented into crud:doc() by this PR.