### PR TITLE
enable horizontal scrolling for tables

### DIFF
--- a/resources/sass/components/_text.scss
+++ b/resources/sass/components/_text.scss
@@ -13,6 +13,7 @@
 .table-wrapper {
     width: 95%;
     margin: auto;
+    overflow-x: auto;
     th {
         font-family:$font-family-sans-serif;
     }


### PR DESCRIPTION
enable horizontal scrolling for tables if they are wider than their container