### PR TITLE
fix attribute prefix

### DIFF
--- a/resources/sass/pages/_guidelines.scss
+++ b/resources/sass/pages/_guidelines.scss
@@ -25,7 +25,7 @@ div.toc-side  {
 }
 
 .attribute:before, .unusedattribute:before {
-    content:"$";
+    content:"@";
 }
 
 .unusedattribute {


### PR DESCRIPTION
I just occurred to me that there is a dollar sign "$" instead of an att sign "@" prefixing attribute names. Don't know how this could hide for several years?!
<img width="850" height="354" alt="Bildschirmfoto 2025-07-11 um 09 10 55" src="https://github.com/user-attachments/assets/431d30d5-f8f0-4b14-baf7-da8996a11c8d" />
