### PR TITLE
suppress empty dates in the CMIF output

### DIFF
--- a/modules/cmif.xql
+++ b/modules/cmif.xql
@@ -1,5 +1,10 @@
 xquery version "3.1" encoding "UTF-8";
 
+(:~
+ : XQuery for creating a CMIF file from the correspondence descriptions of the WeGA letters 
+ : @see https://correspsearch.net/en/documentation.html
+ :)
+
 declare namespace tei="http://www.tei-c.org/ns/1.0";
 declare namespace exist="http://exist.sourceforge.net/NS/exist";
 declare namespace ct="http://wiki.tei-c.org/index.php/SIG:Correspondence/task-force-correspDesc";

--- a/modules/cmif.xql
+++ b/modules/cmif.xql
@@ -154,14 +154,18 @@ declare function ct:place($input as element()) as element(tei:placeName) {
         }
 };
 
-declare function ct:date($input as element()) as element(tei:date) {
-    element {QName('http://www.tei-c.org/ns/1.0', local-name($input))} {
-        $input/@*[not(local-name(.) = ('n', 'calendar'))]
-        (: 
-        no content allowed here with the schema at 
-        https://raw.githubusercontent.com/TEI-Correspondence-SIG/CMIF/master/schema/cmi-customization.rng  
-        :)
-    }
+declare function ct:date($input as element()) as element(tei:date)? {
+    (: The CMIF supports the attributes @when, @from, @to, @notBefore und @notAfter :)
+    if($input/(@when | @from | @to | @notBefore | @notAfter))
+    then
+        element {QName('http://www.tei-c.org/ns/1.0', local-name($input))} {
+            $input/@*[not(local-name(.) = ('n', 'calendar', 'cert'))]
+            (: 
+            no content allowed here with the schema at 
+            https://raw.githubusercontent.com/TEI-Correspondence-SIG/CMIF/master/schema/cmi-customization.rng  
+            :)
+        }
+    else ()
 };
 
 (:~


### PR DESCRIPTION
The function `ct:date#1` now checks for the existence of either `@when`, `@from`, `@to`, `@notBefore` or `@notAfter` and only outputs the date element if such a (by the CMIF standard supported) attribute is present.

Closes #482