### PR TITLE
keep left tc-image on full display

### DIFF
--- a/resources/sass/layout/_header.scss
+++ b/resources/sass/layout/_header.scss
@@ -218,6 +218,10 @@
         height: 100%;
         box-sizing: border-box;
         
+        .left {
+            justify-content: flex-end;
+        }
+        
         .thematicCommentary-image-frame {
             position: relative;
             width: 100%;

--- a/templates/includes/thematicCommentaryOfTheWeek.html
+++ b/templates/includes/thematicCommentaryOfTheWeek.html
@@ -1,12 +1,12 @@
 <div xmlns="http://www.w3.org/1999/xhtml" class="row thematicCommentary-of-the-week-row">
-    <div class="col-xl-3 col-lg-3 d-lg-block d-none thematicCommentary-of-the-week-image left">
-        <div class="thematicCommentary-image-frame">
+    <div class="col-xl-3 col-lg-4 d-lg-block d-none thematicCommentary-of-the-week-image left">
+        <div class="thematicCommentary-image-frame left">
             <img src="$resources/img/Teaser-Test.png" alt="Carl Maria von Weber Jubiläumsbild"/>
             <!-- placeholder for static jubilee picture-->
     
         </div>
     </div>
-    <div class="col-xl-6 col-lg-9 col-md-12 flipcard thematicCommentary-of-the-week-flipcard">
+    <div class="col-xl-6 col-lg-7 col-md-12 flipcard thematicCommentary-of-the-week-flipcard">
         <div class="front transparent">
             <h2 data-template="app-shared:output"
                 data-template-key="thematicCommentaryOfTheWeek-occasion"


### PR DESCRIPTION
Changed the distribution of columns to 3-6-3 (graphic-flipcard-graphic) on large screens and 4-7 (graphic-flipcard) on smaller screens. That leaves enough horizontal space for the graphic to prevent cropping, keeps enough space for the flipcard content (checked with each one individually) and leaves space on the right for the carousel arrow.

<img width="993" height="462" alt="image" src="https://github.com/user-attachments/assets/dcf49116-2a06-4d09-9018-a24ff5d97336" />
