### PR TITLE
fix bug with unwanted linebreaks in table-cell descriptions

### DIFF
--- a/resources/sass/pages/_guidelines.scss
+++ b/resources/sass/pages/_guidelines.scss
@@ -96,7 +96,7 @@ span.label {
 .tei_specList {
     margin-left:1em;
     margin-top:-(ceil(calc($line-height-computed / 2)));
-    li * {
+    li > * {
         display: table-cell;
         padding-right:.5em;
     }


### PR DESCRIPTION
Redo changes that got lost after squashmerging https://github.com/Edirom/WeGA-WebApp/pull/494.
See #498 for original PR.