### PR TITLE
shorten more than three pubPlaces to first

### DIFF
--- a/modules/bibl.xqm
+++ b/modules/bibl.xqm
@@ -283,12 +283,14 @@ declare %private function bibl:printCitationAuthors($authors as element()*, $lan
 declare %private function bibl:printpubPlaceNYear($imprint as element(tei:imprint)?, $edition as element(tei:edition)?, $lang as xs:string) as element(xhtml:span)? {
     let $countPlaces := count($imprint/tei:pubPlace)
     let $places := 
-        for $place at $count in $imprint/tei:pubPlace
-        return (
-            if($count eq $countPlaces) then normalize-space($place)
-            else if($count eq $countPlaces - 1) then concat(normalize-space($place), ' &amp; ')
-            else concat(normalize-space($place), ', ')
-        )
+        if ($countPlaces le 3) then
+            for $place at $count in $imprint/tei:pubPlace
+            return (
+                if($count eq $countPlaces) then normalize-space($place)
+                else if($count eq $countPlaces - 1) then concat(normalize-space($place), ' &amp; ')
+                else concat(normalize-space($place), ', ')
+            )
+        else concat(normalize-space($imprint/tei:pubPlace[1]), ' ', lang:get-language-string('etAlii', $lang), ', ')
     let $date := (
         if($edition castable as xs:integer)
         then (' ', <xhtml:sup>{number($edition)}</xhtml:sup>)

--- a/modules/bibl.xqm
+++ b/modules/bibl.xqm
@@ -290,7 +290,7 @@ declare %private function bibl:printpubPlaceNYear($imprint as element(tei:imprin
                 else if($count eq $countPlaces - 1) then concat(normalize-space($place), ' &amp; ')
                 else concat(normalize-space($place), ', ')
             )
-        else concat(normalize-space($imprint/tei:pubPlace[1]), ' ', lang:get-language-string('etAlii', $lang), ', ')
+        else concat(normalize-space($imprint/tei:pubPlace[1]), ' ', lang:get-language-string('etAlii', $lang))
     let $date := (
         if($edition castable as xs:integer)
         then (' ', <xhtml:sup>{number($edition)}</xhtml:sup>)

--- a/testing/xqsuite/biblio-tests.xqm
+++ b/testing/xqsuite/biblio-tests.xqm
@@ -63,6 +63,7 @@ declare
     %test:args('A111825')         %test:assertEquals("<xhtml:span xmlns:xhtml='http://www.w3.org/1999/xhtml' class='placeNYear'>München 1915</xhtml:span>")
     %test:args('A110159')         %test:assertEquals("<xhtml:span xmlns:xhtml='http://www.w3.org/1999/xhtml' class='placeNYear'>Stuttgart &amp;amp; Weimar 2002</xhtml:span>")
     %test:args('A110046')         %test:assertEquals("<xhtml:span xmlns:xhtml='http://www.w3.org/1999/xhtml' class='placeNYear'>Köln, Weimar &amp;amp; Wien 2008</xhtml:span>")
+    %test:args('A112739')         %test:assertEquals("<xhtml:span xmlns:xhtml='http://www.w3.org/1999/xhtml' class='placeNYear'>Berlin u.a. 2017</xhtml:span>")
     function bt:test-placeNYear($a as xs:string) as element() {
         let $doc := crud:doc($a)
         return


### PR DESCRIPTION
will include those changes:

```
<diff>
    <changed>
        <id>A111124</id>
        <type>incollection</type>
        <citation-old>Helmut Wirth, Natur und Märchen in Webers Oberon, Mendelssohns Ein Sommernachtstraum und Nicolais Die Lustigen Weiber von Windsor, in: Festschrift Friedrich Blume zum 70. Geburtstag, hg. von Anna Amalie Abert und W. Pfannkuch, Kassel, Basel, London, Paris &amp; New York 1963, S. 389–397</citation-old>
        <citation-new>Helmut Wirth, Natur und Märchen in Webers Oberon, Mendelssohns Ein Sommernachtstraum und Nicolais Die Lustigen Weiber von Windsor, in: Festschrift Friedrich Blume zum 70. Geburtstag, hg. von Anna Amalie Abert und W. Pfannkuch, Kassel u.a.,  1963, S. 389–397</citation-new>
    </changed>
    <changed>
        <id>A112739</id>
        <type>incollection</type>
        <citation-old>Petra Eisenhardt, Zur frühen Aufführungsgeschichte von Carl Maria von Webers Der Freischütz im Hamburger Stadt-Theater, in: Musik, Bühne und Publikum. Materialien zum Hamburger Stadttheater 1770–1850, hg. von Claudia Maurer Zenck (Hamburger Jahrbuch für Musikwissenschaft, Bd. 32), Berlin, Bern, Brüssel, New York, Oxford, Warschau &amp; Wien 2017, S. 71–86</citation-old>
        <citation-new>Petra Eisenhardt, Zur frühen Aufführungsgeschichte von Carl Maria von Webers Der Freischütz im Hamburger Stadt-Theater, in: Musik, Bühne und Publikum. Materialien zum Hamburger Stadttheater 1770–1850, hg. von Claudia Maurer Zenck (Hamburger Jahrbuch für Musikwissenschaft, Bd. 32), Berlin u.a.,  2017, S. 71–86</citation-new>
    </changed>
    <changed>
        <id>A112758</id>
        <type>incollection</type>
        <citation-old>Claudia Maurer Zenck, Der ’deutsche’ Freischütz 1822 in Hamburg (und 1824 im Ausland), in: Musik, Bühne und Publikum. Materialien zum Hamburger Stadttheater 1770–1850, hg. von Claudia Maurer Zenck (Hamburger Jahrbuch für Musikwissenschaft, Bd. 32), Berlin, Bern, Brüssel, New York, Oxford, Warschau &amp; Wien 2017, S. 87–101</citation-old>
        <citation-new>Claudia Maurer Zenck, Der ’deutsche’ Freischütz 1822 in Hamburg (und 1824 im Ausland), in: Musik, Bühne und Publikum. Materialien zum Hamburger Stadttheater 1770–1850, hg. von Claudia Maurer Zenck (Hamburger Jahrbuch für Musikwissenschaft, Bd. 32), Berlin u.a.,  2017, S. 87–101</citation-new>
    </changed>
</diff>
```