### PR TITLE
swap 'jg' and 'vol' for NZfM and update expected results

### DIFF
--- a/modules/bibl.xqm
+++ b/modules/bibl.xqm
@@ -190,9 +190,11 @@ declare function bibl:printJournalCitation($monogr as element(tei:monogr), $wrap
  : @return xs:string*
  :)
 declare %private function bibl:biblScope($parent as element(), $lang as xs:string) as xs:string {
+    let $isNZfM := matches(string($parent/../tei:title[not(@type='sub')]), '\(?neue zeitschrift\)? für musik', 'i')
     concat(
+        if($parent/tei:biblScope/@unit = 'jg' and $isNZfM) then concat(', ', 'Jg.', '&#160;', $parent/tei:biblScope[@unit = 'jg']) else (),
         if($parent/tei:biblScope/@unit = 'vol') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'vol'], $lang) else (),
-        if($parent/tei:biblScope/@unit = 'jg') then concat(', ', 'Jg.', '&#160;', $parent/tei:biblScope[@unit = 'jg']) else (),
+        if($parent/tei:biblScope/@unit = 'jg' and not($isNZfM)) then concat(', ', 'Jg.', '&#160;', $parent/tei:biblScope[@unit = 'jg']) else (),
         (: Vierstellige Jahresangaben werden direkt nach vol oder bd ausgegeben :)
         if(matches(normalize-space($parent/tei:date), '^\d{4}$') and $parent/tei:biblScope/@unit = ('vol', 'jg')) then concat(' (', $parent/tei:date, ')') else (),
         if($parent/tei:biblScope/@unit = 'issue') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'issue'], $lang) else (),

--- a/modules/bibl.xqm
+++ b/modules/bibl.xqm
@@ -191,6 +191,7 @@ declare function bibl:printJournalCitation($monogr as element(tei:monogr), $wrap
  :)
 declare %private function bibl:biblScope($parent as element(), $lang as xs:string) as xs:string {
     let $isNZfM := matches(string($parent/../tei:title[not(@type='sub')]), '\(?neue zeitschrift\)? für musik', 'i')
+    return
     concat(
         if($parent/tei:biblScope/@unit = 'jg' and $isNZfM) then concat(', ', 'Jg.', '&#160;', $parent/tei:biblScope[@unit = 'jg']) else (),
         if($parent/tei:biblScope/@unit = 'vol') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'vol'], $lang) else (),

--- a/testing/expected-results/writings/A031897.html
+++ b/testing/expected-results/writings/A031897.html
@@ -604,7 +604,7 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Neue Zeitschrift für Musik</span>, Bd. 13, Jg. 7, Nr. 3 (08. Juli 1840), S. 9–10</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Neue Zeitschrift für Musik</span>, Jg. 7, Bd. 13, Nr. 3 (08. Juli 1840), S. 9–10</span>
                                                                               
                                         <div class="collapse apparatus-details" id="source_4c0de44e3a88b0e4d99bc5df0fd14cb5">
                                             

--- a/testing/expected-results/writings/A031927.html
+++ b/testing/expected-results/writings/A031927.html
@@ -567,7 +567,7 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Neue Zeitschrift für Musik</span>, Bd. 13, Jg. 7, Nr. 9 (29. Juli 1840), S. 33–35</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Neue Zeitschrift für Musik</span>, Jg. 7, Bd. 13, Nr. 9 (29. Juli 1840), S. 33–35</span>
                                                                               
                                         <div class="collapse apparatus-details" id="source_db9060f6e709cbf92f707bca012b9d83">
                                             

--- a/testing/xqsuite/biblio-tests.xqm
+++ b/testing/xqsuite/biblio-tests.xqm
@@ -134,3 +134,11 @@ declare
         return
             bibl:printIncollectionCitation($doc/tei:biblStruct, <xhtml:div/>, 'de')//xhtml:span[@class='editor']
 };
