### PR TITLE
set user agent string for HTTP requests initiated by the WeGA-WebApp

### DIFF
--- a/modules/external-requests.xqm
+++ b/modules/external-requests.xqm
@@ -147,7 +147,7 @@ declare function er:resolve-rdf-resource($elem as element()) as element(er:respo
  : @return element wega:externalResource, a wrapper around er:response
  :)
 declare function er:http-get($url as xs:anyURI) as element(wega:externalResource) {
-    let $req := <http:request href="{$url}" method="get" timeout="3"><http:header name="Connection" value="close"/></http:request>
+    let $req := <http:request href="{$url}" method="get" timeout="3"><http:header name="Connection" value="close"/><http:header name="User-Agent" value="WeGA-WebApp/{config:expath-descriptor()/@version => string()}"/></http:request>
     let $response := 
         try { http:send-request($req) }
         catch * {wega-util:log-to-file(if(contains($err:description, 'Read timed out')) then 'info' else 'warn', string-join(('er:http-get', $err:code, $err:description, 'URL: ' || $url), ' ;; '))}


### PR DESCRIPTION
The current return value of `er:grab-external-resource-wikidata#2` looked like:

```xml
<wega:externalResource xmlns:wega="http://www.weber-gesamtausgabe.de" date="2025-08-29Z">
    <er:response xmlns:er="http://xquery.weber-gesamtausgabe.de/modules/external-requests" statusCode="403">
        <er:headers>
            <er:header name="content-length" value="92"/>
            <er:header name="content-type" value="text/plain"/>
            <er:header name="x-analytics" value=""/>
            <er:header name="server" value="HAProxy"/>
            <er:header name="x-cache" value="cp3067 int"/>
            <er:header name="x-cache-status" value="int-tls"/>
            <er:header name="connection" value="close"/>
        </er:headers>
        <er:body mimetype="text/plain">Please set a user-agent and respect our robot policy https://w.wiki/4wJS. See also T400119.
</er:body>
    </er:response>
</wega:externalResource>
```

This fix remedies the issue with the missing Wikipedia integration. Nevertheless, we might investigate on how to switch to their [REST API](https://www.wikidata.org/wiki/Wikidata:REST_API) instead of grabbing the web pages … 