### PR TITLE
assign z-index to weekday rows

### DIFF
--- a/resources/sass/pages/_index.scss
+++ b/resources/sass/pages/_index.scss
@@ -148,6 +148,10 @@ h1.home
     .fc-button {
         border-radius: unset;
     }
+    .fc-list-day {
+        position: sticky;
+        z-index: 1;
+    }
     .fc-list-day-text, .fc-list-day-side-text {
         color: inherit;
     }


### PR DESCRIPTION
Gave positive z-index to weekday rows, to force them in front of the scrolling calendar events.
<img width="1115" height="75" alt="image" src="https://github.com/user-attachments/assets/bc8990e4-ee9f-4b8f-bb1c-792bb647d848" />
