### PR TITLE
Add date range inputs

### DIFF
--- a/catalogues/dictionary_de.xml
+++ b/catalogues/dictionary_de.xml
@@ -267,6 +267,7 @@
     <entry xml:id="lyricists">Textdichtung von </entry>
     <entry xml:id="occupations">Tätigkeiten</entry>
     <entry xml:id="alphabetic">Alphabetisch</entry>
+    <entry xml:id="chronoFrom">von</entry>
     <entry xml:id="chronoTo">bis</entry>
     <entry xml:id="chronology">Chronologie</entry>
     <entry xml:id="undated">undatiert</entry>

--- a/catalogues/dictionary_en.xml
+++ b/catalogues/dictionary_en.xml
@@ -265,6 +265,7 @@
     <entry xml:id="lyricists">Lyricists</entry>
     <entry xml:id="occupations">Occupations</entry>
     <entry xml:id="alphabetic">Alphabetic</entry>
+    <entry xml:id="chronoFrom">from</entry>
     <entry xml:id="chronoTo">to</entry>
     <entry xml:id="chronology">Chronology</entry>
     <entry xml:id="undated">undated</entry>

--- a/resources/js/init.js
+++ b/resources/js/init.js
@@ -135,7 +135,7 @@ function formatFacet (facet) {
 }
 
 /* 
- * Helper function for rangeSlider and chronology input
+ * Helper functions for rangeSlider and chronology input
  */
 function applyChronologyFilter (data) {
     /* Get active facets to append as URL params */
@@ -151,18 +151,27 @@ function applyChronologyFilter (data) {
     updatePage(params);
 }
 
+function getInputDateFormat() {
+    const lang = getLanguage();
+    return (lang === 'de') ? "DD.MM.YYYY" : "MM/DD/YYYY";
+}
+
+function formatInputDate(timestamp) {
+    return moment(timestamp).locale(getLanguage()).format(getInputDateFormat());
+}
+
 $('.allFilter').on('change', '.chronology-from, .chronology-to', function () {
     const slider = $('.rangeSlider').data('ionRangeSlider');
     if (!slider) return;
 
-    const val = $(this).val().trim();
-        m = moment(val, "YYYY-MM-DD", true);
+    const val = $(this).val().trim(),
+        m = moment(val, getInputDateFormat(), true);
     if (!m.isValid()) return;
     
-    const timestamp = +m;
-        currentFrom = slider.result.from;
-        currentTo = slider.result.to;
-        min = slider.result.min;
+    const timestamp = +m,
+        currentFrom = slider.result.from,
+        currentTo = slider.result.to,
+        min = slider.result.min,
         max = slider.result.max;
     if (timestamp < min || timestamp > max) return;
 
@@ -210,12 +219,12 @@ $.fn.rangeSlider = function () {
             return m.format(format);
         },
         onStart: function (data) {
-            $('.chronology-from').val(moment(data.from).format("YYYY-MM-DD"));
-            $('.chronology-to').val(moment(data.to).format("YYYY-MM-DD"));
+            $('.chronology-from').val(formatInputDate(data.from));
+            $('.chronology-to').val(formatInputDate(data.to));
         },
         onChange: function (data) {
-            $('.chronology-from').val(moment(data.from).format("YYYY-MM-DD"));
-            $('.chronology-to').val(moment(data.to).format("YYYY-MM-DD"));
+            $('.chronology-from').val(formatInputDate(data.from));
+            $('.chronology-to').val(formatInputDate(data.to));
         },
         onFinish: function (data) { applyChronologyFilter(data); }
     });

--- a/resources/js/init.js
+++ b/resources/js/init.js
@@ -134,20 +134,72 @@ function formatFacet (facet) {
     return facet;
 }
 
-$.fn.rangeSlider = function () 
-{
+/* 
+ * Helper function for rangeSlider and chronology input
+ */
+function applyChronologyFilter (data) {
+    /* Get active facets to append as URL params */
+    const params = active_facets(),
+        newFrom = moment(data.from).locale("de").format("YYYY-MM-DD"),
+        newTo = moment(data.to).locale("de").format("YYYY-MM-DD");
+    
+    /* Overwrite date params with new values from the slider */
+    params.sliderDates.fromDate = newFrom;
+    params.sliderDates.toDate = newTo;
+    params.sliderDates.oldFromDate = moment(data.min).locale("de").format("YYYY-MM-DD");
+    params.sliderDates.oldToDate = moment(data.max).locale("de").format("YYYY-MM-DD");
+    updatePage(params);
+}
+
+$('.allFilter').on('change', '.chronology-from, .chronology-to', function () {
+    const slider = $('.rangeSlider').data('ionRangeSlider');
+    if (!slider) return;
+
+    const val = $(this).val().trim();
+        m = moment(val, "YYYY-MM-DD", true);
+    if (!m.isValid()) return;
+    
+    const timestamp = +m;
+        currentFrom = slider.result.from;
+        currentTo = slider.result.to;
+        min = slider.result.min;
+        max = slider.result.max;
+    if (timestamp < min || timestamp > max) return;
+
+    const isFrom = $(this).hasClass('chronology-from');
+    if (isFrom && timestamp > currentTo) return;
+    if (!isFrom && timestamp < currentFrom) return;
+
+    if (isFrom) {
+        slider.update({ from: timestamp });
+        applyChronologyFilter({
+            from: timestamp,
+            to: currentTo,
+            min: min,
+            max: max
+        });
+    } else {
+        slider.update({ to: timestamp });
+        applyChronologyFilter({
+            from: currentFrom,
+            to: timestamp,
+            min: min,
+            max: max
+        });
+    }
+});
+
+$.fn.rangeSlider = function () {
     this.ionRangeSlider({
         min: +moment($(this).attr('data-min-slider')),
         max: +moment($(this).attr('data-max-slider')),
         from: +moment($(this).attr('data-from-slider')),
         to: +moment($(this).attr('data-to-slider')),
-        grid: true,
+        grid: false,
         skin: "flat",
         step: 100,
         force_edges: true,
         type: "double",
-        //force_edges: true,
-        grid_num: 3,
         keyboard: true,
         prettify: function (num) {
             const lang = getLanguage(),
@@ -157,21 +209,15 @@ $.fn.rangeSlider = function ()
             else { format = "MMM D, YYYY" }
             return m.format(format);
         },
-        onFinish: function (data) {
-            /* Get active facets to append as URL params */
-            const params = active_facets(),
-                newFrom = moment(data.from).locale("de").format("YYYY-MM-DD"),
-                newTo = moment(data.to).locale("de").format("YYYY-MM-DD");
-            
-            /* 
-             * Overwrite date params with new values from the slider 
-             */
-            params.sliderDates.fromDate = newFrom;
-            params.sliderDates.toDate = newTo;
-            params.sliderDates.oldFromDate = moment(data.min).locale("de").format("YYYY-MM-DD");
-            params.sliderDates.oldToDate = moment(data.max).locale("de").format("YYYY-MM-DD");
-            updatePage(params);
-        }
+        onStart: function (data) {
+            $('.chronology-from').val(moment(data.from).format("YYYY-MM-DD"));
+            $('.chronology-to').val(moment(data.to).format("YYYY-MM-DD"));
+        },
+        onChange: function (data) {
+            $('.chronology-from').val(moment(data.from).format("YYYY-MM-DD"));
+            $('.chronology-to').val(moment(data.to).format("YYYY-MM-DD"));
+        },
+        onFinish: function (data) { applyChronologyFilter(data); }
     });
 };
 

--- a/resources/sass/layout/_sidebar.scss
+++ b/resources/sass/layout/_sidebar.scss
@@ -116,6 +116,10 @@ a.checkbox-only {
         }
     }
     
+    .chronology-input input {
+        width: 100%
+    }
+    
     #settings {
         background-color: $gray-lightest;
         border-left: 4px solid $gray-light;

--- a/templates/ajax/correspondence.html
+++ b/templates/ajax/correspondence.html
@@ -5,6 +5,17 @@
         <div class="allFilter panel-collapse collapse show" id="allFilter">
             <h4 data-template="lang:translate">chronology</h4>
             <input type="text" class="rangeSlider" name="chronology-slider" data-template="app:set-slider-range"/>
+            <div class="row chronology-input">
+                <div class="col-6">
+                    <h4 data-template="lang:translate">chronoFrom</h4>
+                    <input type="text" class="chronology-from"/>
+                </div>
+                <div class="col-6">
+                    <h4 data-template="lang:translate">chronoTo</h4>
+                    <input type="text" class="chronology-to"/>
+                </div>
+            </div>
+            <hr/>
             <div class="input-group facet-group checkbox">
                 <input type="checkbox" name="undated" id="undatedLetters" data-template="app:set-facet-checkbox" data-template-key="undated"/>
                 <label for="undatedLetters" data-template="lang:translate">showUndatedDocuments</label>
@@ -12,6 +23,7 @@
                 <input type="checkbox" name="hideRevealed" id="hideRevealed" data-template="app:set-facet-checkbox" data-template-key="hideRevealed"/>
                 <label for="hideRevealed" data-template="lang:translate">hideRevealedLetters</label>
             </div>
+            <hr/>
             <h4 data-template="lang:translate">sender</h4>
             <select multiple="multiple" data-template="facets:select" name="sender"/>
             <h4 data-template="lang:translate">addressees</h4>


### PR DESCRIPTION
This should hopefully fit the needs described in issue #36.

**before:**
<img width="279" height="241" alt="image" src="https://github.com/user-attachments/assets/8f2393aa-aa67-403d-a183-249da7fb9d1d" />
**after:**
<img width="298" height="339" alt="image" src="https://github.com/user-attachments/assets/d9407a8f-76f8-4a09-8037-c3e035583f9a" />

The new input boxes are synchronized with the range slider and both update each other in real time. The filtering can be triggered both by changing the dates in the input field and by sliding the slider.

I went with receiving the input as plain text and testing for correct date formats in the JS portion. There are also some basic tests to make sure the input dates are within the allowed min and max range, and that the from date is actually lower than the to date. Although there is no feedback if the input is faulty and nothing happens – but also nothing crashes.

The allowed input date formats are bound to the language and are "DD.MM.YYYY" for german and "MM.DD.YYYY" for english respectively.

I adjusted the looks aswell. I removed the grid (since it was just showing random and confusing dates below the slider) and added some horizontal bars to make the grouping of different filter options more intuitive.

Please feel free to openly comment on the whole approach. I think it works rather nicely and apart from some error feedback I can't think of any major adjustments I would aim for.
I was thinking about implementing a switch that let's you decide between searching for a range / a specific date, but that felt overkill to implement for the time being. Same goes for having a pop-up calendar to input the dates and I'm not even sure if that is any user friendly if not done right.
