### PR TITLE
let white-space break in context links

### DIFF
--- a/resources/sass/layout/_sidebar.scss
+++ b/resources/sass/layout/_sidebar.scss
@@ -122,8 +122,14 @@ a.checkbox-only {
         padding: 0.5em;
     }
 
-    #kontext a {
-        white-space: normal;
+    #kontext {
+        a {
+            white-space: normal;
+        }
+        li {
+            text-indent: -1em; 
+            padding-left: 1em;
+        }
     }
 }
 

--- a/resources/sass/layout/_sidebar.scss
+++ b/resources/sass/layout/_sidebar.scss
@@ -122,6 +122,9 @@ a.checkbox-only {
         padding: 0.5em;
     }
 
+    #kontext a {
+        white-space: normal;
+    }
 }
 
 /*


### PR DESCRIPTION
See the issue #555 for a problem report.
Added a scss rule to let white-space break in links inside the `#kontext` div.