### PR TITLE
520 display multiple imprints in articles

### DIFF
--- a/catalogues/dictionary_de.xml
+++ b/catalogues/dictionary_de.xml
@@ -463,6 +463,8 @@
     <entry xml:id="col">Sp.</entry>
     <entry xml:id="leaf">Bl.</entry>
     <entry xml:id="issue">Heft</entry>
+    <entry xml:id="nr">Nr.</entry>
+    <entry xml:id="jg">Jg.</entry>
     <entry xml:id="edBy">hg. von</entry>
     <entry xml:id="edByIdemM">dems.</entry>
     <entry xml:id="edByIdemF">ders.</entry>

--- a/catalogues/dictionary_en.xml
+++ b/catalogues/dictionary_en.xml
@@ -433,6 +433,8 @@
     <entry xml:id="col">col.</entry>
     <entry xml:id="leaf">f</entry>
     <entry xml:id="issue">issue</entry>
+    <entry xml:id="nr">Nr.</entry>
+    <entry xml:id="jg">Jg.</entry>
     <entry xml:id="edBy">ed. by</entry>
     <entry xml:id="edByIdemM">idem</entry>
     <entry xml:id="edByIdemF">idem</entry>

--- a/modules/bibl.xqm
+++ b/modules/bibl.xqm
@@ -172,7 +172,7 @@ declare function bibl:printIncollectionCitation($biblStruct as element(tei:biblS
  :)
 declare function bibl:printJournalCitation($monogr as element(tei:monogr), $wrapperElement as element(), $lang as xs:string) as element() {
     let $journalTitle := <xhtml:span class="journalTitle">{bibl:printTitles($monogr/tei:title, $monogr/tei:edition)/node()}</xhtml:span>
-    let $biblScope := bibl:biblScope($monogr/tei:imprint[1], $lang)
+    let $biblScope := if(count($monogr/tei:imprint) gt 1) then bibl:biblScope-multiple-imprints($monogr, $lang) else bibl:biblScope($monogr/tei:imprint, $lang)
     return 
         element {$wrapperElement/name()} {
             $wrapperElement/@*,
@@ -204,6 +204,86 @@ declare %private function bibl:biblScope($parent as element(), $lang as xs:strin
         if($parent/tei:biblScope/@unit = 'col') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'col'], $lang) else (),
         if($parent/tei:biblScope/@unit = 'leaf') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'leaf'], $lang) else ()
     )
