### PR TITLE
Update CMIF v2 export and add language information

### DIFF
--- a/modules/cmif.xql
+++ b/modules/cmif.xql
@@ -80,7 +80,10 @@ declare function ct:identity-transform-with-switches($nodes as node()*) as item(
         case element(tei:placeName) return ct:place($node)
         case element(tei:settlement) return ct:place($node)
         case element(tei:country) return ct:place($node)
-        case element(tei:date) return ct:date($node)
+        case element(tei:date) return 
+            (: CMIF only allows for a single date :)
+            if($node/preceding-sibling::tei:date) then ()
+            else ct:date($node)
         case element(tei:note) return 
             element {QName(namespace-uri($node), local-name($node))} {
                 (: skip attributes due to danger of duplicate xml:ids – and we don't need them :)

--- a/modules/cmif.xql
+++ b/modules/cmif.xql
@@ -212,6 +212,21 @@ declare %private function ct:response-headers() as empty-sequence() {
 };
 
 (:~
+ : Helper function for creating CMIF v2 relations 
+ :)
+declare %private function ct:cmif2-ref(
+    $type as xs:string, 
+    $target as xs:string, 
+    $text as xs:string?) as element(tei:ref) 
+    {
+        element {QName('http://www.tei-c.org/ns/1.0', 'ref')} {
+                attribute {'type'} {$type},
+                attribute {'target'} {$target},
+                $text
+            }
+};
+
+(:~
  : Helper function to construct entity references within CMIF v2 tei:note element
  :
  : @param $doc the document to extract the features from
@@ -227,11 +242,7 @@ declare %private function ct:mentioned-entity-by-wega-facet(
         group by $id := $entity/@key
         let $target := ct:ref-target($id)
         return
-            element {QName('http://www.tei-c.org/ns/1.0', 'ref')} {
-                attribute {'type'} {$cmifURI},
-                attribute {'target'} {$target},
-                query:title($id)
-            }
+            ct:cmif2-ref($cmifURI, $target, query:title($id))
 };
 
 (:~

--- a/modules/cmif.xql
+++ b/modules/cmif.xql
@@ -81,9 +81,14 @@ declare function ct:identity-transform-with-switches($nodes as node()*) as item(
         case element(tei:settlement) return ct:place($node)
         case element(tei:country) return ct:place($node)
         case element(tei:date) return 
-            (: CMIF only allows for a single date :)
-            if($node/preceding-sibling::tei:date) then ()
-            else ct:date($node)
+            (: CMIF only allows for a single date.
+               Suppress this <tei:date> only if there is an earlier sibling
+               <tei:date> that would actually be emitted (i.e. has one of
+               @when/@from/@to/@notBefore/@notAfter), and only emit dates
+               that themselves have one of these attributes. :)
+            if ($node/preceding-sibling::tei:date[@when or @from or @to or @notBefore or @notAfter]) then ()
+            else if ($node/@when or $node/@from or $node/@to or $node/@notBefore or $node/@notAfter) then ct:date($node)
+            else ()
         case element(tei:note) return 
             element {QName(namespace-uri($node), local-name($node))} {
                 (: skip attributes due to danger of duplicate xml:ids – and we don't need them :)

--- a/modules/cmif.xql
+++ b/modules/cmif.xql
@@ -162,7 +162,7 @@ declare function ct:date($input as element()) as element(tei:date)? {
     if($input/(@when | @from | @to | @notBefore | @notAfter))
     then
         element {QName('http://www.tei-c.org/ns/1.0', local-name($input))} {
-            $input/@*[not(local-name(.) = ('n', 'calendar', 'cert'))]
+            $input/@* except $input/@n except $input/@calendar except $input/@cert
             (: 
             no content allowed here with the schema at 
             https://raw.githubusercontent.com/TEI-Correspondence-SIG/CMIF/master/schema/cmi-customization.rng  

--- a/modules/cmif.xql
+++ b/modules/cmif.xql
@@ -180,7 +180,7 @@ declare function ct:cmif2-note($doc as document-node()) as element(tei:note)? {
     let $places := ct:mentioned-entity-by-wega-facet($doc, 'places', 'cmif:mentionsPlace')
     let $fullTextURL := config:permalink($doc/*/@xml:id) || '.xml?format=tei_all'
     let $languages := 
-        $doc//tei:language[parent::tei:langUsage] ! ct:cmif2-ref('https://lod.academy/cmif/vocab/terms#hasLanguage', ./@ident, .)
+        $doc//tei:language[parent::tei:langUsage] ! ct:cmif2-ref('https://lod.academy/cmif/vocab/terms#hasLanguage', ./@ident, normalize-space(.))
     return
         element {QName('http://www.tei-c.org/ns/1.0', 'note')} {
             $persons,

--- a/modules/cmif.xql
+++ b/modules/cmif.xql
@@ -173,19 +173,20 @@ declare function ct:date($input as element()) as element(tei:date)? {
 
 (:~
  : Extract text features for CMIF v2 and put them in a tei:note
+ : See https://encoding-correspondence.bbaw.de/v1/CMIF.html#c-4-2
  :)
 declare function ct:cmif2-note($doc as document-node()) as element(tei:note)? {
     let $persons := ct:mentioned-entity-by-wega-facet($doc, 'persons', 'cmif:mentionsPerson')
     let $places := ct:mentioned-entity-by-wega-facet($doc, 'places', 'cmif:mentionsPlace')
     let $fullTextURL := config:permalink($doc/*/@xml:id) || '.xml?format=tei_all'
+    let $languages := 
+        $doc//tei:language[parent::tei:langUsage] ! ct:cmif2-ref('https://lod.academy/cmif/vocab/terms#hasLanguage', ./@ident, .)
     return
         element {QName('http://www.tei-c.org/ns/1.0', 'note')} {
             $persons,
             $places,
-            element {QName('http://www.tei-c.org/ns/1.0', 'ref')} {
-                attribute {'type'} {'cmif:isAvailableAsTEIfile'},
-                attribute {'target'} {$fullTextURL}
-            }
+            ct:cmif2-ref('cmif:isAvailableAsTEIfile', $fullTextURL, ()),
+            $languages
         }
 };
 


### PR DESCRIPTION
@StefanDumont pointed me at the new feature of providing language information for a letter within CMIF v2.
Although documentation seems to be lacking so far (I couldn't find any at https://encoding-correspondence.bbaw.de/v1/CMIF.html#c-4-2), Stefan pointed me at https://gams.uni-graz.at/context:hsa/CMIF where this feature is already successfully introduced.

Also I added a small fix for preventing multiple dates which the CMIF check complained about.