### PR TITLE
fix bug with unwanted linebreaks in table-cell descriptions

### DIFF
--- a/resources/sass/pages/_guidelines.scss
+++ b/resources/sass/pages/_guidelines.scss
@@ -97,7 +97,7 @@ span.desc {
 .tei_specList {
     margin-left:1em;
     margin-top:-(ceil(calc($line-height-computed / 2)));
-    li * {
+    li > * {
         display: table-cell;
         padding-right:.5em;
     }


### PR DESCRIPTION
prevents elements inside of descriptions to be included when table-cells are created for listing guideline specs