### PR TITLE
fix various issues with external content providers

### DIFF
--- a/modules/app.xqm
+++ b/modules/app.xqm
@@ -1114,7 +1114,7 @@ declare
     %templates:wrap
     %templates:default("lang", "en")
     function app:wikipedia-text($node as node(), $model as map(*), $lang as xs:string) as item()* {
-        let $wikiText := wega-util:transform($model('wikiContent')//xhtml:div[@id='bodyContent'], doc(concat($config:xsl-collection-path, '/wikipedia.xsl')), config:get-xsl-params(()))
+        let $wikiText := wega-util:transform($model('wikiContent')//xhtml:main[@id='content'], doc(concat($config:xsl-collection-path, '/wikipedia.xsl')), config:get-xsl-params(()))
         return 
             if(exists($wikiText)) then $wikiText
             else lang:get-language-string('failedToLoadExternalResource', $lang)

--- a/modules/app.xqm
+++ b/modules/app.xqm
@@ -1179,8 +1179,8 @@ declare
     %templates:default("lang", "en")
     function app:deutsche-biographie-text($node as node(), $model as map(*), $type as xs:string, $lang as xs:string) as item()* {
         let $deutsche-biographie-text := 
-            if($type = 'ndb') then wega-util:transform($model('adbndbContent')//xhtml:div[@id='ndbcontent'], doc(concat($config:xsl-collection-path, '/deutsche-biographie.xsl')), config:get-xsl-params(()))/node()
-            else wega-util:transform($model('adbndbContent')//xhtml:div[@id='adbcontent'], doc(concat($config:xsl-collection-path, '/deutsche-biographie.xsl')), config:get-xsl-params(()))/node()
+            if($type = 'ndb') then wega-util:transform($model('adbndbContent')//xhtml:h4[@id='ndbcontent_leben']/ancestor::xhtml:ul[@class='bioartikel'], doc(concat($config:xsl-collection-path, '/deutsche-biographie.xsl')), config:get-xsl-params(()))/node()
+            else wega-util:transform($model('adbndbContent')//xhtml:h4[@id='adbcontent_leben']/ancestor::xhtml:ul[@class='bioartikel'], doc(concat($config:xsl-collection-path, '/deutsche-biographie.xsl')), config:get-xsl-params(()))/node()
         return 
             if(exists($deutsche-biographie-text)) then $deutsche-biographie-text
             else lang:get-language-string('failedToLoadExternalResource', $lang)

--- a/modules/img.xqm
+++ b/modules/img.xqm
@@ -346,12 +346,12 @@ declare %private function img:tripota-images($model as map(*), $lang as xs:strin
     let $pics := $page//xhtml:td
     return 
         for $div in $pics[not(xhtml:a/xhtml:img/@src='portraits/dummy.jpg')]
-        let $picURI := concat('http://www.tripota.uni-trier.de/',  $div//xhtml:img[starts-with(@src, 'portraits')]/data(@src))
+        let $picURI := concat('https://www.tripota.uni-trier.de/',  $div//xhtml:img[starts-with(@src, 'portraits')]/data(@src))
         return 
             if($picURI castable as xs:anyURI) then
                 map {
                     'caption' : normalize-space(string-join($div/xhtml:br[2]/following-sibling::node(), ' ')) || ' (Quelle: Trierer Porträtdatenbank)',
-                    'linkTarget' : 'http://www.tripota.uni-trier.de/' || $div/xhtml:a[1]/data(@href),
+                    'linkTarget' : 'https://www.tripota.uni-trier.de/' || $div/xhtml:a[1]/data(@href),
                     'source' : 'Trierer Porträtdatenbank',
                     'url' : function($size) {
                         $picURI

--- a/resources/sass/components/_ajax.scss
+++ b/resources/sass/components/_ajax.scss
@@ -31,6 +31,9 @@
     .wikipediaOrigin {
         font-style: italic;
     }
+    figure {
+        text-align: center;
+    }
 }
 
 /*

--- a/templates/ajax/adb.html
+++ b/templates/ajax/adb.html
@@ -1,4 +1,4 @@
-<div data-template="app:deutsche-biographie">
+<div xmlns="http://www.w3.org/1999/xhtml" data-template="app:deutsche-biographie">
     <h2 id="top">ADB (Allgemeine Deutsche Biographie)</h2>
     <div data-template="app:deutsche-biographie-text" data-template-type="adb">ADB Text</div>
     <div>

--- a/templates/ajax/beacon.html
+++ b/templates/ajax/beacon.html
@@ -1,4 +1,4 @@
-<div data-template="app:beacon">
+<div xmlns="http://www.w3.org/1999/xhtml" data-template="app:beacon">
     <h2>GND Beacon Links</h2>
     <ul>
         <li data-template="app-shared:each" data-template-from="beaconLinks" data-template-to="beaconLink">

--- a/templates/ajax/dnb.html
+++ b/templates/ajax/dnb.html
@@ -1,4 +1,4 @@
-<div data-template="app:dnb">
+<div xmlns="http://www.w3.org/1999/xhtml" data-template="app:dnb">
     <h2 data-template="lang:translate">infoFromGND</h2>
     <dl data-template="app-shared:if-exists" data-template-key="dnbName">
         <dt data-template="lang:translate">pnd_name</dt>

--- a/templates/ajax/ndb.html
+++ b/templates/ajax/ndb.html
@@ -1,4 +1,4 @@
-<div data-template="app:deutsche-biographie">
+<div xmlns="http://www.w3.org/1999/xhtml" data-template="app:deutsche-biographie">
     <h2 id="top">NDB (Neue Deutsche Biographie)</h2>
     <div data-template="app:deutsche-biographie-text" data-template-type="ndb">NDB Text</div>
     <div>

--- a/templates/ajax/otd.html
+++ b/templates/ajax/otd.html
@@ -1,4 +1,4 @@
-<div class="container" data-template="app:lookup-todays-events">
+<div xmlns="http://www.w3.org/1999/xhtml" class="container" data-template="app:lookup-todays-events">
     <!-- Container for "What happened on this day"   -->
     <!-- on the main index page -->
     <div class="row paddingTopIcon">

--- a/templates/ajax/wikipedia.html
+++ b/templates/ajax/wikipedia.html
@@ -1,4 +1,4 @@
-<div data-template="app:wikipedia">
+<div xmlns="http://www.w3.org/1999/xhtml" data-template="app:wikipedia">
     <h2>Wikipedia</h2>
     <div data-template="app:wikipedia-text">Wikipedia Text</div>
     <p class="linkAppendix" data-template="app:wikipedia-disclaimer">Wikipedia Disclaimer</p>

--- a/xsl/wikipedia.xsl
+++ b/xsl/wikipedia.xsl
@@ -120,4 +120,8 @@
     <xsl:template match="a[following-sibling::div/@id='mw-content-text']"/>
     <xsl:template match="table[@id='Vorlage_Begriffsklärungshinweis']"/>
     <xsl:template match="div[@class='hatnote navigation-not-searchable']"/>
+    <xsl:template match="header[parent::main]"/>
+    <xsl:template match="div[contains(@class, 'vector-column-end')]"/>
+    <xsl:template match="div[contains(@class, 'vector-page-toolbar')]"/>
+    
 </xsl:stylesheet>


### PR DESCRIPTION
1. Adjustments to changes in the  HTML structure of Wikipedia and ADB/NDB 
2. Add some missing namespace declarations 
3. Implement a workaround for dysfunctional http->https redirect at www.tripota.uni-trier.de

## How to check

Check with e.g. Lessing (A002351). This PR should feature two more images (from www.tripota.uni-trier.de) in the top right "Ikonographie" section as well as a working ADB, NDB, and Wikipedia tabs.

### dev version

<img width="1160" height="723" alt="Bildschirmfoto 2025-11-13 um 21 29 43" src="https://github.com/user-attachments/assets/022de554-b3a1-4b53-b539-322bada185b9" />


### this PR

<img width="1130" height="738" alt="Bildschirmfoto 2025-11-13 um 21 30 10" src="https://github.com/user-attachments/assets/26a1fcfe-974f-4411-a031-47796a92b70b" />
