### PR TITLE
display tei:p from tei:exemplum in guideline specs

### DIFF
--- a/modules/gl.xqm
+++ b/modules/gl.xqm
@@ -522,7 +522,7 @@ declare %private function gl:print-exemplum($exemplum as element()) as node()* {
     $exemplum,
     doc(concat($config:xsl-collection-path, '/var.xsl')),
     $params
-  )/*
+  )
 };
 
 (:~

--- a/modules/gl.xqm
+++ b/modules/gl.xqm
@@ -513,17 +513,16 @@ declare %private function gl:wega-customization($model as map(*)) as map(*) {
  : Create examples from spec files
  : Helper function for gl:spec-details()
 ~:)
-declare %private function gl:print-exemplum($exemplum as element()) as item()* {
-	let $serializationParameters := 
-	   <output:serialization-parameters>
-	       <output:method>xml</output:method>
-	       <output:indent>no</output:indent>
-	       <output:media-type>application/xml</output:media-type>
-	       <output:omit-xml-declaration>yes</output:omit-xml-declaration>
-	       <output:encoding>utf-8</output:encoding>
-       </output:serialization-parameters>
-	return
-		serialize(functx:change-element-ns-deep($exemplum, '', '')/*/*, $serializationParameters)
+declare %private function gl:print-exemplum($exemplum as element()) as node()* {
+  let $params := config:get-xsl-params(map {
+    "main-source-path" : document-uri($exemplum),
+    "createSecNos" : "false"
+  })
+  return wega-util:transform(
+    $exemplum,
+    doc(concat($config:xsl-collection-path, '/var.xsl')),
+    $params
+  )/*
 };
 
 (:~

--- a/resources/sass/pages/_guidelines.scss
+++ b/resources/sass/pages/_guidelines.scss
@@ -190,3 +190,10 @@ div.toc {
         }
     }
 }
+
+/*
+ * add some margin to examples
+ */
+.guidelines-specs .exemplum {
+    margin-bottom: $line-height-computed;
+}

--- a/templates/guidelines-specs.html
+++ b/templates/guidelines-specs.html
@@ -201,10 +201,7 @@
                                 <div class="col-md-2">
                                     <span class="label" data-template="lang:translate">example</span>
                                 </div>
-                                <div class="col-md-10">
-                                    <pre class="prettyprint"><code data-template="app-shared:output" data-template-key="example" data-template-wrap="yes" class="language-xml"><span class="element">&lt;castGroup <span class="attribute">rend</span>="<span class="attributevalue">braced</span>"&gt;</span><br/> <span class="element">&lt;castItem&gt;</span><br/>  <span class="element">&lt;role&gt;</span>Walter<span class="element">&lt;/role&gt;</span><br/>  <span class="element">&lt;actor&gt;</span>Mr Frank Hall<span class="element">&lt;/actor&gt;</span><br/> <span class="element">&lt;/castItem&gt;</span><br/> <span class="element">&lt;castItem&gt;</span><br/>  <span class="element">&lt;role&gt;</span>Hans<span class="element">&lt;/role&gt;</span><br/>  <span class="element">&lt;actor&gt;</span>Mr F.W. Irish<span class="element">&lt;/actor&gt;</span><br/> <span class="element">&lt;/castItem&gt;</span><br/> <span class="element">&lt;roleDesc&gt;</span>friends of Mathias<span class="element">&lt;/roleDesc&gt;</span><br/><span class="element">&lt;/castGroup&gt;</span>
-                      				</code></pre>
-                                </div>
+                                <div class="col-md-10" data-template="app-shared:output" data-template-key="example" data-template-wrap="yes"/>
                             </div>
                         </div>
                     </div>

--- a/templates/guidelines-specs.html
+++ b/templates/guidelines-specs.html
@@ -86,11 +86,11 @@
                                 <span class="label" data-template="lang:translate">members</span>
                             </div>
                             <div class="col-md-10">
-                                    <ul>
-                                        <li data-template="app-shared:each" data-template-from="members" data-template-to="member">
-                                            <span data-template="gl:print-member" data-template-key="member"/>
-                                        </li>
-                                    </ul>
+                                <ul>
+                                    <li data-template="app-shared:each" data-template-from="members" data-template-to="member">
+                                        <span data-template="gl:print-member" data-template-key="member"/>
+                                    </li>
+                                </ul>
                             </div>
                         </div>
                         <div class="row attributes" data-template="gl:attributes">
@@ -161,16 +161,13 @@
                                                             Note that in this example the role description ‘friends of Mathias’ is understood to apply to both roles equally.</p>
                                                     </div>
                                                 </div>
-                                                <div class="row">
-                                                    <div class="col-md-3" data-template="app-shared:if-exists" data-template-key="examples">
+                                                <div class="row" data-template="app-shared:each" data-template-from="examples" data-template-to="example">
+                                                    <div class="col-md-3">
                                                         <span class="label" data-template="lang:translate">example</span>
                                                     </div>
-                                                    <div data-template="app-shared:each" data-template-from="examples" data-template-to="example">
-                                                        <div class="col-md-9">
-                                                            <div>
-                                                                <pre class="prettyprint"><code data-template="app-shared:output" data-template-key="example" data-template-wrap="yes" class="language-xml"><span class="element">&lt;castGroup <span class="attribute">rend</span>="<span class="attributevalue">braced</span>"&gt;</span><br/> <span class="element">&lt;castItem&gt;</span><br/>  <span class="element">&lt;role&gt;</span>Walter<span class="element">&lt;/role&gt;</span><br/>  <span class="element">&lt;actor&gt;</span>Mr Frank Hall<span class="element">&lt;/actor&gt;</span><br/> <span class="element">&lt;/castItem&gt;</span><br/> <span class="element">&lt;castItem&gt;</span><br/>  <span class="element">&lt;role&gt;</span>Hans<span class="element">&lt;/role&gt;</span><br/>  <span class="element">&lt;actor&gt;</span>Mr F.W. Irish<span class="element">&lt;/actor&gt;</span><br/> <span class="element">&lt;/castItem&gt;</span><br/> <span class="element">&lt;roleDesc&gt;</span>friends of Mathias<span class="element">&lt;/roleDesc&gt;</span><br/><span class="element">&lt;/castGroup&gt;</span></code></pre>
-                                                            </div>
-                                                        </div>
+                                                    <div class="col-md-9">
+                                                        <div data-template="app-shared:output" data-template-key="example">
+                                                        </div>                                                            
                                                     </div>
                                                 </div>
                                             </div>

--- a/xsl/tagdocs.xsl
+++ b/xsl/tagdocs.xsl
@@ -102,7 +102,7 @@
 				<xsl:attribute name="class">prettyprint</xsl:attribute>
 				<xsl:element name="code">
 					<xsl:attribute name="class">language-xml</xsl:attribute>
-					<xsl:apply-templates select="*|comment()|processing-instruction()" mode="verbatim"/>
+					<xsl:apply-templates select="node()" mode="verbatim"/>
 				</xsl:element>
 			</xsl:element>
 			<!-- WeGA only: create back links to documents for examples -->

--- a/xsl/tagdocs.xsl
+++ b/xsl/tagdocs.xsl
@@ -123,6 +123,14 @@
 		</xsl:element>
 	</xsl:template>
 	
+	<xsl:template match="tei:exemplum">
+		<div class="exemplum_wrapper">
+			<div class="exemplum">
+				<xsl:apply-templates/>
+			</div>
+		</div>
+	</xsl:template>
+	
 	<xsl:function name="wega:spec-link">
 		<xsl:param name="specID" as="xs:string"/>
 		<xsl:variable name="specType">

--- a/xsl/tagdocs.xsl
+++ b/xsl/tagdocs.xsl
@@ -87,6 +87,13 @@
 		</xsl:element>
 	</xsl:template>
 	
+	<xsl:template match="tei:exemplum">
+		<xsl:element name="div">
+			<xsl:attribute name="class">exemplum</xsl:attribute>
+			<xsl:apply-templates/>
+		</xsl:element>
+	</xsl:template>
+	
 	<xsl:template match="teix:egXML">
 		<xsl:element name="div">
 			<xsl:attribute name="class" select="'tei_egXML'"/>
@@ -121,14 +128,6 @@
 				</xsl:element>
 			</xsl:if>
 		</xsl:element>
-	</xsl:template>
-	
-	<xsl:template match="tei:exemplum">
-		<div class="exemplum_wrapper">
-			<div class="exemplum">
-				<xsl:apply-templates/>
-			</div>
-		</div>
 	</xsl:template>
 	
 	<xsl:function name="wega:spec-link">


### PR DESCRIPTION
- update gl.xqm/gl:print-exemplum to transform tei:exemplum from compiled ODDS via xslt, instead of serializing it into plain XML-text
- update tagdocs.xsl to include matching and wrapping of tei:exemplum
- update guidelines-specs.html to handle the new format of examples in the template model