### PR TITLE
fix function `api:documents-otd#1`

### DIFF
--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -119,6 +119,12 @@ declare function api:documents-otd($model as map(*)) as map(*) {
     let $model :=
         (: update model with date information :)
         map:put($model, 'otdDate', string($otdDate)) => map:put('dateWithoutYear', $dateWithoutYear)
+    (:
+        The exact behaviour of the query string is still not clear to me: although enquoted, the query string (and/or the field index)
+        seems to get tokenized, at least the query strings "10-12", "10 12", and "10\-12" yield all the same results (i.e. it will all match October 10 in any year).
+        NB, it does not match any date in December 1810, what one might expect.
+        Since this behaviour might change in some future eXist version I put it here as a word of caution.
+    :)
     let $lucene-query-string := 'date:"' || $dateWithoutYear || '"'
     let $eventElements :=
         for $docType in api:resolve-docTypes($model)

--- a/modules/api.xqm
+++ b/modules/api.xqm
@@ -119,6 +119,7 @@ declare function api:documents-otd($model as map(*)) as map(*) {
     let $model :=
         (: update model with date information :)
         map:put($model, 'otdDate', string($otdDate)) => map:put('dateWithoutYear', $dateWithoutYear)
+    let $lucene-query-string := 'date:"' || $dateWithoutYear || '"'
     let $eventElements :=
         for $docType in api:resolve-docTypes($model)
         return
@@ -126,18 +127,18 @@ declare function api:documents-otd($model as map(*)) as map(*) {
             case 'diaries' return
                 core:getOrCreateColl(
                     $docType, 'indices', true()
-                )//tei:ab[ft:query(., 'date:' || $dateWithoutYear)]/self::tei:ab (: use self axis here for performance reasons :)
+                )//tei:ab[ft:query(., $lucene-query-string)]/self::tei:ab (: use self axis here for performance reasons :)
                 [xs:date(@n) le $otdDate]//tei:seg[@type = ('rehearsal', 'performance', 'production')]
                 [.//tei:workName[not(ancestor::tei:note)]/@key or .//tei:rs[@type='work'][not(ancestor::tei:note)]/@key]
             case 'letters' return
                 core:getOrCreateColl(
                     $docType,'indices', true()
-                )//tei:TEI[ft:query(., 'date:' || $dateWithoutYear)]//tei:correspAction[@type='sent']
+                )//tei:TEI[ft:query(., $lucene-query-string)]//tei:correspAction[@type='sent']
                 [some $cur.date in tei:date satisfies contains($cur.date/@when, $dateWithoutYear) and xs:date($cur.date/@when) le $otdDate][following::tei:text//tei:p]
             case 'persons' return
                 core:getOrCreateColl(
                     $docType, 'indices', true()
-                )//tei:person[ft:query(., 'date:' || $dateWithoutYear, map{'facets': map{'docSource': 'WeGA'}})]
+                )//tei:person[ft:query(., $lucene-query-string, map{'facets': map{'docSource': 'WeGA'}})]
                 //tei:date[contains(@when, $dateWithoutYear)][xs:date(@when) le $otdDate][parent::tei:birth or parent::tei:death]/parent::*
             default return ()
     let $sortedEvents := 


### PR DESCRIPTION
This PR fixes a bug with the query syntax for the date field of the lucene index.
The query string was unquoted which led to various false positives e.g., the query "1817-10-11" would not only return documents from October 11, but also from November 10. 
Surrounding the date search string with double quotes fixes the issue.

## How to check

The basic principle can be checked with 

```xquery
(: unquoted query string; should return two results :)
collection('/db/apps/WeGA-data/diaries')//tei:ab[ft:query(., 'date:1817-12-11')]
```

vs.

```xquery
(: enquoted query string, should return only one result :)
collection('/db/apps/WeGA-data/diaries')//tei:ab[ft:query(., 'date:"1817-12-11"')]
```

The function  `api:documents-otd#1` can be checked like 

```xquery
xquery version "3.1";
declare namespace tei="http://www.tei-c.org/ns/1.0";
import module namespace api="http://xquery.weber-gesamtausgabe.de/modules/api" at "/db/apps/WeGA-WebApp/modules/api.xqm";

let $open-api := json-doc('/db/apps/WeGA-WebApp/api/v1/openapi.json')
return
    api:documents-otd(map {'otdDate': "2025-12-12", 'docType': 'diaries', 'openapi:config': $open-api})
```

which should return a "totalRecordCount" of 10 (this PR) instead of 357 (current dev branch)