+
+declare
+    %test:args('A111335')         %test:assertEquals(", Jg.&#160;8, Bd.&#160;15, Nr.&#160;7 (23. Juli 1841), S.&#160;27–28")
+    function bt:test-NZfM-biblScope($a as xs:string) as text()* {
+        let $doc := crud:doc($a)
+        return
+            bibl:printJournalCitation($doc//tei:monogr, <xhtml:div/>, 'de')/node()[last()]
+};


### PR DESCRIPTION
exerts the following changes:

```
<diff>
    <changed>
        <id>A111335</id>
        <type>article</type>
        <citation-old>Hector Berlioz, Berichte aus Paris. 20. Théâtre de l'Opèra. Die erste Aufführung des Freischütz, in: Neue Zeitschrift für Musik, Bd. 15, Jg. 8, Nr. 7 (23. Juli 1841), S. 27–28</citation-old>
        <citation-new>Hector Berlioz, Berichte aus Paris. 20. Théâtre de l'Opèra. Die erste Aufführung des Freischütz, in: Neue Zeitschrift für Musik, Jg. 8, Bd. 15, Nr. 7 (23. Juli 1841), S. 27–28</citation-new>
    </changed>
    <changed>
        <id>A111991</id>
        <type>article</type>
        <citation-old>Adolph Kohut, Carl Maria von Weber als Musikkritiker, in: Neue Zeitschrift für Musik, Bd. 86, Jg. 57, Nr. 34, 35 (20. und 27. August 1890), S. 385–386, 393–394</citation-old>
        <citation-new>Adolph Kohut, Carl Maria von Weber als Musikkritiker, in: Neue Zeitschrift für Musik, Jg. 57, Bd. 86, Nr. 34, 35 (20. und 27. August 1890), S. 385–386, 393–394</citation-new>
    </changed>
    <changed>
        <id>A111996</id>
        <type>article</type>
        <citation-old>Carl von Weber, Carl Maria von Weber’s unvollendet hinterlassene komische Oper „Die drei
            Pintos“, in: Neue Zeitschrift für Musik, Bd. 84, Jg. 55, Nr. 1-4, 6 (Januar/Februar 1888), S. 5–6, 20, 32–33, 44–45, 65–66</citation-old>
        <citation-new>Carl von Weber, Carl Maria von Weber’s unvollendet hinterlassene komische Oper „Die drei
            Pintos“, in: Neue Zeitschrift für Musik, Jg. 55, Bd. 84, Nr. 1-4, 6 (Januar/Februar 1888), S. 5–6, 20, 32–33, 44–45, 65–66</citation-new>
    </changed>
    <changed>
        <id>A111998</id>
        <type>article</type>
        <citation-old>Franz Poland, Weber-Lebensbild, in: Neue Zeitschrift für Musik, Bd. 84, Jg. 55, Nr. 48–50 (28. November/5. und 12. Dezember 1888), S. 519–520, 527–528, 541–542</citation-old>
        <citation-new>Franz Poland, Weber-Lebensbild, in: Neue Zeitschrift für Musik, Jg. 55, Bd. 84, Nr. 48–50 (28. November/5. und 12. Dezember 1888), S. 519–520, 527–528, 541–542</citation-new>
    </changed>
    <changed>
        <id>A112000</id>
        <type>article</type>
        <citation-old>Carl von Weber, Karl Maria v. Webers unvollendet hinterlassene komische Oper „Die drei Pintos“, in: Neue Zeitschrift für Musik, Bd. 83, Jg. 54, Nr. 42 (19. Oktober 1887), S. 471</citation-old>
        <citation-new>Carl von Weber, Karl Maria v. Webers unvollendet hinterlassene komische Oper „Die drei Pintos“, in: Neue Zeitschrift für Musik, Jg. 54, Bd. 83, Nr. 42 (19. Oktober 1887), S. 471</citation-new>
    </changed>
    <changed>
        <id>A112093</id>
        <type>article</type>
        <citation-old>Robert Musiol, Theodor Körner in der Musik, in: Neue Zeitschrift für Musik, Bd. 75, Jg. 46, Nr. 30, 32, 34-36 (18. Juli, 1., 15., 22. und 29. August 1879), S. 301–303, 317–320, 337–338, 352–353, 359–361</citation-old>
        <citation-new>Robert Musiol, Theodor Körner in der Musik, in: Neue Zeitschrift für Musik, Jg. 46, Bd. 75, Nr. 30, 32, 34-36 (18. Juli, 1., 15., 22. und 29. August 1879), S. 301–303, 317–320, 337–338, 352–353, 359–361</citation-new>
    </changed>
    <changed>
        <id>A112303</id>
        <type>article</type>
        <citation-old>Hermann Zopff, C. M. v. Weber's Biographie, in: Neue Zeitschrift für Musik, Bd. 60, Jg. 31, Nr. 35-47 (August–November 1864), S. 303–305, 313–314, 322–323, 334–335, 344–345, 352–353, 359–360, 367–369, 375–377, 383–386, 394–396, 402–403, 410–413</citation-old>
        <citation-new>Hermann Zopff, C. M. v. Weber's Biographie, in: Neue Zeitschrift für Musik, Jg. 31, Bd. 60, Nr. 35-47 (August–November 1864), S. 303–305, 313–314, 322–323, 334–335, 344–345, 352–353, 359–360, 367–369, 375–377, 383–386, 394–396, 402–403, 410–413</citation-new>
    </changed>
    <changed>
        <id>A112314</id>
        <type>article</type>
        <citation-old>Heinrich Mannstein, Aus den Denkwürdigkeiten der Churfürstl. und Königl. Hofmusik zu Dresden im 18. und 19. Jahrhundert, in: Neue Zeitschrift für Musik, Bd. 58, Jg. 30, Nr. 13-19 (März-Mai 1863), S. 103–105, 112–115, 121–124, 133–135, 140–141, 149–150, 158–159</citation-old>
        <citation-new>Heinrich Mannstein, Aus den Denkwürdigkeiten der Churfürstl. und Königl. Hofmusik zu Dresden im 18. und 19. Jahrhundert, in: Neue Zeitschrift für Musik, Jg. 30, Bd. 58, Nr. 13-19 (März-Mai 1863), S. 103–105, 112–115, 121–124, 133–135, 140–141, 149–150, 158–159</citation-new>
    </changed>
    <changed>
        <id>A112395</id>
        <type>article</type>
        <citation-old>Franz Liszt, Weber´s Euryanthe, in: Neue Zeitschrift für Musik, Bd. 40, Jg. 21, Nr. 13 (24. März 1854), S. 133–138</citation-old>
        <citation-new>Franz Liszt, Weber´s Euryanthe, in: Neue Zeitschrift für Musik, Jg. 21, Bd. 40, Nr. 13 (24. März 1854), S. 133–138</citation-new>
    </changed>
    <changed>
        <id>A112457</id>
        <type>article</type>
        <citation-old>Karl Franz Brendel, Aus C. M. v. Weber's Jugendzeit, in: Neue Zeitschrift für Musik, Bd. 23, Jg. 12, Nr. 16 (22. August 1845), S. 62–64</citation-old>
        <citation-new>Karl Franz Brendel, Aus C. M. v. Weber's Jugendzeit, in: Neue Zeitschrift für Musik, Jg. 12, Bd. 23, Nr. 16 (22. August 1845), S. 62–64</citation-new>
    </changed>
    <changed>
        <id>A112479</id>
        <type>article</type>
        <citation-old>Johann Peter Lyser, Zweier Meister Söhne, in: Neue Zeitschrift für Musik, Bd. 21, Jg. 11, Nr. 43, 44 (November 1844), S. 169–171, 173–175</citation-old>
        <citation-new>Johann Peter Lyser, Zweier Meister Söhne, in: Neue Zeitschrift für Musik, Jg. 11, Bd. 21, Nr. 43, 44 (November 1844), S. 169–171, 173–175</citation-new>
    </changed>
    <changed>
        <id>A112480</id>
        <type>article</type>
        <citation-old>W J S E, Carl Maria von Weber und seine Begräbnisfeier in Dresden, in: Neue Zeitschrift für Musik, Bd. 21, Jg. 11, Nr. 51 (23. Dezember 1844), S. 201–203*Autor ist laut Jähns Julius Schladebach</citation-old>
        <citation-new>W J S E, Carl Maria von Weber und seine Begräbnisfeier in Dresden, in: Neue Zeitschrift für Musik, Jg. 11, Bd. 21, Nr. 51 (23. Dezember 1844), S. 201–203*Autor ist laut Jähns Julius Schladebach</citation-new>
    </changed>
    <changed>
        <id>A112506</id>
        <type>article</type>
        <citation-old>Anton Schindler, An die Redaction, in: Neue Zeitschrift für Musik, Bd. 14, Jg. 8, Nr. 8 (25. Januar 1841), S. 33–34</citation-old>
        <citation-new>Anton Schindler, An die Redaction, in: Neue Zeitschrift für Musik, Jg. 8, Bd. 14, Nr. 8 (25. Januar 1841), S. 33–34</citation-new>
    </changed>
    <changed>
        <id>A112511</id>
        <type>article</type>
        <citation-old>Woldemar Biering, Noch ein Wort über die Schindler'sche Biographie Beethoven's, C. M. v. Weber betreffend, in: Neue Zeitschrift für Musik, Bd. 13, Jg. 7, Nr. 48 (12. Dezember 1840), S. 189–191</citation-old>
        <citation-new>Woldemar Biering, Noch ein Wort über die Schindler'sche Biographie Beethoven's, C. M. v. Weber betreffend, in: Neue Zeitschrift für Musik, Jg. 7, Bd. 13, Nr. 48 (12. Dezember 1840), S. 189–191</citation-new>
    </changed>
    <changed>
        <id>A112512</id>
        <type>article</type>
        <citation-old>Helmina von Chézy, Carl Maria von Weber's Euryanthe. Ein Beitrag zur Geschichte der deutschen Oper, von Helmina v. Chezy, geb. Freiin Klencke, in: Neue Zeitschrift für Musik, Bd. 13, Jg. 7, Nr. 1–11 (Juli-August 1840), S. 1–2, 5–6, 9–10, 13–14, 17–19, 21–22, 33–35, 37–39, 41–43</citation-old>
        <citation-new>Helmina von Chézy, Carl Maria von Weber's Euryanthe. Ein Beitrag zur Geschichte der deutschen Oper, von Helmina v. Chezy, geb. Freiin Klencke, in: Neue Zeitschrift für Musik, Jg. 7, Bd. 13, Nr. 1–11 (Juli-August 1840), S. 1–2, 5–6, 9–10, 13–14, 17–19, 21–22, 33–35, 37–39, 41–43</citation-new>
    </changed>
    <changed>
        <id>A112753</id>
        <type>article</type>
        <citation-old>Friedrich Wilhelm Jähns, [Berichtigung betr. die Partitur des Freischütz in Pest], in: Neue Zeitschrift für Musik, Bd. 75, Jg. 46, Nr. 11 (7. März 1879), S. 117f.</citation-old>
        <citation-new>Friedrich Wilhelm Jähns, [Berichtigung betr. die Partitur des Freischütz in Pest], in: Neue Zeitschrift für Musik, Jg. 46, Bd. 75, Nr. 11 (7. März 1879), S. 117f.</citation-new>
    </changed>
    <changed>
        <id>A113067</id>
        <type>article</type>
        <citation-old>Bernhard Vogel, „Die drei Pintos“. Erste Aufführung auf der Leipziger Bühne am 20. Januar 1888, in: Neue Zeitschrift für Musik, Bd. 84, Jg. 55, Nr. 5 (1. Februar 1888), S. 53f.</citation-old>
        <citation-new>Bernhard Vogel, „Die drei Pintos“. Erste Aufführung auf der Leipziger Bühne am 20. Januar 1888, in: Neue Zeitschrift für Musik, Jg. 55, Bd. 84, Nr. 5 (1. Februar 1888), S. 53f.</citation-new>
    </changed>
</diff>
```