+};
+
+declare %private function bibl:biblScope-multiple-imprints($monogr as element(tei:monogr), $lang as xs:string) as xs:string {
+    concat(
+        bibl:format-biblScope-units($monogr, 'vol', $lang),
+        bibl:format-biblScope-units($monogr, 'jg', $lang),
+        (: Vierstellige Jahresangaben werden direkt nach vol oder bd ausgegeben :)
+        if(matches(normalize-space($monogr/tei:imprint[1]/tei:date), '^\d{4}$') and $monogr/tei:imprint[1]/tei:biblScope/@unit = ('vol', 'jg')) then concat(' (', $monogr/tei:imprint[1]/tei:date, ')') else (),
+        bibl:format-biblScope-units($monogr, 'issue', $lang),
+        bibl:format-biblScope-units($monogr, 'nr', $lang),
+        (: Alle anderen Datumsausgaben hier :)
+        if(string-length(normalize-space($monogr/tei:imprint[1]/tei:date)) gt 4 or (string-length(normalize-space($monogr/tei:imprint[1]/tei:date)) gt 0 and not($monogr/tei:imprint[1]/tei:biblScope/@unit = ('vol', 'jg')))) then bibl:format-multi-dates($monogr, $lang) else (),
+        bibl:format-biblScope-units($monogr, 'pp', $lang),
+        bibl:format-biblScope-units($monogr, 'col', $lang),
+        bibl:format-biblScope-units($monogr, 'leaf', $lang)
+    )
+};
+
+declare %private function bibl:format-biblScope-units($monogr as element(tei:monogr), $unit as xs:string, $lang as xs:string) as xs:string {
+    let $biblScopes := $monogr/tei:imprint/tei:biblScope[@unit = $unit]
+    let $content :=
+        if (empty($biblScopes)) then ''
+        else if ($unit = ('pp', 'col', 'leaf')) then
+            let $pageCounts := (
+                for $biblScope in $biblScopes
+                let $pageCount := normalize-space(string($biblScope))
+                where $pageCount ne ''
+                return $pageCount
+            )
+           return
+                if (empty($pageCounts)) then ''
+                else if (count($pageCounts) = 1) then $pageCounts[1]
+                else if (count($pageCounts) = 2) then string-join($pageCounts, ' &amp; ')
+                else string-join($pageCounts[position() lt last()], ', ') || ' &amp; ' || $pageCounts[last()]
+        else
+            let $entities := (
+                for $biblScope in $biblScopes
+                let $biblScope-content := normalize-space(string($biblScope))
+                where $biblScope-content castable as xs:integer
+                return xs:integer($biblScope)
+            )
+            let $sorted-entities := (
+                for $entity in distinct-values($entities)
+                order by $entity
+                return $entity
+            )
+            let $starts := (
+                for $entity at $position in $sorted-entities
+                return if ($position = 1 or $sorted-entities[$position] != $sorted-entities[$position - 1] + 1) then $position else ()
+            )
+            let $ends := (
+                for $entity at $position in $starts
+                return if ($position lt count($starts)) then $sorted-entities[$starts[$position + 1] - 1] else $sorted-entities[last()]
+            )
+            let $combined-entities := (
+                for $entity at $position in $starts
+                let $first := $sorted-entities[$entity]
+                let $second := $ends[$position]
+                return if ($first = $second) then string($first) else concat(string($first), '–', string($second))
+            )
+            return
+                if (empty($combined-entities)) then ''
+                else if (count($combined-entities) = 1) then $combined-entities[1]
+                else if (count($combined-entities) = 2) then string-join($combined-entities, ' &amp; ')
+                else string-join($combined-entities[position() lt last()], ', ') || ' &amp; ' || $combined-entities[last()]
+        return
+        if ($content = '') then ''
+        else bibl:print-single-biblScope-unit(', ', <tei:biblScope unit="{$unit}">{$content}</tei:biblScope>, $lang)
+};
+
+declare %private function bibl:format-multi-dates($monogr as element(tei:monogr), $lang as xs:string) as xs:string? {
+    let $dates :=
+        distinct-values(    
+            for $date in $monogr/tei:imprint/tei:date
+            order by $date/@when
+            return normalize-space(string($date))
+            )
+    return
+        if (empty($dates)) then ''
+        else concat(' (', string-join($dates, ', '), ')')
 };
 
 (:~

--- a/modules/bibl.xqm
+++ b/modules/bibl.xqm
@@ -172,38 +172,13 @@ declare function bibl:printIncollectionCitation($biblStruct as element(tei:biblS
  :)
 declare function bibl:printJournalCitation($monogr as element(tei:monogr), $wrapperElement as element(), $lang as xs:string) as element() {
     let $journalTitle := <xhtml:span class="journalTitle">{bibl:printTitles($monogr/tei:title, $monogr/tei:edition)/node()}</xhtml:span>
-    let $biblScope := if(count($monogr/tei:imprint) gt 1) then bibl:biblScope-multiple-imprints($monogr, $lang) else bibl:biblScope($monogr/tei:imprint, $lang)
+    let $biblScope := bibl:biblScope-multiple-imprints($monogr, $lang)
     return 
         element {$wrapperElement/name()} {
             $wrapperElement/@*,
             $journalTitle,
             $biblScope
         }
-};
-
-(:~
- : Helper function for various bibl:print*Citation() 
- : 
- : @author Peter Stadler
- : @param $parent the parent element of the tei:biblScope elements (usually tei:imprint or tei:series)
- : @param $lang the language switch (en, de)
- : @return xs:string*
- :)
-declare %private function bibl:biblScope($parent as element(), $lang as xs:string) as xs:string {
-    concat(
-        if($parent/tei:biblScope/@unit = 'vol') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'vol'], $lang) else (),
-        if($parent/tei:biblScope/@unit = 'jg') then concat(', ', 'Jg.', '&#160;', $parent/tei:biblScope[@unit = 'jg']) else (),
-        (: Vierstellige Jahresangaben werden direkt nach vol oder bd ausgegeben :)
-        if(matches(normalize-space($parent/tei:date), '^\d{4}$') and $parent/tei:biblScope/@unit = ('vol', 'jg')) then concat(' (', $parent/tei:date, ')') else (),
-        if($parent/tei:biblScope/@unit = 'issue') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'issue'], $lang) else (),
-        if($parent/tei:biblScope/@unit = 'nr') then concat(', ', 'Nr.', '&#160;', $parent/tei:biblScope[@unit = 'nr']) else (),
-        (: Alle anderen Datumsausgaben hier :)
-        if(string-length(normalize-space($parent/tei:date)) gt 4 or (string-length(normalize-space($parent/tei:date)) gt 0 and not($parent/tei:biblScope/@unit = ('vol', 'jg')))) then concat(' (', $parent/tei:date, ')') else (),
-        if($parent/tei:note/@type = 'additional') then concat(' ', $parent/tei:note[@type = 'additional']) else (),
-        if($parent/tei:biblScope/@unit = 'pp') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'pp'], $lang) else (),
-        if($parent/tei:biblScope/@unit = 'col') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'col'], $lang) else (),
-        if($parent/tei:biblScope/@unit = 'leaf') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'leaf'], $lang) else ()
-    )
 };
 
 declare %private function bibl:biblScope-multiple-imprints($monogr as element(tei:monogr), $lang as xs:string) as xs:string {
@@ -216,6 +191,7 @@ declare %private function bibl:biblScope-multiple-imprints($monogr as element(te
         bibl:format-biblScope-units($monogr, 'nr', $lang),
         (: Alle anderen Datumsausgaben hier :)
         if(string-length(normalize-space($monogr/tei:imprint[1]/tei:date)) gt 4 or (string-length(normalize-space($monogr/tei:imprint[1]/tei:date)) gt 0 and not($monogr/tei:imprint[1]/tei:biblScope/@unit = ('vol', 'jg')))) then bibl:format-multi-dates($monogr, $lang) else (),
+        if($monogr/tei:imprint[1]/tei:note/@type = 'additional') then concat(' ', $monogr/tei:imprint[1]/tei:note[@type = 'additional']) else (),
         bibl:format-biblScope-units($monogr, 'pp', $lang),
         bibl:format-biblScope-units($monogr, 'col', $lang),
         bibl:format-biblScope-units($monogr, 'leaf', $lang)
@@ -227,43 +203,40 @@ declare %private function bibl:format-biblScope-units($monogr as element(tei:mon
     let $content :=
         if (empty($biblScopes)) then ''
         else if ($unit = ('pp', 'col', 'leaf')) then
-            let $pageCounts := (
+            let $pageCounts := 
                 for $biblScope in $biblScopes
                 let $pageCount := normalize-space(string($biblScope))
                 where $pageCount ne ''
                 return $pageCount
-            )
            return
                 if (empty($pageCounts)) then ''
                 else if (count($pageCounts) = 1) then $pageCounts[1]
                 else if (count($pageCounts) = 2) then string-join($pageCounts, ' &amp; ')
                 else string-join($pageCounts[position() lt last()], ', ') || ' &amp; ' || $pageCounts[last()]
         else
-            let $entities := (
+            let $entities :=
                 for $biblScope in $biblScopes
                 let $biblScope-content := normalize-space(string($biblScope))
-                where $biblScope-content castable as xs:integer
-                return xs:integer($biblScope)
-            )
-            let $sorted-entities := (
-                for $entity in distinct-values($entities)
+                where $biblScope-content ne ''
+                return $biblScope-content
+            let $string-entities := for $entity in $entities where not($entity castable as xs:integer) return $entity
+            let $integer-entities := for $entity in $entities where $entity castable as xs:integer return xs:integer($entity)
+            let $sorted-integer-entities :=
+                for $entity in distinct-values($integer-entities)
                 order by $entity
                 return $entity
-            )
-            let $starts := (
-                for $entity at $position in $sorted-entities
-                return if ($position = 1 or $sorted-entities[$position] != $sorted-entities[$position - 1] + 1) then $position else ()
-            )
-            let $ends := (
+            let $starts :=
+                for $entity at $position in $sorted-integer-entities
+                return if ($position = 1 or $sorted-integer-entities[$position] != $sorted-integer-entities[$position - 1] + 1) then $position else ()
+            let $ends :=
                 for $entity at $position in $starts
-                return if ($position lt count($starts)) then $sorted-entities[$starts[$position + 1] - 1] else $sorted-entities[last()]
-            )
-            let $combined-entities := (
+                return if ($position lt count($starts)) then $sorted-integer-entities[$starts[$position + 1] - 1] else $sorted-integer-entities[last()]
+            let $collapsed-integer-entities :=
                 for $entity at $position in $starts
-                let $first := $sorted-entities[$entity]
+                let $first := $sorted-integer-entities[$entity]
                 let $second := $ends[$position]
                 return if ($first = $second) then string($first) else concat(string($first), '–', string($second))
-            )
+            let $combined-entities := ($collapsed-integer-entities, $string-entities)
             return
                 if (empty($combined-entities)) then ''
                 else if (count($combined-entities) = 1) then $combined-entities[1]

--- a/modules/bibl.xqm
+++ b/modules/bibl.xqm
@@ -190,9 +190,11 @@ declare function bibl:printJournalCitation($monogr as element(tei:monogr), $wrap
  : @return xs:string*
  :)
 declare %private function bibl:biblScope($monogr as element(tei:monogr), $lang as xs:string) as xs:string {
-    concat(
+    let $isNZfM := matches(string($monogr/tei:title[not(@type='sub')]), '\(?neue zeitschrift\)? für musik', 'i')
+    return concat(
+        if($monogr/tei:imprint[1]/tei:biblScope/@unit = 'jg' and $isNZfM) then bibl:format-biblScope-units($monogr, 'jg', $lang) else (),
         bibl:format-biblScope-units($monogr, 'vol', $lang),
-        bibl:format-biblScope-units($monogr, 'jg', $lang),
+        if($monogr/tei:imprint[1]/tei:biblScope/@unit = 'jg' and not($isNZfM)) then bibl:format-biblScope-units($monogr, 'jg', $lang) else (),
         (: Vierstellige Jahresangaben werden direkt nach vol oder bd ausgegeben :)
         if(matches(normalize-space($monogr/tei:imprint[1]/tei:date), '^\d{4}$') and $monogr/tei:imprint[1]/tei:biblScope/@unit = ('vol', 'jg')) then concat(' (', $monogr/tei:imprint[1]/tei:date, ')') else (),
         bibl:format-biblScope-units($monogr, 'issue', $lang),

--- a/modules/bibl.xqm
+++ b/modules/bibl.xqm
@@ -172,7 +172,7 @@ declare function bibl:printIncollectionCitation($biblStruct as element(tei:biblS
  :)
 declare function bibl:printJournalCitation($monogr as element(tei:monogr), $wrapperElement as element(), $lang as xs:string) as element() {
     let $journalTitle := <xhtml:span class="journalTitle">{bibl:printTitles($monogr/tei:title, $monogr/tei:edition)/node()}</xhtml:span>
-    let $biblScope := bibl:biblScope-multiple-imprints($monogr, $lang)
+    let $biblScope := bibl:biblScope($monogr, $lang)
     return 
         element {$wrapperElement/name()} {
             $wrapperElement/@*,
@@ -181,7 +181,15 @@ declare function bibl:printJournalCitation($monogr as element(tei:monogr), $wrap
         }
 };
 
-declare %private function bibl:biblScope-multiple-imprints($monogr as element(tei:monogr), $lang as xs:string) as xs:string {
+(:~
+ : Helper function to print biblScopes of one or many imprint elements
+ : 
+ : @author Peter Stadler
+ : @param $monogr the parent element of the tei:imprint elements that contain tei:biblScopes
+ : @param $lang the language switch (en, de)
+ : @return xs:string*
+ :)
+declare %private function bibl:biblScope($monogr as element(tei:monogr), $lang as xs:string) as xs:string {
     concat(
         bibl:format-biblScope-units($monogr, 'vol', $lang),
         bibl:format-biblScope-units($monogr, 'jg', $lang),
@@ -198,65 +206,106 @@ declare %private function bibl:biblScope-multiple-imprints($monogr as element(te
     )
 };
 
+(:~
+ : Helper function for bibl:biblScope to collapse tei:biblScopes from several tei:imprint elements into a citation format
+ : Splits biblScope values into strings and integers, then splits integer values into runs (non consecutive numbers) and collapses them into ranges
+ : 
+ : @author Steffen Astheimer
+ : @param $monogr the parent element of the tei:imprint elements that contain tei:biblScopes
+ : @param $unit the unit that is to be displayed
+ : @param $lang the language switch (en, de)
+ : @return xs:string
+ :)
 declare %private function bibl:format-biblScope-units($monogr as element(tei:monogr), $unit as xs:string, $lang as xs:string) as xs:string {
-    let $biblScopes := $monogr/tei:imprint/tei:biblScope[@unit = $unit]
-    let $content :=
-        if (empty($biblScopes)) then ''
-        else if ($unit = ('pp', 'col', 'leaf')) then
-            let $pageCounts := 
-                for $biblScope in $biblScopes
-                let $pageCount := normalize-space(string($biblScope))
-                where $pageCount ne ''
-                return $pageCount
-           return
-                if (empty($pageCounts)) then ''
-                else if (count($pageCounts) = 1) then $pageCounts[1]
-                else if (count($pageCounts) = 2) then string-join($pageCounts, ' &amp; ')
-                else string-join($pageCounts[position() lt last()], ', ') || ' &amp; ' || $pageCounts[last()]
-        else
-            let $entities :=
-                for $biblScope in $biblScopes
-                let $biblScope-content := normalize-space(string($biblScope))
-                where $biblScope-content ne ''
-                return $biblScope-content
-            let $string-entities := for $entity in $entities where not($entity castable as xs:integer) return $entity
-            let $integer-entities := for $entity in $entities where $entity castable as xs:integer return xs:integer($entity)
-            let $sorted-integer-entities :=
-                for $entity in distinct-values($integer-entities)
-                order by $entity
-                return $entity
-            let $starts :=
-                for $entity at $position in $sorted-integer-entities
-                return if ($position = 1 or $sorted-integer-entities[$position] != $sorted-integer-entities[$position - 1] + 1) then $position else ()
-            let $ends :=
-                for $entity at $position in $starts
-                return if ($position lt count($starts)) then $sorted-integer-entities[$starts[$position + 1] - 1] else $sorted-integer-entities[last()]
-            let $collapsed-integer-entities :=
-                for $entity at $position in $starts
-                let $first := $sorted-integer-entities[$entity]
-                let $second := $ends[$position]
-                return if ($first = $second) then string($first) else concat(string($first), '–', string($second))
-            let $combined-entities := ($collapsed-integer-entities, $string-entities)
-            return
-                if (empty($combined-entities)) then ''
-                else if (count($combined-entities) = 1) then $combined-entities[1]
-                else if (count($combined-entities) = 2) then string-join($combined-entities, ' &amp; ')
-                else string-join($combined-entities[position() lt last()], ', ') || ' &amp; ' || $combined-entities[last()]
-        return
-        if ($content = '') then ''
-        else bibl:print-single-biblScope-unit(', ', <tei:biblScope unit="{$unit}">{$content}</tei:biblScope>, $lang)
+  let $biblScopes := $monogr/tei:imprint/tei:biblScope[@unit = $unit]
+  let $values :=
+    distinct-values(
+      for $biblScope in $biblScopes
+      let $value := normalize-space(string($biblScope))
+      where $value ne ''
+      return $value
+    )
+  let $citationString :=
+    if ($unit = ('pp', 'col', 'leaf')) then bibl:join-list($values)
+    else
+      let $strValues := $values[not(. castable as xs:integer)]
+      let $intValues := 
+        for $value in $values[. castable as xs:integer]
+        return xs:integer($value)
+      let $runStartsPositions :=
+        for $value at $position in $intValues
+        return if($position = 1 or $intValues[$position] != $intValues[$position - 1] + 1) then $position else ()
+      let $runEndsValues :=
+        for $value at $position in $runStartsPositions
+        return if($position lt count($runStartsPositions))
+               then $intValues[$runStartsPositions[$position + 1] - 1]
+               else $intValues[last()]
+      let $collapsedIntValues :=
+        for $value at $position in $runStartsPositions
+        let $first := $intValues[$value]
+        let $last := $runEndsValues[$position]
+        return if($first = $last) then string($first) else concat(string($first), '–', string($last))
+      return bibl:join-list(($collapsedIntValues, $strValues)) (: currently seperates ints from strings, if bibl documents mix both types the rendering will be wrong:)
+  return 
+    if($citationString = '') then ''
+    else bibl:print-single-biblScope-unit(', ', <tei:biblScope unit="{$unit}">{$citationString}</tei:biblScope>, $lang)
 };
 
+(:~
+ : Helper function for bibl:format-biblScope-units to collapse tei:dates from several tei:imprint elements into a citation format
+ : Will group by year and month and concatenate the days with commas, naming each corresponding month and year only once at the end of a group
+ : This might lead to unwanted / unhelpful rendering if a group of imprints ranges over the change of a year
+ : 
+ : @author Steffen Astheimer
+ : @param $monogr the parent element of the tei:imprint elements that contain tei:biblScopes
+ : @param $lang the language switch (en, de)
+ : @return xs:string
+ :)
 declare %private function bibl:format-multi-dates($monogr as element(tei:monogr), $lang as xs:string) as xs:string? {
-    let $dates :=
-        distinct-values(    
-            for $date in $monogr/tei:imprint/tei:date
-            order by $date/@when
-            return normalize-space(string($date))
-            )
+  if(count($monogr/tei:imprint) = 1) then concat(' (', $monogr/tei:imprint/tei:date, ')')
+  else
+    let $whenValues :=
+      for $date in $monogr/tei:imprint/tei:date[@when]
+      let $when := normalize-space(string($date/@when))
+      where $when ne ''
+      return $when
     return
-        if (empty($dates)) then ''
-        else concat(' (', string-join($dates, ', '), ')')
+      if(empty($whenValues)) then ''
+      else if(every $when in $whenValues satisfies matches($when, '^\d{4}$')) then concat(' (', bibl:join-list(distinct-values($whenValues)), ')')
+      else
+        let $parsed :=
+          for $when in $whenValues
+          where matches($when, '^\d{4}-\d{2}-\d{2}$')
+          let $year := xs:integer(substring($when, 1, 4))
+          let $month := xs:integer(substring($when, 6, 2))
+          let $day := xs:integer(substring($when, 9, 2))
+          return map { "year": $year, "month": $month, "day": $day }
+        return
+            let $years := distinct-values($parsed?year)
+            let $multiYears := count($years) gt 1
+            let $yearGroups :=
+              for $year in $years
+              let $inYear := $parsed[$parsed?year = $year]
+              let $months := distinct-values($inYear?month)
+              let $monthPieces :=
+                for $month in $months
+                let $days := 
+                  distinct-values(
+                    for $p in $inYear
+                    where $p?month = $month
+                    return $p?day
+                  )
+                let $dayStrings := for $day in $days return concat($day, '.')
+                let $dayList := bibl:join-list($dayStrings)
+                let $monthName := lang:get-language-string(concat('month', $month), $lang)
+                return
+                  if ($multiYears) then concat($dayList, ' ', $monthName, ' ', $year)
+                  else concat($dayList, ' ', $monthName)
+              let $monthsJoined := bibl:join-list($monthPieces)
+              return
+                if ($multiYears) then $monthsJoined
+                else concat($monthsJoined, ' ', $year)
+            return concat(' (', bibl:join-list($yearGroups), ')')
 };
 
 (:~
@@ -272,6 +321,16 @@ declare %private function bibl:print-single-biblScope-unit($separator as xs:stri
         bibl:normalize-hyphen($biblScope),
         if($biblScope/@rend='bracketed') then ']' else ()
     )
+};
+
+(:~
+ : Helper function for bibl:format-biblScope-units and bibl:format-multi-dates to collapse multiple strings
+ :)
+declare %private function bibl:join-list($items as xs:string*) as xs:string {
+  if (empty($items)) then ''
+  else if (count($items) = 1) then $items[1]
+  else if (count($items) = 2) then string-join($items, ' und ')
+  else string-join($items[position() lt last()], ', ') || ' und ' || $items[last()]
 };
 
 (:~

--- a/testing/xqsuite/biblio-tests.xqm
+++ b/testing/xqsuite/biblio-tests.xqm
@@ -52,6 +52,9 @@ declare
     %test:args('A111038')         %test:assertEquals("„Ei, dem alten Herrn zoll’ ich Achtung gern’“. Festschrift für Joachim Veit zum 60. Geburtstag (2016), S. 89–99")
     %test:args('A113127')         %test:assertEquals("Salzburger Volksblatt, Jg. 28, Nr. 95 (28. April 1898), [S. 3]")
     %test:args('A110998')         %test:assertEquals("Schlesien. Eine Vierteljahresschrift für Kunst, Wissenschaft und Volkstum, Jg. 19 (1974), Nr. 3, S. 158–162")
+    %test:args('A110471')         %test:assertEquals("Frankfurter Conversationsblatt.  Belletristische und kritische Beilage zur Postzeitung, Jg. 12, Nr. 65–66 (17. und 18. März 1859), S. 258f. und 262f.")
+    %test:args('A112093')         %test:assertEquals("Neue Zeitschrift für Musik, Jg. 46, Bd. 75, Nr. 30, 32 und 34–36 (18. Juli und 1., 15., 22. und 29. August 1879), S. 301–303, 317–320, 337–338, 352–353 und 359–361")
+    %test:args('A112776')         %test:assertEquals("Blätter für Musik, Theater und Kunst, Jg. 3, Nr. 74–79, 90–91 und 93 (15., 18., 22., 25. und 29. September und 2., 6., 9. und 16. Oktober 1857), S. 298f., 302f., 306f., 310f., 314, 318f., 321f. und 330f.")
     function bt:test-printJournalCitation($a as xs:string) as xs:string {
         let $doc := crud:doc($a)
         return

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,21 +22,21 @@
   integrity sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==
 
 "@babel/parser@^7.23.5":
-  version "7.28.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.28.0.tgz#979829fbab51a29e13901e5a80713dbcb840825e"
-  integrity sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==
+  version "7.28.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.28.4.tgz#da25d4643532890932cc03f7705fe19637e03fa8"
+  integrity sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==
   dependencies:
-    "@babel/types" "^7.28.0"
+    "@babel/types" "^7.28.4"
 
 "@babel/runtime@^7.16.7", "@babel/runtime@^7.17.8":
-  version "7.28.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.2.tgz#2ae5a9d51cc583bd1f5673b3bb70d6d819682473"
-  integrity sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==
+  version "7.28.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.4.tgz#a70226016fabe25c5783b2f22d3e1c9bc5ca3326"
+  integrity sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==
 
-"@babel/types@^7.28.0":
-  version "7.28.2"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.28.2.tgz#da9db0856a9a88e0a13b019881d7513588cf712b"
-  integrity sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==
+"@babel/types@^7.28.4":
+  version "7.28.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.28.4.tgz#0a4e618f4c60a7cd6c11cb2d48060e4dbe38ac3a"
+  integrity sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==
   dependencies:
     "@babel/helper-string-parser" "^7.27.1"
     "@babel/helper-validator-identifier" "^7.27.1"
@@ -141,9 +141,9 @@
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
 "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
-  version "0.3.30"
-  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.30.tgz#4a76c4daeee5df09f5d3940e087442fb36ce2b99"
-  integrity sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==
+  version "0.3.31"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
+  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
@@ -538,11 +538,11 @@
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
 "@types/node@>=13.7.0":
-  version "24.2.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.2.1.tgz#83e41543f0a518e006594bb394e2cd961de56727"
-  integrity sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==
+  version "24.5.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.5.2.tgz#52ceb83f50fe0fcfdfbd2a9fab6db2e9e7ef6446"
+  integrity sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==
   dependencies:
-    undici-types "~7.10.0"
+    undici-types "~7.12.0"
 
 "@types/stylis@4.2.5":
   version "4.2.5"
@@ -571,11 +571,11 @@ Easy-Responsive-Tabs-to-Accordion@peterstadler/Easy-Responsive-Tabs-to-Accordion
 
 "Junicode-New@https://github.com/psb1558/Junicode-New":
   version "0.0.0"
-  resolved "https://github.com/psb1558/Junicode-New#4dddd220b237266c4cdab2afe66218da98fc849c"
+  resolved "https://github.com/psb1558/Junicode-New#b6c9a35b54d683f020c3d014e8dfb8cd48fd7ffb"
 
 WeGA-ODD@edirom/WeGA-ODD#develop:
   version "0.0.0"
-  resolved "https://codeload.github.com/edirom/WeGA-ODD/tar.gz/558854f44771bcd968b396adebda23706cf26367"
+  resolved "https://codeload.github.com/edirom/WeGA-ODD/tar.gz/ad18c338e16aacad1160ae3752c60465721adefd"
 
 abort-controller@^3.0.0:
   version "3.0.0"
@@ -584,7 +584,7 @@ abort-controller@^3.0.0:
   dependencies:
     event-target-shim "^5.0.0"
 
-acorn@^8.14.0:
+acorn@^8.15.0:
   version "8.15.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.15.0.tgz#a360898bc415edaac46c8241f6383975b930b816"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
@@ -695,9 +695,9 @@ bootstrap@^4.3.1, bootstrap@^4.6.1:
   integrity sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==
 
 bootstrap@^5.1.3:
-  version "5.3.7"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.7.tgz#8640065036124d961d885d80b5945745e1154d90"
-  integrity sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==
+  version "5.3.8"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-5.3.8.tgz#6401a10057a22752d21f4e19055508980656aeed"
+  integrity sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==
 
 brace-expansion@^1.1.7:
   version "1.1.12"
@@ -903,9 +903,9 @@ core-js@^2.4.0, core-js@^2.5.0:
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
 
 core-js@^3.32.1:
-  version "3.45.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.45.0.tgz#556c2af44a2d9c73ea7b49504392474a9f7c947e"
-  integrity sha512-c2KZL9lP4DjkN3hk/an4pWn5b5ZefhRJnAc42n6LJ19kSnbeRbdQZE5dSeE2LBol1OwJD3X1BQvFTAsa8ReeDA==
+  version "3.45.1"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.45.1.tgz#5810e04a1b4e9bc5ddaa4dd12e702ff67300634d"
+  integrity sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==
 
 core-util-is@~1.0.0:
   version "1.0.3"
@@ -984,9 +984,9 @@ datatables.net@1.13.11, datatables.net@^1.11.3, datatables.net@^1.13.0:
     jquery "1.8 - 4"
 
 debug@4, debug@^4.1.0, debug@^4.3.1:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.1.tgz#e5a8bc6cbc4c6cd3e64308b0693a3d4fa550189b"
-  integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
 
@@ -1029,9 +1029,9 @@ diff-sequences@^29.6.3:
   integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
 
 dompurify@^3.2.4:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.6.tgz#ca040a6ad2b88e2a92dc45f38c79f84a714a1cad"
-  integrity sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==
+  version "3.2.7"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.7.tgz#721d63913db5111dd6dfda8d3a748cfd7982d44a"
+  integrity sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 
@@ -1944,9 +1944,9 @@ prop-types@^15.5.0, prop-types@^15.8.1:
     react-is "^16.13.1"
 
 protobufjs@^7.3.0:
-  version "7.5.3"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.3.tgz#13f95a9e3c84669995ec3652db2ac2fb00b89363"
-  integrity sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.4.tgz#885d31fe9c4b37f25d1bb600da30b1c5b37d286a"
+  integrity sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
@@ -2121,9 +2121,9 @@ resolve@^1.1.6:
     supports-preserve-symlinks-flag "^1.0.0"
 
 run-applescript@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/run-applescript/-/run-applescript-7.0.0.tgz#e5a553c2bffd620e169d276c1cd8f1b64778fbeb"
-  integrity sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/run-applescript/-/run-applescript-7.1.0.tgz#2e9e54c4664ec3106c5b5630e249d3d6595c4911"
+  integrity sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==
 
 safe-buffer@^5.1.0, safe-buffer@~5.2.0:
   version "5.2.1"
@@ -2136,9 +2136,9 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
 sass@^1.22.12:
-  version "1.90.0"
-  resolved "https://registry.yarnpkg.com/sass/-/sass-1.90.0.tgz#d6fc2be49c7c086ce86ea0b231a35bf9e33cb84b"
-  integrity sha512-9GUyuksjw70uNpb1MTYWsH9MQHOHY6kwfnkafC24+7aOMZn9+rVMBxRbLvw756mrBFbIsFg6Xw9IkR2Fnn3k+Q==
+  version "1.93.2"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.93.2.tgz#e97d225d60f59a3b3dbb6d2ae3c1b955fd1f2cd1"
+  integrity sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==
   dependencies:
     chokidar "^4.0.0"
     immutable "^5.0.2"
@@ -2392,12 +2392,12 @@ terser@^4.6.3:
     source-map-support "~0.5.12"
 
 terser@^5.3.2:
-  version "5.43.1"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.43.1.tgz#88387f4f9794ff1a29e7ad61fb2932e25b4fdb6d"
-  integrity sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==
+  version "5.44.0"
+  resolved "https://registry.yarnpkg.com/terser/-/terser-5.44.0.tgz#ebefb8e5b8579d93111bfdfc39d2cf63879f4a82"
+  integrity sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==
   dependencies:
     "@jridgewell/source-map" "^0.3.3"
-    acorn "^8.14.0"
+    acorn "^8.15.0"
     commander "^2.20.0"
     source-map-support "~0.5.20"
 
@@ -2438,10 +2438,10 @@ uglify-js@^3.1.4:
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.19.3.tgz#82315e9bbc6f2b25888858acd1fff8441035b77f"
   integrity sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==
 
-undici-types@~7.10.0:
-  version "7.10.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.10.0.tgz#4ac2e058ce56b462b056e629cc6a02393d3ff350"
-  integrity sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==
+undici-types@~7.12.0:
+  version "7.12.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.12.0.tgz#15c5c7475c2a3ba30659529f5cdb4674b622fafb"
+  integrity sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==
 
 undici@^6.21.1:
   version "6.21.3"


### PR DESCRIPTION
I added a helper function that can handle multiple imprints and print the biblScope and date informations in an (almost) desirable way:
- vol/jg/issue/nr are collapsed into ranges (eg. '1–3' instead of '1, 2, 3' – but '1–3, 5' if there's a gap)
- dates are collapsed into similar ranges with the use of `@when` attributes to get something like '1. und 3. Oktober 1820' or even '25., 27. und 29. Oktober, 15. November 1820 und 1. Januar 1821'
- I then realized that the function is easily handling single imprint monogr elements just as well and merged it together with the old biblScope function

One big potential downside to the whole code is the potential of having articles that span over a turn of the year. Currently we have none, but I added a warning in the code.

At the moment roughly 125 biblio files have spans of issues encoded into one imprint. They should at some point get cleaned up, but they are also being displayed correctly with this code.