### PR TITLE
add filters to bibliography for keywords

### DIFF
--- a/api/v1/openapi/schemas/facets.yaml
+++ b/api/v1/openapi/schemas/facets.yaml
@@ -16,6 +16,7 @@ enum:
   - geonamesFeatureClass
   - journals
   - keywords
+  - keywords_biblio
   - librettists
   - lyricists
   - occupations

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -1168,6 +1168,16 @@ declare function api:validate-keywords($model as map(*)) as map(*)? {
 };
 
 (:~
+ : Check parameter keywords_biblio
+ : multiple values allowed as input, either by providing multiple URL parameters
+ : or by sending a comma separated list as the value of one URL parameter
+~:)
+declare function api:validate-keywords_biblio($model as map(*)) as map(*)? {
+    if(every $i in $model?keywords_biblio ! tokenize(., ',') satisfies $i castable as xs:string) then map { 'keywords_biblio': ($model?keywords_biblio ! tokenize(., ',')) ! xmldb:decode-uri(.) }
+    else error($api:INVALID_PARAMETER, 'Unsupported value for parameter "keywords_biblio".')
+};
+
+(:~
  : Check parameter docLang
  : multiple values allowed as input, either by providing multiple URL parameters
  : or by sending a comma separated list as the value of one URL parameter

--- a/modules/query.xqm
+++ b/modules/query.xqm
@@ -347,7 +347,7 @@ declare function query:get-facets($collection as node()*, $facet as xs:string) a
     case 'placeOfSender' return $collection//tei:settlement[parent::tei:correspAction/@type='sent']/@key
     case 'placeOfAddressee' return $collection//tei:settlement[parent::tei:correspAction/@type='received']/@key
     case 'journals' return $collection//tei:title[@level='j'][not(@type='sub')][ancestor::tei:sourceDesc]
-    case 'places' return $collection//tei:settlement[ancestor::tei:text or ancestor::tei:ab]/@key
+    case 'places' return $collection//tei:settlement[ancestor::tei:text or ancestor::tei:ab]/@key | $collection//tei:term[parent::tei:keywords][starts-with(., 'A13')]
     case 'dedicatees' return $collection//mei:persName[@role='dte']/@codedval
     case 'lyricists' return $collection//mei:persName[@role='lyr']/@codedval
     case 'librettists' return $collection//mei:persName[@role='lbt']/@codedval
@@ -358,8 +358,8 @@ declare function query:get-facets($collection as node()*, $facet as xs:string) a
         (: index-keys does not work with multiple whitespace separated keys
             probably need to change to ft:query() someday?!
         :)
-    case 'persons' return ($collection//tei:persName[ancestor::tei:text or ancestor::tei:ab or ancestor::tei:notesStmt]/@key | $collection//tei:rs[@type='person'][ancestor::tei:text or ancestor::tei:ab or ancestor::tei:notesStmt]/@key)
-    case 'works' return $collection//tei:workName[ancestor::tei:text or ancestor::tei:ab or ancestor::tei:notesStmt]/@key[string-length(.) = 7] | $collection//tei:rs[@type='work'][ancestor::tei:text or ancestor::tei:ab or ancestor::tei:notesStmt]/@key[string-length(.) = 7]
+    case 'persons' return $collection//tei:persName[ancestor::tei:text or ancestor::tei:ab or ancestor::tei:notesStmt]/@key | $collection//tei:rs[@type='person'][ancestor::tei:text or ancestor::tei:ab or ancestor::tei:notesStmt]/@key | $collection//tei:term[parent::tei:keywords][starts-with(., 'A00')]
+    case 'works' return $collection//tei:workName[ancestor::tei:text or ancestor::tei:ab or ancestor::tei:notesStmt]/@key[string-length(.) = 7] | $collection//tei:rs[@type='work'][ancestor::tei:text or ancestor::tei:ab or ancestor::tei:notesStmt]/@key[string-length(.) = 7] | $collection//tei:term[parent::tei:keywords][starts-with(., 'A02')]
     case 'authors' return $collection//tei:author/@key
     case 'editors' return $collection//tei:editor/@key
     case 'biblioType' return $collection/tei:biblStruct/@type
@@ -375,6 +375,7 @@ declare function query:get-facets($collection as node()*, $facet as xs:string) a
     case 'repository' return $collection//tei:repository/@n
     case 'series' return $collection//mei:seriesStmt/mei:title[@level='s']
     case 'keywords' return $collection//tei:term[parent::tei:keywords]
+    case 'keywords_biblio' return $collection//tei:term[parent::tei:keywords][not(matches(., '[A-F0-9]{6}'))]
     case 'docLang' return $collection//tei:language/@ident
     case 'workTitle' return $collection//mei:title[parent::mei:titleStmt]
     case 'geonamesFeatureClass' return $collection//tei:place/@typeof

--- a/templates/ajax/biblio.html
+++ b/templates/ajax/biblio.html
@@ -1,6 +1,10 @@
 <div xmlns="http://www.w3.org/1999/xhtml" class="row" data-template="search:results" data-template-docType="biblio">
     <div class="col-md-3 order-2 side-col">
-        <h2><a href="#allFilter" class="collapseSingle" aria-expanded="true" data-toggle="collapse"><span data-template="lang:translate">filter</span></a></h2>
+        <h2>
+            <a href="#allFilter" class="collapseSingle" aria-expanded="true" data-toggle="collapse">
+                <span data-template="lang:translate">filter</span>
+            </a>
+        </h2>
         <!-- Facetten Filter-->
         <div class="allFilter panel-collapse collapse show" id="allFilter">
             <h4 data-template="lang:translate">chronology</h4>
@@ -15,6 +19,20 @@
             
             <h4 data-template="lang:translate">editors</h4>
             <select multiple="multiple" data-template="facets:select" name="editors"/>
+            
+            <div data-template="app-shared:if-matches" data-template-key="environment" data-template-value="development" data-template-wrap="no">
+                <h4 data-template="lang:translate">persons_mentioned</h4>
+                <select multiple="multiple" data-template="facets:select" name="persons"/>
+                
+                <h4 data-template="lang:translate">works_mentioned</h4>
+                <select multiple="multiple" data-template="facets:select" name="works"/>
+                
+                <h4 data-template="lang:translate">places_mentioned</h4>
+                <select multiple="multiple" data-template="facets:select" name="places"/>
+                
+                <h4 data-template="lang:translate">keywords</h4>
+                <select multiple="multiple" data-template="facets:select" name="keywords_biblio"/>
+            </div>
             
             <!--<h4 data-template="lang:translate">journals</h4>
             <select multiple="multiple" data-template="facets:select" name="journals"/>-->


### PR DESCRIPTION
There are four new filter options now:
- mentioned persons
- mentioned works
- mentioned places
- keywords

I realized one issue: Countries are now listed in the keywords, not in 'mentioned places', as they don't have a register entry. I couldn't think of any fix that wouldn't include hard coding said places to be handled as places.

I also realized that some other document types are included as keywords:
- 11 x writings (A03)
- 2 x letters (A04)
- 5 x oranizations (A08)
- 2 x documents (A10)
- 2 x biblio (A11)

I highly doubt that creating filter fields for each of them would yield any benefit – the UI would be way to stuffed and most of those entities have such long names, that a dropdown menu would look horrible.
But I'd also refrain from putting them into the 'keywords' filter menu.
So we'd either have to collect them in a 'andere erwähnte Entitäten' filter, or – what I'd prefer – we could just have them as backlinks for the mentioned documents, so that if a biblio file mentions a letter in the keywords, this letter would have the corresponding bibliographic entry as a backlink. What do you think?

In this case I'd merge this branch and create a new ticket for this backlink generating.