### PR TITLE
process articles with multiple imprints in preview

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,6 @@ RUN ant -lib /usr/share/java
 FROM stadlerpeter/existdb:6
 LABEL org.opencontainers.image.authors="Peter Stadler"
 
-ADD --chown=wegajetty https://weber-gesamtausgabe.de/downloads/WeGA-data-testing-44180.xar ${EXIST_HOME}/autodeploy/
+ADD --chown=wegajetty https://weber-gesamtausgabe.de/downloads/WeGA-data-testing-44180a.xar ${EXIST_HOME}/autodeploy/
 COPY --from=builder /opt/wega-lib/build/*.xar ${EXIST_HOME}/autodeploy/
 COPY --from=builder /opt/wega/build/*.xar ${EXIST_HOME}/autodeploy/

--- a/catalogues/dictionary_de.xml
+++ b/catalogues/dictionary_de.xml
@@ -458,6 +458,7 @@
     <entry xml:id="editorialGuidelines-text">Editionsrichtlinien Text</entry>
     <entry xml:id="restrictSelection">Auswahl einschränken</entry>
     <entry xml:id="and">und</entry>
+    <entry xml:id="publishedIn">erschienen in</entry>
     <entry xml:id="vol">Bd.</entry>
     <entry xml:id="jg">Jg.</entry>
     <entry xml:id="pp">S.</entry>

--- a/catalogues/dictionary_de.xml
+++ b/catalogues/dictionary_de.xml
@@ -458,7 +458,6 @@
     <entry xml:id="editorialGuidelines-text">Editionsrichtlinien Text</entry>
     <entry xml:id="restrictSelection">Auswahl einschränken</entry>
     <entry xml:id="and">und</entry>
-    <entry xml:id="publishedIn">erschienen in</entry>
     <entry xml:id="vol">Bd.</entry>
     <entry xml:id="jg">Jg.</entry>
     <entry xml:id="pp">S.</entry>

--- a/catalogues/dictionary_en.xml
+++ b/catalogues/dictionary_en.xml
@@ -428,7 +428,6 @@
     <entry xml:id="editorialGuidelines-text">Editorial Guidelines Text</entry>
     <entry xml:id="restrictSelection">Restrict selection</entry>
     <entry xml:id="and">and</entry>
-    <entry xml:id="publishedIn">published in</entry>
     <entry xml:id="vol">vol.</entry>
     <entry xml:id="jg">Jg.</entry>
     <entry xml:id="pp">pp.</entry>

--- a/catalogues/dictionary_en.xml
+++ b/catalogues/dictionary_en.xml
@@ -428,6 +428,7 @@
     <entry xml:id="editorialGuidelines-text">Editorial Guidelines Text</entry>
     <entry xml:id="restrictSelection">Restrict selection</entry>
     <entry xml:id="and">and</entry>
+    <entry xml:id="publishedIn">published in</entry>
     <entry xml:id="vol">vol.</entry>
     <entry xml:id="jg">Jg.</entry>
     <entry xml:id="pp">pp.</entry>

--- a/modules/app.xqm
+++ b/modules/app.xqm
@@ -1984,7 +1984,7 @@ declare
             case element(tei:biblStruct) return 
                 element {node-name($node)} {
                     $node/@*,
-                    bibl:printCitation($source, <xhtml:p/>, $lang)/node()[not(self::xhtml:span[@class=('deleteme_journalTitle', 'deleteme_imprintSection')])]
+                    bibl:printCitation($source, <xhtml:p/>, $lang)/node()[not(self::xhtml:span[@class=('journalTitleForMultipleImprints', 'imprintSection')])]
                 }
             default return ()
 };

--- a/modules/app.xqm
+++ b/modules/app.xqm
@@ -1926,6 +1926,23 @@ declare
 };
 
 declare
+    %templates:default("lang", "en")
+    function app:process-biblio-publishing($node as node(), $model as map(*), $lang as xs:string) as map(*) {
+        let $biblStruct := $model('result-page-entry')//tei:biblStruct[1]
+        let $journalCitations :=
+            if(count($biblStruct/tei:monogr/tei:imprint) gt 1)
+            then 
+                for $journalCitation in bibl:printJournalCitationsByImprint($biblStruct/tei:monogr, <xhtml:li/>, $lang)
+                return normalize-space(string-join($journalCitation//text(), ''))
+            else ()
+        return 
+            map {
+                'publishedLabel' : lang:get-language-string('publishedIn', $lang),
+                'journalCitations' : $journalCitations
+            }
+};
+
+declare
     %templates:wrap
     function app:preview-details($node as node(), $model as map(*)) as map(*) {
         map {
@@ -1973,24 +1990,6 @@ declare
                     bibl:printCitation($source, <xhtml:p/>, $lang)/node()
                 }
             default return ()
-};
-
-declare
-    %templates:default("lang", "en")
-    function app:preview-published-in($node as node(), $model as map(*), $lang as xs:string) as element()? {
-        let $biblStruct := $model('doc')//tei:biblStruct[1]
-        let $journalCitations :=
-            if(count($biblStruct/tei:monogr/tei:imprint) gt 1)
-            then bibl:printJournalCitationsByImprint($biblStruct/tei:monogr, <xhtml:li/>, $lang)
-            else ()
-        return
-            if(exists($journalCitations)) then
-                element {node-name($node)} {
-                    $node/@*,
-                    <xhtml:strong>{lang:get-language-string('publishedIn', $lang)}:</xhtml:strong>,
-                    <xhtml:ul class="journal-citations">{$journalCitations}</xhtml:ul>
-                }
-            else ()
 };
 
 declare 

--- a/modules/app.xqm
+++ b/modules/app.xqm
@@ -1931,13 +1931,10 @@ declare
         let $biblStruct := $model('result-page-entry')//tei:biblStruct[1]
         let $journalCitations :=
             if(count($biblStruct/tei:monogr/tei:imprint) gt 1)
-            then 
-                for $journalCitation in bibl:printJournalCitationsByImprint($biblStruct/tei:monogr, <xhtml:li/>, $lang)
-                return normalize-space(string-join($journalCitation//text(), ''))
+            then bibl:printJournalCitationsByImprint($biblStruct/tei:monogr, <xhtml:li class="journal-citation"/>, $lang)
             else ()
         return 
             map {
-                'publishedLabel' : lang:get-language-string('publishedIn', $lang),
                 'journalCitations' : $journalCitations
             }
 };

--- a/modules/app.xqm
+++ b/modules/app.xqm
@@ -1975,6 +1975,24 @@ declare
             default return ()
 };
 
+declare
+    %templates:default("lang", "en")
+    function app:preview-published-in($node as node(), $model as map(*), $lang as xs:string) as element()? {
+        let $biblStruct := $model('doc')//tei:biblStruct[1]
+        let $journalCitations :=
+            if(count($biblStruct/tei:monogr/tei:imprint) gt 1)
+            then bibl:printJournalCitationsByImprint($biblStruct/tei:monogr, <xhtml:li/>, $lang)
+            else ()
+        return
+            if(exists($journalCitations)) then
+                element {node-name($node)} {
+                    $node/@*,
+                    <xhtml:strong>{lang:get-language-string('publishedIn', $lang)}:</xhtml:strong>,
+                    <xhtml:ul class="journal-citations">{$journalCitations}</xhtml:ul>
+                }
+            else ()
+};
+
 declare 
     %templates:wrap
     %templates:default("max", "200")

--- a/modules/app.xqm
+++ b/modules/app.xqm
@@ -1931,7 +1931,7 @@ declare
         let $biblStruct := $model('result-page-entry')//tei:biblStruct[1]
         let $journalCitations :=
             if(count($biblStruct/tei:monogr/tei:imprint) gt 1)
-            then bibl:printJournalCitationsByImprint($biblStruct/tei:monogr, <xhtml:li class="journal-citation"/>, $lang)
+            then bibl:printJournalCitationPerImprint($biblStruct/tei:monogr, <xhtml:li class="journal-citation"/>, $lang)
             else ()
         return 
             map {
@@ -1984,7 +1984,7 @@ declare
             case element(tei:biblStruct) return 
                 element {node-name($node)} {
                     $node/@*,
-                    bibl:printCitation($source, <xhtml:p/>, $lang)/node()
+                    bibl:printCitation($source, <xhtml:p/>, $lang)/node()[not(self::xhtml:span[@class=('deleteme_journalTitle', 'deleteme_imprintSection')])]
                 }
             default return ()
 };

--- a/modules/bibl.xqm
+++ b/modules/bibl.xqm
@@ -217,24 +217,22 @@ declare %private function bibl:print-journal-citation-from-imprint($monogr as el
  : @return xs:string*
  :)
 declare %private function bibl:biblScope($parent as element(), $lang as xs:string) as xs:string {
-    if(count($parent) = 1) then
-        let $isNZfM := some $title in $parent/../tei:title[not(@type='sub')] satisfies matches(string($title), '\(?neue zeitschrift\)? für musik', 'i')
-        return concat(
-            if($parent/tei:biblScope/@unit = 'jg' and $isNZfM) then concat(', ', 'Jg.', '&#160;', $parent/tei:biblScope[@unit = 'jg']) else (),
-            if($parent/tei:biblScope/@unit = 'vol') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'vol'], $lang) else (),
-            if($parent/tei:biblScope/@unit = 'jg' and not($isNZfM)) then concat(', ', 'Jg.', '&#160;', $parent/tei:biblScope[@unit = 'jg']) else (),
-            (: Vierstellige Jahresangaben werden direkt nach vol oder bd ausgegeben :)
-            if(matches(normalize-space($parent/tei:date), '^\d{4}$') and $parent/tei:biblScope/@unit = ('vol', 'jg')) then concat(' (', $parent/tei:date, ')') else (),
-            if($parent/tei:biblScope/@unit = 'issue') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'issue'], $lang) else (),
-            if($parent/tei:biblScope/@unit = 'nr') then concat(', ', 'Nr.', '&#160;', $parent/tei:biblScope[@unit = 'nr']) else (),
-            (: Alle anderen Datumsausgaben hier :)
-            if(string-length(normalize-space($parent/tei:date)) gt 4 or (string-length(normalize-space($parent/tei:date)) gt 0 and not($parent/tei:biblScope/@unit = ('vol', 'jg')))) then concat(' (', $parent/tei:date, ')') else (),
-            if($parent/tei:note/@type = 'additional') then concat(' ', $parent/tei:note[@type = 'additional']) else (),
-            if($parent/tei:biblScope/@unit = 'pp') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'pp'], $lang) else (),
-            if($parent/tei:biblScope/@unit = 'col') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'col'], $lang) else (),
-            if($parent/tei:biblScope/@unit = 'leaf') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'leaf'], $lang) else ()
-        )
-    else()
+    let $isNZfM := some $title in $parent/../tei:title[not(@type='sub')] satisfies matches(string($title), '\(?neue zeitschrift\)? für musik', 'i')
+    return concat(
+        if($parent/tei:biblScope/@unit = 'jg' and $isNZfM) then concat(', ', 'Jg.', '&#160;', $parent/tei:biblScope[@unit = 'jg']) else (),
+        if($parent/tei:biblScope/@unit = 'vol') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'vol'], $lang) else (),
+        if($parent/tei:biblScope/@unit = 'jg' and not($isNZfM)) then concat(', ', 'Jg.', '&#160;', $parent/tei:biblScope[@unit = 'jg']) else (),
+        (: Vierstellige Jahresangaben werden direkt nach vol oder bd ausgegeben :)
+        if(matches(normalize-space($parent/tei:date), '^\d{4}$') and $parent/tei:biblScope/@unit = ('vol', 'jg')) then concat(' (', $parent/tei:date, ')') else (),
+        if($parent/tei:biblScope/@unit = 'issue') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'issue'], $lang) else (),
+        if($parent/tei:biblScope/@unit = 'nr') then concat(', ', 'Nr.', '&#160;', $parent/tei:biblScope[@unit = 'nr']) else (),
+        (: Alle anderen Datumsausgaben hier :)
+        if(string-length(normalize-space($parent/tei:date)) gt 4 or (string-length(normalize-space($parent/tei:date)) gt 0 and not($parent/tei:biblScope/@unit = ('vol', 'jg')))) then concat(' (', $parent/tei:date, ')') else (),
+        if($parent/tei:note/@type = 'additional') then concat(' ', $parent/tei:note[@type = 'additional']) else (),
+        if($parent/tei:biblScope/@unit = 'pp') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'pp'], $lang) else (),
+        if($parent/tei:biblScope/@unit = 'col') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'col'], $lang) else (),
+        if($parent/tei:biblScope/@unit = 'leaf') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'leaf'], $lang) else ()
+    )
 };
 
 (:~

--- a/modules/bibl.xqm
+++ b/modules/bibl.xqm
@@ -175,9 +175,21 @@ declare function bibl:printIncollectionCitation($biblStruct as element(tei:biblS
  : @return element
  :)
 declare function bibl:printJournalCitation($monogr as element(tei:monogr), $wrapperElement as element(), $lang as xs:string) as element()? {
-    if (count($monogr/tei:imprint) = 1) then
-        bibl:print-journal-citation-from-imprint($monogr, $monogr/tei:imprint, $wrapperElement, $lang)
-    else ()
+    let $journalTitle := 
+        if (count($monogr/tei:imprint) gt 1)
+        then <xhtml:span class="deleteme_journalTitle">{bibl:printTitles($monogr/tei:title, $monogr/tei:edition)/node()}</xhtml:span>
+        else (<xhtml:span class="journalTitle">{bibl:printTitles($monogr/tei:title, $monogr/tei:edition)/node()}</xhtml:span>)
+    let $biblScope := 
+        if (count($monogr/tei:imprint) gt 1)
+        then for $imprint in $monogr/tei:imprint
+            return <xhtml:span class="deleteme_imprintSection">{bibl:biblScope($imprint, $lang)}</xhtml:span>
+        else <xhtml:span class="imprint">{bibl:biblScope($monogr/tei:imprint, $lang)}</xhtml:span>
+    return
+        element {$wrapperElement/name()} {
+            $wrapperElement/@*,
+            $journalTitle,
+            $biblScope
+        }
 };
 
 (:~
@@ -189,23 +201,17 @@ declare function bibl:printJournalCitation($monogr as element(tei:monogr), $wrap
  : @param $lang the language switch (en, de)
  : @return element*
  :)
-declare function bibl:printJournalCitationsByImprint($monogr as element(tei:monogr), $wrapperElement as element(), $lang as xs:string) as element()* {
+declare function bibl:printJournalCitationPerImprint($monogr as element(tei:monogr), $wrapperElement as element(), $lang as xs:string) as element()* {
     for $imprint in $monogr/tei:imprint
-    return bibl:print-journal-citation-from-imprint($monogr, $imprint, $wrapperElement, $lang)
-};
-
-(:~
- : Helper function for bibl:printJournalCitation() and bibl:printJournalCitationsByImprint()
- :)
-declare %private function bibl:print-journal-citation-from-imprint($monogr as element(tei:monogr), $imprint as element(tei:imprint), $wrapperElement as element(), $lang as xs:string) as element() {
-    let $journalTitle := <xhtml:span class="journalTitle">{bibl:printTitles($monogr/tei:title, $monogr/tei:edition)/node()}</xhtml:span>
-    let $biblScope := bibl:biblScope($imprint, $lang)
-    return
-        element {$wrapperElement/name()} {
-            $wrapperElement/@*,
-            $journalTitle,
-            $biblScope
-        }
+    return 
+        let $journalTitle := <xhtml:span class="journalTitle">{bibl:printTitles($monogr/tei:title, $monogr/tei:edition)/node()}</xhtml:span>
+        let $biblScope := <xhtml:span class="imprintSection">{bibl:biblScope($imprint, $lang)}</xhtml:span>
+        return
+            element {$wrapperElement/name()} {
+                $wrapperElement/@*,
+                $journalTitle,
+                $biblScope
+            }
 };
 
 (:~

--- a/modules/bibl.xqm
+++ b/modules/bibl.xqm
@@ -122,7 +122,8 @@ declare function bibl:printArticleCitation($biblStruct as element(tei:biblStruct
             $wrapperElement/@*,
             if(exists($authors)) then ($authors, ', ') else (), 
             if($biblStruct[@type='review']) then '[' || lang:get-language-string('review', $lang) || '] ' else (),
-            if($articleTitle) then (bibl:printTitles($articleTitle, ()), ', in: ') else (),
+            if($articleTitle) then (bibl:printTitles($articleTitle, ())) else (),
+            if($journalCitation) then (', in: ') else (),
             $journalCitation/xhtml:span,
             $journalCitation/text(),
             $note
@@ -173,10 +174,33 @@ declare function bibl:printIncollectionCitation($biblStruct as element(tei:biblS
  : @param $lang the language switch (en, de)
  : @return element
  :)
-declare function bibl:printJournalCitation($monogr as element(tei:monogr), $wrapperElement as element(), $lang as xs:string) as element() {
+declare function bibl:printJournalCitation($monogr as element(tei:monogr), $wrapperElement as element(), $lang as xs:string) as element()? {
+    if (count($monogr/tei:imprint) = 1) then
+        bibl:print-journal-citation-from-imprint($monogr, $monogr/tei:imprint, $wrapperElement, $lang)
+    else ()
+};
+
+(:~
+ : Create bibliographic citations for all imprints of a journal monogr
+ :
+ : @author Steffen Astheimer
+ : @param $monogr the TEI monogr element with the bibliographic reference of the journal
+ : @param $wrapperElement the HTML element for wrapping each output item (usually li or span)
+ : @param $lang the language switch (en, de)
+ : @return element*
+ :)
+declare function bibl:printJournalCitationsByImprint($monogr as element(tei:monogr), $wrapperElement as element(), $lang as xs:string) as element()* {
+    for $imprint in $monogr/tei:imprint
+    return bibl:print-journal-citation-from-imprint($monogr, $imprint, $wrapperElement, $lang)
+};
+
+(:~
+ : Helper function for bibl:printJournalCitation() and bibl:printJournalCitationsByImprint()
+ :)
+declare %private function bibl:print-journal-citation-from-imprint($monogr as element(tei:monogr), $imprint as element(tei:imprint), $wrapperElement as element(), $lang as xs:string) as element() {
     let $journalTitle := <xhtml:span class="journalTitle">{bibl:printTitles($monogr/tei:title, $monogr/tei:edition)/node()}</xhtml:span>
-    let $biblScope := bibl:biblScope($monogr/tei:imprint[1], $lang)
-    return 
+    let $biblScope := bibl:biblScope($imprint, $lang)
+    return
         element {$wrapperElement/name()} {
             $wrapperElement/@*,
             $journalTitle,
@@ -193,23 +217,24 @@ declare function bibl:printJournalCitation($monogr as element(tei:monogr), $wrap
  : @return xs:string*
  :)
 declare %private function bibl:biblScope($parent as element(), $lang as xs:string) as xs:string {
-    let $isNZfM := some $title in $parent/../tei:title[not(@type='sub')] satisfies matches(string($title), '\(?neue zeitschrift\)? für musik', 'i')
-    return
-    concat(
-        if($parent/tei:biblScope/@unit = 'jg' and $isNZfM) then concat(', ', 'Jg.', '&#160;', $parent/tei:biblScope[@unit = 'jg']) else (),
-        if($parent/tei:biblScope/@unit = 'vol') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'vol'], $lang) else (),
-        if($parent/tei:biblScope/@unit = 'jg' and not($isNZfM)) then concat(', ', 'Jg.', '&#160;', $parent/tei:biblScope[@unit = 'jg']) else (),
-        (: Vierstellige Jahresangaben werden direkt nach vol oder bd ausgegeben :)
-        if(matches(normalize-space($parent/tei:date), '^\d{4}$') and $parent/tei:biblScope/@unit = ('vol', 'jg')) then concat(' (', $parent/tei:date, ')') else (),
-        if($parent/tei:biblScope/@unit = 'issue') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'issue'], $lang) else (),
-        if($parent/tei:biblScope/@unit = 'nr') then concat(', ', 'Nr.', '&#160;', $parent/tei:biblScope[@unit = 'nr']) else (),
-        (: Alle anderen Datumsausgaben hier :)
-        if(string-length(normalize-space($parent/tei:date)) gt 4 or (string-length(normalize-space($parent/tei:date)) gt 0 and not($parent/tei:biblScope/@unit = ('vol', 'jg')))) then concat(' (', $parent/tei:date, ')') else (),
-        if($parent/tei:note/@type = 'additional') then concat(' ', $parent/tei:note[@type = 'additional']) else (),
-        if($parent/tei:biblScope/@unit = 'pp') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'pp'], $lang) else (),
-        if($parent/tei:biblScope/@unit = 'col') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'col'], $lang) else (),
-        if($parent/tei:biblScope/@unit = 'leaf') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'leaf'], $lang) else ()
-    )
+    if(count($parent) = 1) then
+        let $isNZfM := some $title in $parent/../tei:title[not(@type='sub')] satisfies matches(string($title), '\(?neue zeitschrift\)? für musik', 'i')
+        return concat(
+            if($parent/tei:biblScope/@unit = 'jg' and $isNZfM) then concat(', ', 'Jg.', '&#160;', $parent/tei:biblScope[@unit = 'jg']) else (),
+            if($parent/tei:biblScope/@unit = 'vol') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'vol'], $lang) else (),
+            if($parent/tei:biblScope/@unit = 'jg' and not($isNZfM)) then concat(', ', 'Jg.', '&#160;', $parent/tei:biblScope[@unit = 'jg']) else (),
+            (: Vierstellige Jahresangaben werden direkt nach vol oder bd ausgegeben :)
+            if(matches(normalize-space($parent/tei:date), '^\d{4}$') and $parent/tei:biblScope/@unit = ('vol', 'jg')) then concat(' (', $parent/tei:date, ')') else (),
+            if($parent/tei:biblScope/@unit = 'issue') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'issue'], $lang) else (),
+            if($parent/tei:biblScope/@unit = 'nr') then concat(', ', 'Nr.', '&#160;', $parent/tei:biblScope[@unit = 'nr']) else (),
+            (: Alle anderen Datumsausgaben hier :)
+            if(string-length(normalize-space($parent/tei:date)) gt 4 or (string-length(normalize-space($parent/tei:date)) gt 0 and not($parent/tei:biblScope/@unit = ('vol', 'jg')))) then concat(' (', $parent/tei:date, ')') else (),
+            if($parent/tei:note/@type = 'additional') then concat(' ', $parent/tei:note[@type = 'additional']) else (),
+            if($parent/tei:biblScope/@unit = 'pp') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'pp'], $lang) else (),
+            if($parent/tei:biblScope/@unit = 'col') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'col'], $lang) else (),
+            if($parent/tei:biblScope/@unit = 'leaf') then bibl:print-single-biblScope-unit(', ', $parent/tei:biblScope[@unit = 'leaf'], $lang) else ()
+        )
+    else()
 };
 
 (:~

--- a/modules/bibl.xqm
+++ b/modules/bibl.xqm
@@ -177,12 +177,12 @@ declare function bibl:printIncollectionCitation($biblStruct as element(tei:biblS
 declare function bibl:printJournalCitation($monogr as element(tei:monogr), $wrapperElement as element(), $lang as xs:string) as element()? {
     let $journalTitle := 
         if (count($monogr/tei:imprint) gt 1)
-        then <xhtml:span class="deleteme_journalTitle">{bibl:printTitles($monogr/tei:title, $monogr/tei:edition)/node()}</xhtml:span>
+        then <xhtml:span class="journalTitleForMultipleImprints">{bibl:printTitles($monogr/tei:title, $monogr/tei:edition)/node()}</xhtml:span>
         else (<xhtml:span class="journalTitle">{bibl:printTitles($monogr/tei:title, $monogr/tei:edition)/node()}</xhtml:span>)
     let $biblScope := 
         if (count($monogr/tei:imprint) gt 1)
         then for $imprint in $monogr/tei:imprint
-            return <xhtml:span class="deleteme_imprintSection">{bibl:biblScope($imprint, $lang)}</xhtml:span>
+            return <xhtml:span class="imprintSection">{bibl:biblScope($imprint, $lang)}</xhtml:span>
         else <xhtml:span class="imprint">{bibl:biblScope($monogr/tei:imprint, $lang)}</xhtml:span>
     return
         element {$wrapperElement/name()} {

--- a/resources/sass/pages/_search.scss
+++ b/resources/sass/pages/_search.scss
@@ -39,7 +39,8 @@
         }
     }
     
-    .wega-volltext {
+    .wega-volltext,
+    .journal-citations {
         display: block;
         margin-left: 1em;
     }

--- a/resources/sass/pages/_search.scss
+++ b/resources/sass/pages/_search.scss
@@ -40,7 +40,7 @@
     }
     
     .wega-volltext,
-    .journal-citations {
+    .journal-citation {
         display: block;
         margin-left: 1em;
     }

--- a/resources/sass/pages/_search.scss
+++ b/resources/sass/pages/_search.scss
@@ -42,7 +42,8 @@
     .wega-volltext,
     .journal-citation {
         display: block;
-        margin-left: 1em;
+        margin-left: 3em;
+        text-indent: -1em;
     }
     
     .doi-link {

--- a/templates/includes/preview-biblio.html
+++ b/templates/includes/preview-biblio.html
@@ -13,10 +13,12 @@
             September 1809)
         </p>
 
-        <div data-template="app:preview-published-in">
-            <strong>erschienen in:</strong>
-            <ul class="journal-citations">
-                <li>Zeitung für die elegante Welt, Jg. 32, Nr. 117 (18. Juni 1832), S. 929–932</li>
+        <div data-template="app:process-biblio-publishing" data-template-wrap="no">
+            <ul data-template="app-shared:if-exists" data-template-key="journalCitations" class="publishing-info">
+                <strong><span data-template="app-shared:print" data-template-key="publishedLabel">publishedIn</span>:</strong>
+                <li data-template="app-shared:each" data-template-from="journalCitations" data-template-to="journalCitation">
+                    <span data-template="app-shared:print" data-template-key="journalCitation"  class="journal-citation">Allgemeine Musikalische Zeitung</span>
+                </li>
             </ul>
         </div>
 

--- a/templates/includes/preview-biblio.html
+++ b/templates/includes/preview-biblio.html
@@ -12,6 +12,14 @@
             Allgemeine Musikalische Zeitung (13.
             September 1809)
         </p>
+
+        <div data-template="app:preview-published-in">
+            <strong>erschienen in:</strong>
+            <ul class="journal-citations">
+                <li>Zeitung für die elegante Welt, Jg. 32, Nr. 117 (18. Juni 1832), S. 929–932</li>
+            </ul>
+        </div>
+
         <p>
             <strong><span data-template="lang:translate">biblioType</span>:</strong> 
             <span data-template="lang:translate-key" data-template-key="biblioType">book</span>

--- a/templates/includes/preview-biblio.html
+++ b/templates/includes/preview-biblio.html
@@ -9,16 +9,12 @@
             <a data-template="app:preview-title">Biblio Title</a>
         </h3>-->
         <p data-template="app:preview-citation" class="biblio-entry">
-            Allgemeine Musikalische Zeitung (13.
-            September 1809)
+            Johann Andreas Stumpff, Huldigung, Karl Maria von Weber nach der ersten Erscheinung des „Oberon“ (am 12. April.), in: Berliner Allgemeine Musikalische Zeitung, Jg. 3, Nr. 37 (13. September 1826), S. 293
         </p>
 
         <div data-template="app:process-biblio-publishing" data-template-wrap="no">
             <ul data-template="app-shared:if-exists" data-template-key="journalCitations" class="publishing-info">
-                <li>
-                    <strong><span data-template="lang:translate" data-template-key="publishedIn">publishedIn</span>:</strong>
-                </li>
-                <li data-template="app-shared:output" data-template-key="journalCitations" data-template-wrap="no">…</li>
+                <li data-template="app-shared:output" data-template-key="journalCitations" data-template-wrap="no">Berliner Allgemeine Musikalische Zeitung, Jg. 3, Nr. 37 (13. September 1826), S. 293</li>
             </ul>
         </div>
 

--- a/templates/includes/preview-biblio.html
+++ b/templates/includes/preview-biblio.html
@@ -15,10 +15,10 @@
 
         <div data-template="app:process-biblio-publishing" data-template-wrap="no">
             <ul data-template="app-shared:if-exists" data-template-key="journalCitations" class="publishing-info">
-                <strong><span data-template="app-shared:print" data-template-key="publishedLabel">publishedIn</span>:</strong>
-                <li data-template="app-shared:each" data-template-from="journalCitations" data-template-to="journalCitation">
-                    <span data-template="app-shared:print" data-template-key="journalCitation"  class="journal-citation">Allgemeine Musikalische Zeitung</span>
+                <li>
+                    <strong><span data-template="lang:translate" data-template-key="publishedIn">publishedIn</span>:</strong>
                 </li>
+                <li data-template="app-shared:output" data-template-key="journalCitations" data-template-wrap="no">…</li>
             </ul>
         </div>
 

--- a/testing/expected-results/documents/A100102.html
+++ b/testing/expected-results/documents/A100102.html
@@ -415,9 +415,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Dresdner Anzeigen</span>, Nr. 33 (25. April 1805)</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Dresdner Anzeigen</span><span class="imprint">, Nr. 33 (25. April 1805)</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_08916fd863ac9e51890a7f9f57355b76">
+                                        <div class="collapse apparatus-details" id="source_22edbb977443e205662a0fb388673279">
                                             
                                             
                                             <div>
@@ -597,7 +597,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/documents/A100432.html
+++ b/testing/expected-results/documents/A100432.html
@@ -418,9 +418,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Wöchentliche Nachrichten von dem Augsburgischen auch auswärtigen Intelligenzwesen, nebst allerlei gelehrten, ökonom- und meteorologischen Artikeln [= Augsburgisches Intelligenz-Blatt]</span>, Nr. 49 (6. Dezember 1790), S. 200</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Wöchentliche Nachrichten von dem Augsburgischen auch auswärtigen Intelligenzwesen, nebst allerlei gelehrten, ökonom- und meteorologischen Artikeln [= Augsburgisches Intelligenz-Blatt]</span><span class="imprint">, Nr. 49 (6. Dezember 1790), S. 200</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_7e6a5a5d76d5b25fd7e40e7dbfbd017a">
+                                        <div class="collapse apparatus-details" id="source_aac15d60f07bdc1089d37b9fc371b685">
                                             
                                             
                                             <div>
@@ -600,7 +600,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/documents/A100437.html
+++ b/testing/expected-results/documents/A100437.html
@@ -430,9 +430,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Münchner Anzeiger</span>, Nr. 37 (12. September 1804)</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Münchner Anzeiger</span><span class="imprint">, Nr. 37 (12. September 1804)</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_704b7333fe2bc3d2f9e0a66b50bfc23f">
+                                        <div class="collapse apparatus-details" id="source_2c3579a215d046cf5c30802bca3355de">
                                             
                                             
                                             <div>
@@ -612,7 +612,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/documents/A100472.html
+++ b/testing/expected-results/documents/A100472.html
@@ -428,9 +428,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Nürnbergische Frage- und Anzeige-Nachrichten</span>, Nr. 40 (29. Mai 1801)</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Nürnbergische Frage- und Anzeige-Nachrichten</span><span class="imprint">, Nr. 40 (29. Mai 1801)</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_7edd1ea20c86c106762190a0b126b0ff">
+                                        <div class="collapse apparatus-details" id="source_d9b0feea098cce919654a8533e2a0802">
                                             
                                             
                                             <div>
@@ -618,7 +618,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A041624.html
+++ b/testing/expected-results/letters/A041624.html
@@ -572,9 +572,9 @@
                                         
                                         <span>Verbleib unbekannt</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_13f44f3afa6bca82caf13ceef9258aa7"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_0eeb1ecb9b95dbc5657feb07240aee03"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_13f44f3afa6bca82caf13ceef9258aa7">
+                                        <div class="collapse apparatus-details" id="source_0eeb1ecb9b95dbc5657feb07240aee03">
                                             <h4 class="media-heading">Provenienz</h4>
                                                     <ul>
                                                         <li><a class="preview orgs A080017" href="">Henrici</a> Kat. 123 (<span class="tei_date">29.9. 1927</span>), Nr. 430 (= Slg. Heyer III)</li>
@@ -591,7 +591,7 @@
                                                             
                                                             <span>tV: MMW II, S. 248–249</span>
                                                               
-                                                            <div class="collapse" id="source_054a963d4c1b5cf7d482089a34664791">
+                                                            <div class="collapse" id="source_760217878971892b91c2daaf766e71b8">
                                                                 
                                                             </div>
                                                         </div>
@@ -610,11 +610,11 @@
                                     <div>
                                         <strong><span>2. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="author">Anonym</span>, <span class="title">Ungedruckte Briefe Carl Maria von Webers</span>, in: <span class="journalTitle">Allgemeiner Anzeiger</span>, Nr. 162 (12. Juni 1904) 6. Beiblatt</span>
+                                        <span class="biblio-entry"><span class="author">Anonym</span>, <span class="title">Ungedruckte Briefe Carl Maria von Webers</span>, in: <span class="journalTitle">Allgemeiner Anzeiger</span><span class="imprint">, Nr. 162 (12. Juni 1904) 6. Beiblatt</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_020182e639fc4df7c52a5018fdc49d99"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_66043209724e6692f8997f4ab4f67eed"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_020182e639fc4df7c52a5018fdc49d99">
+                                        <div class="collapse apparatus-details" id="source_66043209724e6692f8997f4ab4f67eed">
                                             
                                             
                                             <div>
@@ -625,9 +625,9 @@
                                                     <li>
                                                         <div>
                                                             
-                                                            <span class="biblio-entry"><span class="title">Unbekannte Briefe Karl Maria von Webers</span>, in: <span class="journalTitle">Neue Musik-Zeitung</span>, Jg. 26 (17. August 1905), S. 487–489</span>
+                                                            <span class="biblio-entry"><span class="title">Unbekannte Briefe Karl Maria von Webers</span>, in: <span class="journalTitle">Neue Musik-Zeitung</span><span class="imprint">, Jg. 26 (17. August 1905), S. 487–489</span></span>
                                                               
-                                                            <div class="collapse" id="source_fa6c43a9fe175257a17773aa294bc28a">
+                                                            <div class="collapse" id="source_cd078afb6ea997306ef02eefaa9705cd">
                                                                 
                                                             </div>
                                                         </div>
@@ -855,7 +855,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A041743.html
+++ b/testing/expected-results/letters/A041743.html
@@ -566,10 +566,10 @@ einem klugen, ziemlich unbefangenen <span class="tei_app"><span class="tei_lem">
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry book"><span class="author">Friedrich Kind</span>, <span class="title">Freischütz-Buch</span>, <span class="placeNYear">1843</span>, S. 159–161<a class="noteMarker biblioNote" data-toggle="popover" data-ref="#PD1763N3l5l2l10l4l2l4l5">*</a>
-                                                    <div id="PD1763N3l5l2l10l4l2l4l5" data-title="Bemerkung" style="display:none;">Nr. 27</div></span>
+                                        <span class="biblio-entry book"><span class="author">Friedrich Kind</span>, <span class="title">Freischütz-Buch</span>, <span class="placeNYear">1843</span>, S. 159–161<a class="noteMarker biblioNote" data-toggle="popover" data-ref="#PD1990N3l5l2l10l4l2l4l5">*</a>
+                                                    <div id="PD1990N3l5l2l10l4l2l4l5" data-title="Bemerkung" style="display:none;">Nr. 27</div></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_c2658063f0a21d500d697a21041f605d">
+                                        <div class="collapse apparatus-details" id="source_b91d231a2da252e13ce83419e431feef">
                                             
                                             
                                             <div>
@@ -588,10 +588,10 @@ einem klugen, ziemlich unbefangenen <span class="tei_app"><span class="tei_lem">
                                     <div>
                                         <strong><span>2. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="title">Briefe von Karl Maria v. Weber, an Friedrich Kind</span>, in: <span class="journalTitle">Zeitung für die elegante Welt</span>, Jg. 32, Nr. 121 (23. Juni 1832), Sp. 963–964<a class="noteMarker biblioNote" data-toggle="popover" data-ref="#N_01">*</a>
+                                        <span class="biblio-entry"><span class="title">Briefe von Karl Maria v. Weber, an Friedrich Kind</span>, in: <span class="journalTitle">Zeitung für die elegante Welt</span><span class="imprint">, Jg. 32, Nr. 121 (23. Juni 1832), Sp. 963–964</span><a class="noteMarker biblioNote" data-toggle="popover" data-ref="#N_01">*</a>
                                                     <div id="N_01" data-title="Bemerkung" style="display:none;">Mit Namens-Auslassungen</div></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_77e85dc778ed0631481577eae273f991">
+                                        <div class="collapse apparatus-details" id="source_fadcb47f53a449c601b9ee5c3cc20567">
                                             
                                             
                                             <div>
@@ -612,9 +612,9 @@ einem klugen, ziemlich unbefangenen <span class="tei_app"><span class="tei_lem">
                                         
                                         <span>Verbleib unbekannt</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_0debcc0ab833c6e7072fe52533769db4"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e962b4d9c266723312b6f0ac53fde2f7"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_0debcc0ab833c6e7072fe52533769db4">
+                                        <div class="collapse apparatus-details" id="source_e962b4d9c266723312b6f0ac53fde2f7">
                                             <h4 class="media-heading">Provenienz</h4>
                                                     <ul>
                                                         <li><a class="preview orgs A080017" href="">Henrici</a> Kat. 114 (<span class="tei_date">6./7. Dez. 1926</span>, mit <a class="preview orgs A080018" href="">Liepmannssohn</a> = Slg. Heyer I), Nr. 596</li>
@@ -1372,7 +1372,6 @@ einem klugen, ziemlich unbefangenen <span class="tei_app"><span class="tei_lem">
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A041761.html
+++ b/testing/expected-results/letters/A041761.html
@@ -461,9 +461,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. II A a 3, 6</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_ba0a5b27338937d48d8df08693bdd347"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_17092c91cfe5d77dd1beb534e484a3af"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_ba0a5b27338937d48d8df08693bdd347">
+                                        <div class="collapse apparatus-details" id="source_17092c91cfe5d77dd1beb534e484a3af">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S. o. Adr.)</li>
@@ -485,7 +485,7 @@
                                                             
                                                             <span>Kaiser (Schriften), S. 530f. (KS 149)</span>
                                                               
-                                                            <div class="collapse" id="source_a727645eaec740b1fc7b4c71cf7cf09a">
+                                                            <div class="collapse" id="source_797419ca0a8f53ac7d70e30e39951d14">
                                                                 
                                                             </div>
                                                         </div>
@@ -685,7 +685,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A041782.html
+++ b/testing/expected-results/letters/A041782.html
@@ -482,9 +482,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XI), Bl. 74a/v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_754be22d5f61f04f1083b73679f3d029"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_94ff22e59e20a9979f74562f339fcf88"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_754be22d5f61f04f1083b73679f3d029">
+                                        <div class="collapse apparatus-details" id="source_94ff22e59e20a9979f74562f339fcf88">
                                             
                                             
                                             <div>
@@ -497,7 +497,7 @@
                                                             
                                                             <span>MMW II, S. 338</span>
                                                               
-                                                            <div class="collapse" id="source_50be94dd21edc014d76e50cedf8ec335">
+                                                            <div class="collapse" id="source_d3152750be6dacd2dada4a16777b4daa">
                                                                 
                                                             </div>
                                                         </div>
@@ -507,7 +507,7 @@
                                                             
                                                             <span>Arne Langer, Dokumente zu Webers geplanter Anstellung in Kassel 1821, in: Weber-Studien 3, Mainz 1996, S. 94f.</span>
                                                               
-                                                            <div class="collapse" id="source_c71941417e9f4330083559e3b8f5b637">
+                                                            <div class="collapse" id="source_a2515b2da0deb5a50c2171e8d8c17e6b">
                                                                 
                                                             </div>
                                                         </div>
@@ -816,7 +816,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A041790.html
+++ b/testing/expected-results/letters/A041790.html
@@ -491,9 +491,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ep. C. M. v. Weber 151</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_083fb7876a6e9372472a7dd6c0a77df0"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_39716f014456eaeeff38e88bf208796f"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_083fb7876a6e9372472a7dd6c0a77df0">
+                                        <div class="collapse apparatus-details" id="source_39716f014456eaeeff38e88bf208796f">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S. einschl. Adr.)</li>
@@ -510,7 +510,7 @@
                                                             
                                                             <span class="tei_bibl">Anon.: <span class="tei_hi_italic">Unveröffentlichte Briefe Carl Maria von Webers</span>, in: <span class="tei_hi_italic">Blätter der Staatsoper</span>, Jg. 3, Heft 1 (Oktober 1922), S. 10–11</span>
                                                               
-                                                            <div class="collapse" id="source_19d66ff6e6861c262636a466fd19147d">
+                                                            <div class="collapse" id="source_f98d0b1cbb74264afb9f88bbea9c8bb5">
                                                                 
                                                             </div>
                                                         </div>
@@ -520,7 +520,7 @@
                                                             
                                                             <span class="tei_bibl">Schnoor, Hans: <span class="tei_hi_italic">Dresden - Vierhundert Jahre Deutsche Musikkultur</span>. Dresden o.J. [1948], S. 162 (vollst. Faks.) </span>
                                                               
-                                                            <div class="collapse" id="source_f784b189e8e3531b851c4568679cbf38">
+                                                            <div class="collapse" id="source_732b80b999d2e922a9a46633e63e9f3e">
                                                                 
                                                             </div>
                                                         </div>
@@ -543,7 +543,7 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XI), Bl. 74b/r u. 74b/v</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_c6560c7b3024565cc7cc00d2ff16d6be">
+                                        <div class="collapse apparatus-details" id="source_831e7fe3c0bdc1122959da8be06f7150">
                                             
                                             
                                             <div>
@@ -566,9 +566,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. II A f 1, 6</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_bc3cafe49e8ad7a985325e5c9c5c1436"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_2e6b265c4f4ce8a67591fcbbdb29a30a"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_bc3cafe49e8ad7a985325e5c9c5c1436">
+                                        <div class="collapse apparatus-details" id="source_2e6b265c4f4ce8a67591fcbbdb29a30a">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S.)</li>
@@ -1341,7 +1341,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A041797.html
+++ b/testing/expected-results/letters/A041797.html
@@ -496,9 +496,9 @@
                                         
                                         <span>Leipzig (D), Universitätsbibliothek, Bibliotheca Albertina (D-LEu), Sammlung Kestner<br /><i>Signatur</i>: I.C.II.437</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_df8fa28353b4163ff5ddda06f7405adb"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_66b25f130683f367b30854142265676d"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_df8fa28353b4163ff5ddda06f7405adb">
+                                        <div class="collapse apparatus-details" id="source_66b25f130683f367b30854142265676d">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (2 b. S. einschl. Adr.)</li>
@@ -514,7 +514,7 @@
                                                             
                                                             <span id="printUnger" class="tei_bibl">Unger, Max, „Von Bach bis Brahms. Ungedruckte Briefe und Schriftstücke deutscher Meister, mitgeteilt und erläutert von Dr. Max Unger (Leipzig)“, in: Neue Musik-Zeitung, Jg. 38, Heft 3 (1917), S. 37 (mit Adresse)</span>
                                                               
-                                                            <div class="collapse" id="source_5dceb1b123075a561193b74d7eefcc59">
+                                                            <div class="collapse" id="source_95e4844f770276013459e3788561fbcd">
                                                                 
                                                             </div>
                                                         </div>
@@ -716,7 +716,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A041812.html
+++ b/testing/expected-results/letters/A041812.html
@@ -493,9 +493,9 @@
                                         
                                         <span>verschollen</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_7228a32a58b336ad5e4162e6e4e770fe"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_bded9a00f67f5f275cddc90921749a3b"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_7228a32a58b336ad5e4162e6e4e770fe">
+                                        <div class="collapse apparatus-details" id="source_bded9a00f67f5f275cddc90921749a3b">
                                             <h4 class="media-heading">Provenienz</h4>
                                                     <ul>
                                                         <li>1875 noch im Besitz von <a class="preview persons A002E79" href="">Hinrich Böckmann</a> (1809–1891), Oberalter von <a class="preview places A131327" href="">St. Petri</a>, der seit 16. September 1835 mit F. L. Schmidts Tochter <span class="65117103117115116101">Auguste</span> 
@@ -513,7 +513,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="tei_hi_italic">Denkwürdigkeiten des Schauspielers, Schauspieldichters und Schauspieldirektors Friedrich Ludwig Schmidt (1772–1841)</span>, hg. von Hermann Uhde, Bd. 2, Hamburg 1875, S. 171 (kurzer Ausschnitt)</span>
                                                               
-                                                            <div class="collapse" id="source_f1fb4fea41c2888de4c418dc8a8cdb54">
+                                                            <div class="collapse" id="source_ec9764d92ed9f12dad91d801cab635ad">
                                                                 
                                                             </div>
                                                         </div>
@@ -536,9 +536,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. V (Mappe XIX), Abt. 5, Nr. 5b</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_91f9209658a4d7760136e1f765d5f11b"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e95cec3e28643e5a094d887e17aa2cab"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_91f9209658a4d7760136e1f765d5f11b">
+                                        <div class="collapse apparatus-details" id="source_e95cec3e28643e5a094d887e17aa2cab">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Kopie von unbekannter Hand, übersendet mit <a class="preview persons A004366" href="">Hermann Uhdes</a> <a class="preview letters A043818" href="">Brief</a> an <a class="preview persons A000914" href="/exist/apps/WeGA-WebApp/de/A000914.html">F. W. Jähns</a> vom 8. Oktober 1875</li>
@@ -558,9 +558,9 @@
                                                             
                                                             <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. II B, 4, Nachtrag, Nr. 11, S. 949f.</span>
                                                             <span>
-                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_4cf29ae80d6d1e94db4a3ee833a1b1db"></a>
+                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_e20d9c4dc287650cbd021e84b67dcac8"></a>
                                                             </span>  
-                                                            <div class="collapse" id="source_4cf29ae80d6d1e94db4a3ee833a1b1db">
+                                                            <div class="collapse" id="source_e20d9c4dc287650cbd021e84b67dcac8">
                                                                 <h4 class="media-heading">Quellenbeschreibung</h4>
                                                                         <ul>
                                                                             <li>Kopie von <a class="preview persons A000914" href="/exist/apps/WeGA-WebApp/de/A000914.html">F. W. Jähns</a> </li>
@@ -802,7 +802,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A041823.html
+++ b/testing/expected-results/letters/A041823.html
@@ -509,9 +509,9 @@
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz,
                      Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XII), Bl. 76a/r</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_ab07deeb9d91409fc6007aee04da684b"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_2c040d8e7081ec2b6f3a5df97159c3e8"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_ab07deeb9d91409fc6007aee04da684b">
+                                        <div class="collapse apparatus-details" id="source_2c040d8e7081ec2b6f3a5df97159c3e8">
                                             
                                             
                                             <div>
@@ -527,9 +527,9 @@
                                                             <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer
                               Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. II B, 2a, S. 843f. (Nr. 29)</span>
                                                             <span>
-                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_0281bf594effb183d3ef849240b7037a"></a>
+                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_71e938ebf7e32ddcbe725bd53f7d9922"></a>
                                                             </span>  
-                                                            <div class="collapse" id="source_0281bf594effb183d3ef849240b7037a">
+                                                            <div class="collapse" id="source_71e938ebf7e32ddcbe725bd53f7d9922">
                                                                 <h4 class="media-heading">Quellenbeschreibung</h4>
                                                                         <ul>
                                                                             <li>Kopie von Ida Jähns mit Adressatin-Zusatz von F. W. Jähns</li>
@@ -840,7 +840,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A041826.html
+++ b/testing/expected-results/letters/A041826.html
@@ -468,7 +468,7 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XII), Bl. 76a/r</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_57ed5b81c47f618212631e98d40061da">
+                                        <div class="collapse apparatus-details" id="source_8533596ace5fc0945cc4fe249d7abb0a">
                                             
                                             
                                             <div>
@@ -688,7 +688,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A041870.html
+++ b/testing/expected-results/letters/A041870.html
@@ -473,9 +473,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. L. van Beethoven 37, Nr 2</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b8780ea95cb646dda7b8d0dc0823f85d"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_86706a12d7267a468b9683627be87994"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_b8780ea95cb646dda7b8d0dc0823f85d">
+                                        <div class="collapse apparatus-details" id="source_86706a12d7267a468b9683627be87994">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Dbl. ? (2 b. S. o. Adr.?)</li>
@@ -496,7 +496,7 @@
                                                             
                                                             <span>Thayer, Alexander Wheelock, Ludwig van Beethovens Leben. (hg. v. Hermann Deiters / Hugo Riemann), Leipzig: Breitkopf &amp; Härtel, 1907, Bd. 4, S. 288 (nur Auszug), Gedicht S. 575–576</span>
                                                               
-                                                            <div class="collapse" id="source_fef54828ae42633c2d671d1d2d763129">
+                                                            <div class="collapse" id="source_23dc528a384a6bc54b2a42a446d456e2">
                                                                 
                                                             </div>
                                                         </div>
@@ -702,7 +702,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A041879.html
+++ b/testing/expected-results/letters/A041879.html
@@ -495,11 +495,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="author"></span>, <span class="title">Carl Maria von Weber's Euryanthe</span>, in: <span class="journalTitle"><a class="preview writings A031880" href="">Neue Zeitschrift für Musik</a></span>, Jg. 13, Heft 10 (1. August 1840), S. 39</span>
+                                        <span class="biblio-entry"><span class="author"></span>, <span class="title">Carl Maria von Weber's Euryanthe</span>, in: <span class="journalTitle"><a class="preview writings A031880" href="">Neue Zeitschrift für Musik</a></span><span class="imprint">, Jg. 13, Heft 10 (1. August 1840), S. 39</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a4ccb12fc1a7ea85a3179242da10310a"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_df562d49da55ad604905b5f23060754c"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_a4ccb12fc1a7ea85a3179242da10310a">
+                                        <div class="collapse apparatus-details" id="source_df562d49da55ad604905b5f23060754c">
                                             
                                             
                                             <div>
@@ -512,7 +512,7 @@
                                                             
                                                             <span class="tei_bibl">Kopie von F. W. Jähns nach ED mit geringfügig abweichender Orthographie: <span class="tei_hi_italic">D-B</span>, Weberiana Cl. II B, 4. Nachtrag, Nr. 18, S. 957f.</span>
                                                               
-                                                            <div class="collapse" id="source_aa2153ffb59022573198461b91a629c6">
+                                                            <div class="collapse" id="source_50ef3385e5bb5b38e9d76811b606b550">
                                                                 
                                                             </div>
                                                         </div>
@@ -714,7 +714,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A041890.html
+++ b/testing/expected-results/letters/A041890.html
@@ -503,9 +503,9 @@
                                         
                                         <span>In Privatbesitz</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_dcfb0cb68b3e4421f80f3090ad373c50"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_07e49d6edff9d20cda8a98d856050d53"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_dcfb0cb68b3e4421f80f3090ad373c50">
+                                        <div class="collapse apparatus-details" id="source_07e49d6edff9d20cda8a98d856050d53">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (2 b. S. einschl. Adr.)</li>
@@ -712,7 +712,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A041892.html
+++ b/testing/expected-results/letters/A041892.html
@@ -624,9 +624,9 @@
                                         
                                         <span>In Privatbesitz</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_379773245f51b7cc4a182bb621f0f23d"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e262cdf82365641bd3a616026af8b473"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_379773245f51b7cc4a182bb621f0f23d">
+                                        <div class="collapse apparatus-details" id="source_e262cdf82365641bd3a616026af8b473">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. einschl. Adr.)</li>
@@ -652,9 +652,9 @@
                                                             
                                                             <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. II B, 1. h.</span>
                                                             <span>
-                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_ecb59a7340b0cb24579a13612222c7ba"></a>
+                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_2661aa835b95a78670809324375af0b0"></a>
                                                             </span>  
-                                                            <div class="collapse" id="source_ecb59a7340b0cb24579a13612222c7ba">
+                                                            <div class="collapse" id="source_2661aa835b95a78670809324375af0b0">
                                                                 <h4 class="media-heading">Quellenbeschreibung</h4>
                                                                         <ul>
                                                                             <li>Kopie von <a class="preview persons A008040" href="">Ida Jähns</a></li>
@@ -667,7 +667,7 @@
                                                             
                                                             <span>Hirschberg77, S. 36–37 (Nr. 47)</span>
                                                               
-                                                            <div class="collapse" id="source_f6149a463dfba2a5dfa8a833132f02f2">
+                                                            <div class="collapse" id="source_83f586efdbce9b9c47fb50297ce69055">
                                                                 
                                                             </div>
                                                         </div>
@@ -690,9 +690,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XII), Bl. 76b/r u. v.</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_1ade1a4ad19872b8fc944e1377288cbe"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_455b3eeac43d831b19b7e49f5505dd2c"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_1ade1a4ad19872b8fc944e1377288cbe">
+                                        <div class="collapse apparatus-details" id="source_455b3eeac43d831b19b7e49f5505dd2c">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Überschrift von C. M. von Webers Hand, nachfolgend Entwurfs-Diktat von der Hand Caroline von Webers; Rand vom zweiten Teil des Briefes etwas beschnitten</li>
@@ -1016,7 +1016,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A041894.html
+++ b/testing/expected-results/letters/A041894.html
@@ -485,9 +485,9 @@
                                         
                                         <span>In Privatbesitz</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_0a3ee2924193eaee2e5693a91a582c17"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_190afced99af909792139568dec7ef87"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_0a3ee2924193eaee2e5693a91a582c17">
+                                        <div class="collapse apparatus-details" id="source_190afced99af909792139568dec7ef87">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 S. 4°</li>
@@ -510,7 +510,7 @@
                                                             
                                                             <span>Hanns Zeeck, Henriette Hendel-Schütz. Eine Lebensskizze, Köslin 1939 (Auszug)</span>
                                                               
-                                                            <div class="collapse" id="source_83f33560bfc5ed10c5509f7691775c08">
+                                                            <div class="collapse" id="source_24d95e9029e8e5989c9ba880d7198cb4">
                                                                 
                                                             </div>
                                                         </div>
@@ -704,7 +704,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A041929.html
+++ b/testing/expected-results/letters/A041929.html
@@ -542,9 +542,9 @@ Trauermusik von Ferne. <span class="69117114121"><span class="tei_hi_underline1"
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: 55 Ep 1942</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_614c0c7918c041cd6fa5eb065a6be5ef"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b779fd2551661772244e0facef8506ed"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_614c0c7918c041cd6fa5eb065a6be5ef">
+                                        <div class="collapse apparatus-details" id="source_b779fd2551661772244e0facef8506ed">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. einschl. Adr.)</li>
@@ -569,7 +569,7 @@ Trauermusik von Ferne. <span class="69117114121"><span class="tei_hi_underline1"
                                                             
                                                             <span class="tei_bibl">Chezy, H.v.: <span class="tei_hi_italic">Carl Maria von Weber’s Euryanthe. Ein Beitrag zur Geschichte der deutschen Oper</span> in : NZfM 13.Bd. (1840), S. 33</span>
                                                               
-                                                            <div class="collapse" id="source_166f6c2c712be4f37ba8b9422601ddab">
+                                                            <div class="collapse" id="source_eea3e46b9a9cd68b35339bbac3725bf7">
                                                                 
                                                             </div>
                                                         </div>
@@ -772,7 +772,6 @@ Trauermusik von Ferne. <span class="69117114121"><span class="tei_hi_underline1"
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A041956.html
+++ b/testing/expected-results/letters/A041956.html
@@ -533,9 +533,9 @@
                                         <span>Dresden (D), Sächsische Landesbibliothek – Staats- und
                      Universitätsbibliothek (D-Dl)<br /><i>Signatur</i>: Mus. Schu 314a (= Schumannalbum)</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_ad21101f3b29f40406e187a35b10c6fc"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_eacc35ccad50d41809e92bb83056ba5c"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_ad21101f3b29f40406e187a35b10c6fc">
+                                        <div class="collapse apparatus-details" id="source_eacc35ccad50d41809e92bb83056ba5c">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S. einschl. Adr.)</li>
@@ -1134,7 +1134,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A041972.html
+++ b/testing/expected-results/letters/A041972.html
@@ -549,9 +549,9 @@
                                         
                                         <span>Krakau (PL), Uniwersytet Jagielloński. Biblioteka Jagiellońska  (PL-Kj)<br /><i>Signatur</i>: Slg. Varnhagen, MS. 273</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b6a809762a9f805362a17c9980a113d4"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_0cae97758bfd20b971e0452138652e69"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_b6a809762a9f805362a17c9980a113d4">
+                                        <div class="collapse apparatus-details" id="source_0cae97758bfd20b971e0452138652e69">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. o. Adr.)</li>
@@ -567,7 +567,7 @@
                                                             
                                                             <span id="printNZfM" class="tei_bibl">Chezy, H.v.: <span class="tei_hi_italic">Carl Maria von Weber’s Euryanthe. Ein Beitrag zur Geschichte der deutschen Oper</span>, in: NZfM 13.Jg., Nr. 10 (1. August 1840), S. 37</span>
                                                               
-                                                            <div class="collapse" id="source_f3725807340ef4624f03273e9ce9b3dc">
+                                                            <div class="collapse" id="source_81c9aa2ff0cf48ebc95c77a68d6be150">
                                                                 
                                                             </div>
                                                         </div>
@@ -577,7 +577,7 @@
                                                             
                                                             <span id="printBdS" class="tei_bibl">Anon.: <span class="tei_hi_italic">Unveröffentlichte Briefe Carl Maria von Webers</span>, in: <span class="tei_hi_italic">Blätter der Staatsoper</span>, Jg. 3, Heft 1 (Oktober 1922), S. 11–12</span>
                                                               
-                                                            <div class="collapse" id="source_4f845078553adc6ebef5e604e680ad06">
+                                                            <div class="collapse" id="source_9500886d57cdf98d2942c072353bbf49">
                                                                 
                                                             </div>
                                                         </div>
@@ -810,7 +810,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A041993.html
+++ b/testing/expected-results/letters/A041993.html
@@ -519,7 +519,7 @@
                                         
                                         <span class="tei_msName">Entwurf in zwei Teilen</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_0c4212aeac57089477648b169debc366">
+                                        <div class="collapse apparatus-details" id="source_f84a3533f2f8e1ca57351f17b952c0fc">
                                             
                                             
                                             <div>
@@ -541,9 +541,9 @@
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz,
                         Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XII), Bl. 78a</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6af909dd0125702247f6bf19a725ec5d"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_84f84e28e562ec29f8abd56a0c2371b9"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_6af909dd0125702247f6bf19a725ec5d">
+                                        <div class="collapse apparatus-details" id="source_84f84e28e562ec29f8abd56a0c2371b9">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Im letzten Abschnitt seitlich beschnitten mit kleinen Textverlusten</li>
@@ -568,9 +568,9 @@
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz,
                         Musikabteilung (D-B)<br /><i>Signatur</i>: N. Mus. ep. 1524</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_5a353c5db7cd54f8fcf754ee13bf768a"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_783e9207590cdd5190b65121ac5e789e"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_5a353c5db7cd54f8fcf754ee13bf768a">
+                                        <div class="collapse apparatus-details" id="source_783e9207590cdd5190b65121ac5e789e">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>die Versoseite des Blattes enthält u. a. die beim Ausschneiden eines <a class="preview letters A041991" href="">Brieffragments</a> abgetrennten
@@ -895,7 +895,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A041994.html
+++ b/testing/expected-results/letters/A041994.html
@@ -490,9 +490,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: 55 Ep 179</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b86837281871b8b36388066f6f41f759"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a20acb7c282d120dbb1de0fd6d15da23"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_b86837281871b8b36388066f6f41f759">
+                                        <div class="collapse apparatus-details" id="source_a20acb7c282d120dbb1de0fd6d15da23">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. o. Adr.)</li>
@@ -519,9 +519,9 @@
                                                             
                                                             <span>Leipzig (Deutschland), Leipziger Stadtbibliothek – Musikbibliothek (D-LEm)<br /><i>Signatur</i>: PB 37 (Nr. 38)</span>
                                                             <span>
-                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_605b998809e6e63a24dd985a227c5cc8"></a>
+                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_71aeb805d92a801f97221e36ea28fd8e"></a>
                                                             </span>  
-                                                            <div class="collapse" id="source_605b998809e6e63a24dd985a227c5cc8">
+                                                            <div class="collapse" id="source_71aeb805d92a801f97221e36ea28fd8e">
                                                                 <h4 class="media-heading">Quellenbeschreibung</h4>
                                                                         <ul>
                                                                             <li>Abschrift von Lichtenstein</li>
@@ -534,7 +534,7 @@
                                                             
                                                             <span>Rungenhagen, Carl Friedrich, Nachrichten aus dem Leben und über die Musik-Werke Carl Maria von Weber's mit dem sehr ähnlichen Bildnisse desselben, Berlin: T. Trautwein, 1826, S. 6</span>
                                                               
-                                                            <div class="collapse" id="source_33ef6390b2d647da0dc27d468df26c01">
+                                                            <div class="collapse" id="source_8a4fc204369cfb451cb981fa5fa21126">
                                                                 
                                                             </div>
                                                         </div>
@@ -544,7 +544,7 @@
                                                             
                                                             <span>Rudorff: Westermanns illustrierte deutsche Monats-Hefte, 44. Jg. (1899), 87. Bd., S. 180 (als Beilage zum Br. an Lichtenstein v. 18.12.)</span>
                                                               
-                                                            <div class="collapse" id="source_f698e39dce62512e6b9884295ec7568f">
+                                                            <div class="collapse" id="source_378a6fe875858860adc2cb2e49bcb0ec">
                                                                 
                                                             </div>
                                                         </div>
@@ -554,7 +554,7 @@
                                                             
                                                             <span class="tei_bibl">Nusser, G.: „Bisher unveröffentlichte Briefe hervorragender Musiker“, in: Der Zeitgeist. Beiblatt zum ’Berliner Tageblatt’, Nr. 21 (22. Mai 1899)</span>
                                                               
-                                                            <div class="collapse" id="source_3bbe2bb751b11688fcddb0b79ac542d7">
+                                                            <div class="collapse" id="source_deb6428e8860a8246d7f53aed2ce1ebe">
                                                                 
                                                             </div>
                                                         </div>
@@ -564,7 +564,7 @@
                                                             
                                                             <span>Rudorff 1900, S. 117–119 (ebf. als Beil. zum Br. an L. v. 18.12.)</span>
                                                               
-                                                            <div class="collapse" id="source_53a6382d328a13f08473fa732ac5edba">
+                                                            <div class="collapse" id="source_5623bf1aa123d6647df52f27a7018df1">
                                                                 
                                                             </div>
                                                         </div>
@@ -764,7 +764,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042001.html
+++ b/testing/expected-results/letters/A042001.html
@@ -546,7 +546,7 @@
                                         
                                         <span class="tei_msName">Brief in zwei Teilen</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_5d4fa35cb5cde3f5a303a7b94e382ba6">
+                                        <div class="collapse apparatus-details" id="source_1ed94ce16c35eed7197186b868418c8c">
                                             
                                             
                                             <div>
@@ -567,7 +567,7 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XII), Bl. 78a/v u. 78b/r</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_569fa7835850ebfff23a0e55dbb4115f">
+                                        <div class="collapse apparatus-details" id="source_60bc216e22b7afdffb7c24e3c09ddb7b">
                                             
                                             
                                             <div>
@@ -588,9 +588,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: N. Mus. ep. 1524</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6ca9c4a42fe6513a8e85ff8dca234f40"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_44c86d06773964d4fa8746ab5db3f051"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_6ca9c4a42fe6513a8e85ff8dca234f40">
+                                        <div class="collapse apparatus-details" id="source_44c86d06773964d4fa8746ab5db3f051">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>die Versoseite des Blattes enthält u. a. die beim Ausschneiden eines <a class="preview letters A041991" href="">Brieffragments</a> abgetrennten Zeilenanfänge sowie den Absendevermerk zu diesem Entwurf</li>
@@ -1060,7 +1060,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042005.html
+++ b/testing/expected-results/letters/A042005.html
@@ -522,9 +522,9 @@
                                         
                                         <span>Oxford (GB), Bodleian Library (GB-Ob)<br /><i>Signatur</i>: MS. M. D. Mendelssohn C 21, fol. 40r. u. 40v.</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_7e191458d2ff12d2744ad932ddb38024"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_2dd48b5629097969fc3eb99d5a344281"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_7e191458d2ff12d2744ad932ddb38024">
+                                        <div class="collapse apparatus-details" id="source_2dd48b5629097969fc3eb99d5a344281">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. einschl. Adr.)</li>
@@ -727,7 +727,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042017.html
+++ b/testing/expected-results/letters/A042017.html
@@ -494,9 +494,9 @@
                                         
                                         <span>Verbleib unbekannt</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_1094063665dc7c5e20aa3d5235d41d58"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_d869747edab6fe41eb583504207a6f6d"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_1094063665dc7c5e20aa3d5235d41d58">
+                                        <div class="collapse apparatus-details" id="source_d869747edab6fe41eb583504207a6f6d">
                                             
                                             
                                             <div>
@@ -509,7 +509,7 @@
                                                             
                                                             <span>AMZ, Neue Folge, Jg. 1, Nr. 36 (2. September 1863), Sp. 618–620</span>
                                                               
-                                                            <div class="collapse" id="source_d00c8460ea7aa56d8a688ac4f3064fcc">
+                                                            <div class="collapse" id="source_6695e10853914a746beada482d54bb27">
                                                                 
                                                             </div>
                                                         </div>
@@ -705,7 +705,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042031.html
+++ b/testing/expected-results/letters/A042031.html
@@ -610,9 +610,9 @@
                                         
                                         <span>In Privatbesitz</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_3463675c92e7ad8b0e050849382dec3d"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_52bec439501e8c6d3dcac01575f73b07"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_3463675c92e7ad8b0e050849382dec3d">
+                                        <div class="collapse apparatus-details" id="source_52bec439501e8c6d3dcac01575f73b07">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S. o. Adr.)</li>
@@ -858,7 +858,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042032.html
+++ b/testing/expected-results/letters/A042032.html
@@ -496,9 +496,9 @@
                                         
                                         <span>Verbleib unbekannt</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_28ab922b407e179477b02f6f14313235"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_98b48c80c9f982d5a3ba1e7cac274a1e"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_28ab922b407e179477b02f6f14313235">
+                                        <div class="collapse apparatus-details" id="source_98b48c80c9f982d5a3ba1e7cac274a1e">
                                             
                                             
                                             <div>
@@ -511,7 +511,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A112483" data-ref="">Kind: Freischütz-Buch</span>, S. 174 (Nr. 41)</span>
                                                               
-                                                            <div class="collapse" id="source_73e88016d321b291e1ae5320ccfe9495">
+                                                            <div class="collapse" id="source_e63ce1f7e4439b6579561311278d82c8">
                                                                 
                                                             </div>
                                                         </div>
@@ -717,7 +717,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042035.html
+++ b/testing/expected-results/letters/A042035.html
@@ -461,9 +461,9 @@
                                         
                                         <span>Wien (A), Wienbibliothek im Rathaus (A-Wst)<br /><i>Signatur</i>: H.I.N. 5974</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_3f7336e5e0d86668821a763d820992bb"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_fd3b842e876f1fdc9efea2427d1c6ebe"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_3f7336e5e0d86668821a763d820992bb">
+                                        <div class="collapse apparatus-details" id="source_fd3b842e876f1fdc9efea2427d1c6ebe">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. o. Adr.)</li>
@@ -669,7 +669,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042038.html
+++ b/testing/expected-results/letters/A042038.html
@@ -479,9 +479,9 @@
                                         
                                         <span>Krakau (PL), Uniwersytet Jagielloński. Biblioteka Jagiellońska (PL-Kj)<br /><i>Signatur</i>: Slg. Varnhagen, MS. 43</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_c3d1522b398a0f518cbdcd8afc50e7ca"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a1f0ee6652adb99221e5bdd1d01385da"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_c3d1522b398a0f518cbdcd8afc50e7ca">
+                                        <div class="collapse apparatus-details" id="source_a1f0ee6652adb99221e5bdd1d01385da">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. einschl. Adr.)</li>
@@ -686,7 +686,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042046.html
+++ b/testing/expected-results/letters/A042046.html
@@ -513,9 +513,9 @@
                                         
                                         <span>Dresden (D), Sächsische Landesbibliothek – Staats- und Universitätsbibliothek (D-Dl)<br /><i>Signatur</i>: Mscr.Dresd. App. 292, 35a</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_44fdbf68b059e86429a2b54ef6fa8259"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e0054ceb0e75d4b5ea84fc37da674daa"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_44fdbf68b059e86429a2b54ef6fa8259">
+                                        <div class="collapse apparatus-details" id="source_e0054ceb0e75d4b5ea84fc37da674daa">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. einschl. Adr.)</li>
@@ -547,9 +547,9 @@
                                         
                                         <span>Marbach (D), Deutsches Literaturarchiv (D-MB)<br /><i>Signatur</i>: A: Minde-Pouet, Georg/Autographen, HS001788343</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_bcd57348b5357f11eeaf7f31a1532fcc"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a1d8db4fe86a638f3339a886a6966d53"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_bcd57348b5357f11eeaf7f31a1532fcc">
+                                        <div class="collapse apparatus-details" id="source_a1d8db4fe86a638f3339a886a6966d53">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S.)</li>
@@ -1044,7 +1044,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042052.html
+++ b/testing/expected-results/letters/A042052.html
@@ -483,9 +483,9 @@
                                         
                                         <span>Paris (F), Bibliothèque nationale de France (F-Pn)<br /><i>Signatur</i>: Lettres autographes, Vol. XX, Bl. 288</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_432473351bffce5e52e2d8762c531f99"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_27a86d0f921044fd367bcad3a44b74eb"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_432473351bffce5e52e2d8762c531f99">
+                                        <div class="collapse apparatus-details" id="source_27a86d0f921044fd367bcad3a44b74eb">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. o. Adr.)</li>
@@ -786,7 +786,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042069.html
+++ b/testing/expected-results/letters/A042069.html
@@ -478,9 +478,9 @@
                                         
                                         <span>Innsbruck (A), Tiroler Landesmuseum Ferdinandeum, Musiksammlung (A-Imf)<br /><i>Signatur</i>: Nr. 11</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_152c7e7a2324aa64a2c0b144e57dcf94"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6bf68c566cf10ced6db7e8380e5517fa"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_152c7e7a2324aa64a2c0b144e57dcf94">
+                                        <div class="collapse apparatus-details" id="source_6bf68c566cf10ced6db7e8380e5517fa">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S. o. Adr.)</li>
@@ -692,7 +692,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042070.html
+++ b/testing/expected-results/letters/A042070.html
@@ -573,9 +573,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ep. Spohr-Correspondenz 1, 88</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_7f70a462a55db4a9e1b441f55b63e084"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_cff93aaa9229990f2a63d3652c0a618a"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_7f70a462a55db4a9e1b441f55b63e084">
+                                        <div class="collapse apparatus-details" id="source_cff93aaa9229990f2a63d3652c0a618a">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Siegelloch</li>
@@ -596,7 +596,7 @@
                                                             
                                                             <span class="tei_bibl">Rychnovsky, Ernst: „Konradin Kreutzer und Ludwig Spohr“ in: Neue Musik-Zeitung (Stuttgart: Grüninger) 35.Jg. (1914), Heft 4, S. 70</span>
                                                               
-                                                            <div class="collapse" id="source_850acde1d643cb71bcd46cf29e3a3770">
+                                                            <div class="collapse" id="source_e26a6db95b848fcfc97bfdd5e0b83c84">
                                                                 
                                                             </div>
                                                         </div>
@@ -840,7 +840,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042073.html
+++ b/testing/expected-results/letters/A042073.html
@@ -504,9 +504,9 @@
                                         
                                         <span>Wien (A), Wien Österreichische Nationalbibliothek, Handschriften- u. Inkunabelsammlung (A-Wn)<br /><i>Signatur</i>: Autogr. 7/130-10</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6b756cf8425c92d03767369a4f39359a"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_32944c368ecacc63b728017d25740c88"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_6b756cf8425c92d03767369a4f39359a">
+                                        <div class="collapse apparatus-details" id="source_32944c368ecacc63b728017d25740c88">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. einschl. Adr.)</li>
@@ -697,7 +697,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042078.html
+++ b/testing/expected-results/letters/A042078.html
@@ -524,7 +524,7 @@
                                         
                                         <span>Verbleib unbekannt</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_9e97cac965984bf36960d28d54aeb62d">
+                                        <div class="collapse apparatus-details" id="source_0cf48b578a4641e173c002e0c03cc5fb">
                                             
                                             
                                             <div>
@@ -543,9 +543,9 @@
                                     <div>
                                         <strong><span>2. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="title">Zwey Briefe I. Susann's an C.M.v.Weber</span>, in: <span class="journalTitle">Wiener Zeitschrift für Kunst, Literatur, Theater und Mode</span>, Jg. 28, Nr. 8 (12. Januar 1843), S. 57–61</span>
+                                        <span class="biblio-entry"><span class="title">Zwey Briefe I. Susann's an C.M.v.Weber</span>, in: <span class="journalTitle">Wiener Zeitschrift für Kunst, Literatur, Theater und Mode</span><span class="imprint">, Jg. 28, Nr. 8 (12. Januar 1843), S. 57–61</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_e7a3db9aae214152c4512a2bb1fb2966">
+                                        <div class="collapse apparatus-details" id="source_4b23f23d4f1150b3a63411d7afdf402e">
                                             
                                             
                                             <div>
@@ -761,7 +761,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042080.html
+++ b/testing/expected-results/letters/A042080.html
@@ -498,9 +498,9 @@
                                         
                                         <span>Karlsruhe (D), Generallandesarchiv (D-KAg)<br /><i>Signatur</i>: 47/1105</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_5a1e11e548773d5aef76adf496824a01"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_7acffc993883f9a312dbeee12866581b"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_5a1e11e548773d5aef76adf496824a01">
+                                        <div class="collapse apparatus-details" id="source_7acffc993883f9a312dbeee12866581b">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S.)</li>
@@ -758,7 +758,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042089.html
+++ b/testing/expected-results/letters/A042089.html
@@ -511,9 +511,9 @@
                                         
                                         <span>Leipzig (D), Leipziger Stadtbibliothek – Musikbibliothek (D-LEm)<br /><i>Signatur</i>: PB 37, (Nr. 42)</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_416e73f9c98b428d5394af17d8e43765"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_402af776eec65714952e19fba1d3186b"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_416e73f9c98b428d5394af17d8e43765">
+                                        <div class="collapse apparatus-details" id="source_402af776eec65714952e19fba1d3186b">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. einschl. Adr.)</li>
@@ -531,7 +531,7 @@
                                                             
                                                             <span>Rudorff: Westermanns illustrierte deutsche Monats-Hefte, 44. Jg. (1899), 87. Bd., S. S. 181 (mit Beilage: Abschr. Weber an Brühl v. 13.1., s.d., S. 181–182)</span>
                                                               
-                                                            <div class="collapse" id="source_b6a6f980a9ba0db9298c217893e251b1">
+                                                            <div class="collapse" id="source_f7cfaf9dbb24f54507dad09ac92b33d4">
                                                                 
                                                             </div>
                                                         </div>
@@ -541,7 +541,7 @@
                                                             
                                                             <span>Rudorff 1900, S. 123–124 u. Abschrift an Brühl, S. 124–127</span>
                                                               
-                                                            <div class="collapse" id="source_065c75c3cdd723ae15d5a4dc80f0963e">
+                                                            <div class="collapse" id="source_e7a65338c382dbb121fb0a39fae6070b">
                                                                 
                                                             </div>
                                                         </div>
@@ -767,7 +767,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042093.html
+++ b/testing/expected-results/letters/A042093.html
@@ -484,9 +484,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. II A f 2, Nr. 19</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_979ed6dce6d9606e8c3bbe4f86b28ec0"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_5c34a85f4133a4d09eb7b6290da658e3"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_979ed6dce6d9606e8c3bbe4f86b28ec0">
+                                        <div class="collapse apparatus-details" id="source_5c34a85f4133a4d09eb7b6290da658e3">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S.)</li>
@@ -505,7 +505,7 @@
                                                             
                                                             <span>tV: AmZ, Neue Folge, Jg. 1, Nr. 37 (9. September 1863), Sp. 631–633 (nach Entwurf)</span>
                                                               
-                                                            <div class="collapse" id="source_c51b5fbf95d07c10fbd159deeb12f4c9">
+                                                            <div class="collapse" id="source_b858b4a1ada90f5829344ccdbd47828f">
                                                                 
                                                             </div>
                                                         </div>
@@ -737,7 +737,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042125.html
+++ b/testing/expected-results/letters/A042125.html
@@ -370,7 +370,7 @@
                                    <h4>Folgend</h4>
                                    <ul>
                                        <li>
-                                           <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A042269.html">1824-03-03</a>:  an  <a href="" class="preview A001473 persons"></a>
+                                           <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A044991.html">1824-03-03</a>:  an  <a href="" class="preview A001473 persons"></a>
                                        </li>
                                             <li>
                                            <a href="/exist/apps/WeGA-WebApp/de/A000288/Korrespondenz/A042046.html">1823-07-05</a>:  von  <a href="" class="preview A000288 persons"></a>
@@ -491,9 +491,9 @@
                                         
                                         <span>Washington, D.C. (US), Library of Congress, Music Division (US-Wc), Moldenhauer Archiv</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e65d47d653c8c63cd3bae102b881727a"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e33eb8fbe3dc08fea3a75e3d8721edb5"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_e65d47d653c8c63cd3bae102b881727a">
+                                        <div class="collapse apparatus-details" id="source_e33eb8fbe3dc08fea3a75e3d8721edb5">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (2 b. S. einschl. Adr.)</li>
@@ -517,9 +517,9 @@
                                                             
                                                             <span>Krakau (Polen), Biblioteka Jagiellońska (PL-Kj), Slg. Varnhagen<br /><i>Signatur</i>: MS. 273</span>
                                                             <span>
-                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_8069da6adf7552f5d4c9c25715ad9f92"></a>
+                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_98da6ef37950476a4fda5b4b94b9301c"></a>
                                                             </span>  
-                                                            <div class="collapse" id="source_8069da6adf7552f5d4c9c25715ad9f92">
+                                                            <div class="collapse" id="source_98da6ef37950476a4fda5b4b94b9301c">
                                                                 <h4 class="media-heading">Quellenbeschreibung</h4>
                                                                         <ul>
                                                                             <li>Abschrift von L. Assing</li>
@@ -545,9 +545,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XIII), Bl. 80b/r</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b069d29de93986a31c2069435b246ab7"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_eef2d2692731b07fa674906c89481a54"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_b069d29de93986a31c2069435b246ab7">
+                                        <div class="collapse apparatus-details" id="source_eef2d2692731b07fa674906c89481a54">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>von <a class="preview persons A002085" href="/exist/apps/WeGA-WebApp/de/A002085.html">Max Maria von Weber</a> herausgeschnitten und durch eine Abschrift ersetzt mit der Bemerkung: „Original im Besiz der Fräulein Freisleben zu Dresden“. 
@@ -758,7 +758,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042125.html
+++ b/testing/expected-results/letters/A042125.html
@@ -370,7 +370,7 @@
                                    <h4>Folgend</h4>
                                    <ul>
                                        <li>
-                                           <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A044991.html">1824-03-03</a>:  an  <a href="" class="preview A001473 persons"></a>
+                                           <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A042269.html">1824-03-03</a>:  an  <a href="" class="preview A001473 persons"></a>
                                        </li>
                                             <li>
                                            <a href="/exist/apps/WeGA-WebApp/de/A000288/Korrespondenz/A042046.html">1823-07-05</a>:  von  <a href="" class="preview A000288 persons"></a>
@@ -491,9 +491,9 @@
                                         
                                         <span>Washington, D.C. (US), Library of Congress, Music Division (US-Wc), Moldenhauer Archiv</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e33eb8fbe3dc08fea3a75e3d8721edb5"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_df3c57f0bc76dddec0da9bcfd46552a1"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_e33eb8fbe3dc08fea3a75e3d8721edb5">
+                                        <div class="collapse apparatus-details" id="source_df3c57f0bc76dddec0da9bcfd46552a1">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (2 b. S. einschl. Adr.)</li>
@@ -517,9 +517,9 @@
                                                             
                                                             <span>Krakau (Polen), Biblioteka Jagiellońska (PL-Kj), Slg. Varnhagen<br /><i>Signatur</i>: MS. 273</span>
                                                             <span>
-                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_98da6ef37950476a4fda5b4b94b9301c"></a>
+                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_52c784fd7997c8645c385d7189fd7927"></a>
                                                             </span>  
-                                                            <div class="collapse" id="source_98da6ef37950476a4fda5b4b94b9301c">
+                                                            <div class="collapse" id="source_52c784fd7997c8645c385d7189fd7927">
                                                                 <h4 class="media-heading">Quellenbeschreibung</h4>
                                                                         <ul>
                                                                             <li>Abschrift von L. Assing</li>
@@ -545,9 +545,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XIII), Bl. 80b/r</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_eef2d2692731b07fa674906c89481a54"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_1d2ab9102d4d64a8d4b261847aeef7ae"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_eef2d2692731b07fa674906c89481a54">
+                                        <div class="collapse apparatus-details" id="source_1d2ab9102d4d64a8d4b261847aeef7ae">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>von <a class="preview persons A002085" href="/exist/apps/WeGA-WebApp/de/A002085.html">Max Maria von Weber</a> herausgeschnitten und durch eine Abschrift ersetzt mit der Bemerkung: „Original im Besiz der Fräulein Freisleben zu Dresden“. 

--- a/testing/expected-results/letters/A042215.html
+++ b/testing/expected-results/letters/A042215.html
@@ -488,9 +488,9 @@
                                         
                                         <span>Karlsruhe (D), Generallandesarchiv (D-KAg)<br /><i>Signatur</i>: 47/1105</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_c9db39fb834d176c4fdfc8081bbd7817"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_9acac01b6e550cc1c6fd724f65a776b1"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_c9db39fb834d176c4fdfc8081bbd7817">
+                                        <div class="collapse apparatus-details" id="source_9acac01b6e550cc1c6fd724f65a776b1">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S. einschl. Adr.)</li>
@@ -708,7 +708,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042269.html
+++ b/testing/expected-results/letters/A042269.html
@@ -372,7 +372,7 @@
                                    <h4>Vorausgehend</h4>
                                    <ul>
                                        <li>
-                                           <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A042125.html">1823-06-17</a>:  an  <a href="" class="preview A000288 persons"></a>
+                                           <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A044991.html">1824-03-03</a>:  an  <a href="" class="preview A001473 persons"></a>
                                        </li>
                                             <li>
                                            <a href="/exist/apps/WeGA-WebApp/de/A080005/Korrespondenz/A042080.html">1823-12-04</a>:  von  <a href="" class="preview A080005 orgs"></a>
@@ -381,7 +381,7 @@
                                    <h4>Folgend</h4>
                                    <ul>
                                        <li>
-                                           <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A044991.html">1824-03-03</a>:  an  <a href="" class="preview A001473 persons"></a>
+                                           <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A042302.html">1824-05-27</a>:  an  <a href="" class="preview A000561 persons"></a>
                                        </li>
                                             <li>
                                            <a href="/exist/apps/WeGA-WebApp/de/A000213/Korrespondenz/A042699.html">1826-02-21</a>:  von  <a href="" class="preview A000213 persons"></a>
@@ -393,13 +393,13 @@
                                     <h3>Korrespondenzstelle</h3>
                                     <h4>Vorausgehend</h4>
                                     <ul>
-                                        
-                                    </ul>
-                                    <h4>Folgend</h4>
-                                    <ul>
                                         <li>
                                             <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A044991.html">1824-03-03</a>:  an  <a href="" class="preview A001473 persons"></a>
                                         </li>
+                                    </ul>
+                                    <h4>Folgend</h4>
+                                    <ul>
+                                        
                                     </ul>
                                 
                             </div>
@@ -508,7 +508,7 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XIV), Bl. 81a/r</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_6cdb10df76d73a0f647b4b30ab2c1406">
+                                        <div class="collapse apparatus-details" id="source_0d390440016ee6e75cabee7603554632">
                                             
                                             
                                             <div>
@@ -810,7 +810,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042269.html
+++ b/testing/expected-results/letters/A042269.html
@@ -372,7 +372,7 @@
                                    <h4>Vorausgehend</h4>
                                    <ul>
                                        <li>
-                                           <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A044991.html">1824-03-03</a>:  an  <a href="" class="preview A001473 persons"></a>
+                                           <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A042125.html">1823-06-17</a>:  an  <a href="" class="preview A000288 persons"></a>
                                        </li>
                                             <li>
                                            <a href="/exist/apps/WeGA-WebApp/de/A080005/Korrespondenz/A042080.html">1823-12-04</a>:  von  <a href="" class="preview A080005 orgs"></a>
@@ -381,7 +381,7 @@
                                    <h4>Folgend</h4>
                                    <ul>
                                        <li>
-                                           <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A042302.html">1824-05-27</a>:  an  <a href="" class="preview A000561 persons"></a>
+                                           <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A044991.html">1824-03-03</a>:  an  <a href="" class="preview A001473 persons"></a>
                                        </li>
                                             <li>
                                            <a href="/exist/apps/WeGA-WebApp/de/A000213/Korrespondenz/A042699.html">1826-02-21</a>:  von  <a href="" class="preview A000213 persons"></a>
@@ -393,13 +393,13 @@
                                     <h3>Korrespondenzstelle</h3>
                                     <h4>Vorausgehend</h4>
                                     <ul>
-                                        <li>
-                                            <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A044991.html">1824-03-03</a>:  an  <a href="" class="preview A001473 persons"></a>
-                                        </li>
+                                        
                                     </ul>
                                     <h4>Folgend</h4>
                                     <ul>
-                                        
+                                        <li>
+                                            <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A044991.html">1824-03-03</a>:  an  <a href="" class="preview A001473 persons"></a>
+                                        </li>
                                     </ul>
                                 
                             </div>
@@ -508,7 +508,7 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XIV), Bl. 81a/r</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_0d390440016ee6e75cabee7603554632">
+                                        <div class="collapse apparatus-details" id="source_10e8083ba699d0cac77501939eadb9a8">
                                             
                                             
                                             <div>

--- a/testing/expected-results/letters/A042302.html
+++ b/testing/expected-results/letters/A042302.html
@@ -362,7 +362,7 @@
                                    <h4>Vorausgehend</h4>
                                    <ul>
                                        <li>
-                                           <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A042269.html">1824-03-03</a>:  an  <a href="" class="preview A001473 persons"></a>
+                                           <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A044991.html">1824-03-03</a>:  an  <a href="" class="preview A001473 persons"></a>
                                        </li>
                                             <li>
                                            <a href="/exist/apps/WeGA-WebApp/de/A080005/Korrespondenz/A042080.html">1823-12-04</a>:  von  <a href="" class="preview A080005 orgs"></a>
@@ -476,7 +476,7 @@
                                         
                                         <span class="biblio-entry"><span class="author">Aloys Fuchs</span>, <span class="title">Karl Maria von Weber an die, welche sich der Kunst widmen möchten</span>, in: <span class="journalTitle">BamZ</span><span class="imprint">, Jg. 3, Nr. 38 (26. Sept. 1826), S. 301–302</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_d101f8e97ca8cbc2af6a986901c13976">
+                                        <div class="collapse apparatus-details" id="source_ecfc26fa67e253e7fe6a8b564081c9c7">
                                             
                                             
                                             <div>
@@ -497,9 +497,9 @@
                                         
                                         <span class="biblio-entry book"><span class="author">Theodor Hell</span>, <span class="title">Hinterlassene Schriften von Carl Maria von Weber</span>,  Bd. 1, <span class="placeNYear">Dresden &amp; Leipzig 1828</span>, S. XXXII–XXXV</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_3f3a4369b56a5c5fb9db1bdb3d1c54b0"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_f1688b16a5760c51801bc756eb6df856"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_3f3a4369b56a5c5fb9db1bdb3d1c54b0">
+                                        <div class="collapse apparatus-details" id="source_f1688b16a5760c51801bc756eb6df856">
                                             
                                             
                                             <div>
@@ -512,7 +512,7 @@
                                                             
                                                             <span>Laux, Karl: Kunstansichten. 1977, S. 241–242</span>
                                                               
-                                                            <div class="collapse" id="source_ef17da64a5e8eb2fbda1cc8adef5c8ac">
+                                                            <div class="collapse" id="source_cfd5ea83f93af9f1113778f7854c07f5">
                                                                 
                                                             </div>
                                                         </div>
@@ -522,7 +522,7 @@
                                                             
                                                             <span>Kaiser (Schriften) Nr. 152 und S. 52–54</span>
                                                               
-                                                            <div class="collapse" id="source_6b09a15aad912a17ea436bfb2a02f5b5">
+                                                            <div class="collapse" id="source_73446de507e95cbfc3e32afc8ef34264">
                                                                 
                                                             </div>
                                                         </div>

--- a/testing/expected-results/letters/A042302.html
+++ b/testing/expected-results/letters/A042302.html
@@ -362,7 +362,7 @@
                                    <h4>Vorausgehend</h4>
                                    <ul>
                                        <li>
-                                           <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A044991.html">1824-03-03</a>:  an  <a href="" class="preview A001473 persons"></a>
+                                           <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A042269.html">1824-03-03</a>:  an  <a href="" class="preview A001473 persons"></a>
                                        </li>
                                             <li>
                                            <a href="/exist/apps/WeGA-WebApp/de/A080005/Korrespondenz/A042080.html">1823-12-04</a>:  von  <a href="" class="preview A080005 orgs"></a>
@@ -474,9 +474,9 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="author">Aloys Fuchs</span>, <span class="title">Karl Maria von Weber an die, welche sich der Kunst widmen möchten</span>, in: <span class="journalTitle">BamZ</span>, Jg. 3, Nr. 38 (26. Sept. 1826), S. 301–302</span>
+                                        <span class="biblio-entry"><span class="author">Aloys Fuchs</span>, <span class="title">Karl Maria von Weber an die, welche sich der Kunst widmen möchten</span>, in: <span class="journalTitle">BamZ</span><span class="imprint">, Jg. 3, Nr. 38 (26. Sept. 1826), S. 301–302</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_4a2f4a348cac372dfdf1502102b97c97">
+                                        <div class="collapse apparatus-details" id="source_d101f8e97ca8cbc2af6a986901c13976">
                                             
                                             
                                             <div>
@@ -497,9 +497,9 @@
                                         
                                         <span class="biblio-entry book"><span class="author">Theodor Hell</span>, <span class="title">Hinterlassene Schriften von Carl Maria von Weber</span>,  Bd. 1, <span class="placeNYear">Dresden &amp; Leipzig 1828</span>, S. XXXII–XXXV</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_78166b14052deef98d426d1624a65f84"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_3f3a4369b56a5c5fb9db1bdb3d1c54b0"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_78166b14052deef98d426d1624a65f84">
+                                        <div class="collapse apparatus-details" id="source_3f3a4369b56a5c5fb9db1bdb3d1c54b0">
                                             
                                             
                                             <div>
@@ -512,7 +512,7 @@
                                                             
                                                             <span>Laux, Karl: Kunstansichten. 1977, S. 241–242</span>
                                                               
-                                                            <div class="collapse" id="source_2d79ab68cb92e18c786ea06f4d3b0a02">
+                                                            <div class="collapse" id="source_ef17da64a5e8eb2fbda1cc8adef5c8ac">
                                                                 
                                                             </div>
                                                         </div>
@@ -522,7 +522,7 @@
                                                             
                                                             <span>Kaiser (Schriften) Nr. 152 und S. 52–54</span>
                                                               
-                                                            <div class="collapse" id="source_6f3babd64a201b63e539a58ac1c7ac78">
+                                                            <div class="collapse" id="source_6b09a15aad912a17ea436bfb2a02f5b5">
                                                                 
                                                             </div>
                                                         </div>
@@ -889,7 +889,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042315.html
+++ b/testing/expected-results/letters/A042315.html
@@ -495,9 +495,9 @@
                                         
                                         <span>Quedlinburg (D), Städtische Museen, Archiv Klopstockhaus<br /><i>Signatur</i>: V/1127/S u. Beilage V/1129/S</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_86c1bb38b48d26b22a882e3caa6b0a66"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_609fc6b66976053d1aec7d212ae24e91"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_86c1bb38b48d26b22a882e3caa6b0a66">
+                                        <div class="collapse apparatus-details" id="source_609fc6b66976053d1aec7d212ae24e91">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl.? (3 b. S. o. Adr.)</li>
@@ -514,7 +514,7 @@
                                                             
                                                             <span>Selmar Kleemann, Die Hundertjahrfeier der Geburt Klopstocks in Quedlinburg am 2. Juli 1824, Quedlinburg: Ernst Klöppel [1924], S. 8 (gekürzt)</span>
                                                               
-                                                            <div class="collapse" id="source_553c17cbd5f32d81fb1a85ac940653d2">
+                                                            <div class="collapse" id="source_77f5bf206760d4f0c2350d7da811a05c">
                                                                 
                                                             </div>
                                                         </div>
@@ -524,7 +524,7 @@
                                                             
                                                             <span class="tei_bibl">Thom, Eitelfriedrich: „Zur Entwicklung mitteldeutscher Musikfeste in der ersten Hälfte des 19. Jahrhunderts“, in: „Beiträge zur Geschichte des Konzerts“. Fs. Siegfried Kross, hg. v. Reinmar Emans u. Matthias Wendt, Bonn 1990, S. 176</span>
                                                               
-                                                            <div class="collapse" id="source_d3acdab411914f4d368dc362f03b26af">
+                                                            <div class="collapse" id="source_578835096137d06cad184b7d4a59f1c7">
                                                                 
                                                             </div>
                                                         </div>
@@ -743,7 +743,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042320.html
+++ b/testing/expected-results/letters/A042320.html
@@ -514,7 +514,7 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XIV), Bl. 83a/r</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_19a46a232919bdf3ee2d3eb39f8cc025">
+                                        <div class="collapse apparatus-details" id="source_472e736df29958fb5bb539cd401c54bc">
                                             
                                             
                                             <div>
@@ -535,9 +535,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: 55 Ep 1921</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_aeee6ebc3500ed42e8d818fd9d34fe85"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_58157b1e79a9e298a37b842aba44614d"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_aeee6ebc3500ed42e8d818fd9d34fe85">
+                                        <div class="collapse apparatus-details" id="source_58157b1e79a9e298a37b842aba44614d">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Fragment, nur die letzten Zeilen des Br.</li>
@@ -566,9 +566,9 @@
                                         
                                         <span>Teil-Abschrift der dienstlich relevanten Passagen in einer Akte von Brühl der ehemaligen Hofoper (fraglich, ob im Geheimen Staatsarchiv oder im Opernarchiv selbst), seit 1945 verschollen </span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a7d33f86c8aaa2ba9d5d25c8c579aa0f"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_3338945710b8f2a7b954f14b0b1e8ce5"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_a7d33f86c8aaa2ba9d5d25c8c579aa0f">
+                                        <div class="collapse apparatus-details" id="source_3338945710b8f2a7b954f14b0b1e8ce5">
                                             
                                             
                                             <div>
@@ -581,7 +581,7 @@
                                                             
                                                             <span>Kopie: Ida Jähns, in: Weberiana Cl. II B, 1. a., Nr. 41, S. 43–44</span>
                                                               
-                                                            <div class="collapse" id="source_fbe16b8bfea909c14f77c53c794b6975">
+                                                            <div class="collapse" id="source_2f41dccd5400c10e0da44c45460e24fb">
                                                                 
                                                             </div>
                                                         </div>
@@ -591,7 +591,7 @@
                                                             
                                                             <span>Brühl, S. 45 (Nr. 43) (unvollst.!)</span>
                                                               
-                                                            <div class="collapse" id="source_18e75db43b2c6a2604ef2aab0e0810cc">
+                                                            <div class="collapse" id="source_59b413ad4982dcf545f366d2e42aea56">
                                                                 
                                                             </div>
                                                         </div>
@@ -817,7 +817,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042331.html
+++ b/testing/expected-results/letters/A042331.html
@@ -478,9 +478,9 @@
                                         
                                         <span>Wien (A), Österreichische Nationalbibliothek, Musiksammlung (A-Wn)<br /><i>Signatur</i>: (Autogr. 7/120-2) mit gedr. Beilage</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_038c33d2b91c4baf3ca12829b1174e6d"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_50bf0f316f36370abfb3271ddafed8de"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_038c33d2b91c4baf3ca12829b1174e6d">
+                                        <div class="collapse apparatus-details" id="source_50bf0f316f36370abfb3271ddafed8de">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. einschl. Adr.)</li>
@@ -675,7 +675,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042338.html
+++ b/testing/expected-results/letters/A042338.html
@@ -542,9 +542,9 @@
                                         
                                         <span>Verbleib unbekannt</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6a623555d3d687141ad5faf00d15ccd2"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_d74fa2e90e36656853dc39b3dc4b784d"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_6a623555d3d687141ad5faf00d15ccd2">
+                                        <div class="collapse apparatus-details" id="source_d74fa2e90e36656853dc39b3dc4b784d">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. o. Adr.)</li>
@@ -566,7 +566,7 @@
                                                             
                                                             <span>vollst. Faks. als Beilage ohne Ü bei Guy de Charnacé: Lettres de Gluck et de Weber. publiées par M. L. Nohl. Traduites par Guy de Charnacé. Paris, Henri Plon, 1870</span>
                                                               
-                                                            <div class="collapse" id="source_23fe2062e1bba756f2c3086708bea67a">
+                                                            <div class="collapse" id="source_87d50caec7ac76257d3a67413d63aeb3">
                                                                 
                                                             </div>
                                                         </div>
@@ -578,9 +578,9 @@
                                                             
                                                             <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ep. C. M. v. Weber 182</span>
                                                             <span>
-                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_9ac7c4561b82e670515ad4c203f01d2b"></a>
+                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_54dc76ecf20b366559caee777403b3f6"></a>
                                                             </span>  
-                                                            <div class="collapse" id="source_9ac7c4561b82e670515ad4c203f01d2b">
+                                                            <div class="collapse" id="source_54dc76ecf20b366559caee777403b3f6">
                                                                 <h4 class="media-heading">Quellenbeschreibung</h4>
                                                                         <ul>
                                                                             <li>Abschrift von unbekannter Hand</li>
@@ -812,7 +812,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042343.html
+++ b/testing/expected-results/letters/A042343.html
@@ -539,9 +539,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XVI), Bl. 89A/r u. v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_96fddf81ce3b6fe71fbacf447804807c"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_eabfbb9749d9b47ed088a9473e64131e"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_96fddf81ce3b6fe71fbacf447804807c">
+                                        <div class="collapse apparatus-details" id="source_eabfbb9749d9b47ed088a9473e64131e">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Entwurf von der Hand <a class="preview persons A000194" href="">Carl August Böttigers</a>, mit einigen Zusätzen Webers</li>
@@ -861,7 +861,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042351.html
+++ b/testing/expected-results/letters/A042351.html
@@ -530,9 +530,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. II A f 1, 14 mit Beilagen: Weberiana Cl. II A f 1, 13</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a347187e6d63c5fe713f608960969b2a"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_ed1c767badb9f8309534612e1fd6d0ef"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_a347187e6d63c5fe713f608960969b2a">
+                                        <div class="collapse apparatus-details" id="source_ed1c767badb9f8309534612e1fd6d0ef">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. einschl. Adr.) und 1 DBl. (4 b. S.)</li>
@@ -556,7 +556,7 @@
                                                             
                                                             <span>Leipzig (Deutschland), Leipziger Stadtbibliothek – Musikbibliothek (D-LEm)<br /><i>Signatur</i>: PB 37 (Nr. 64)</span>
                                                               
-                                                            <div class="collapse" id="source_c62aac032e58528d0087025e2185c357">
+                                                            <div class="collapse" id="source_d13a0c7540f1d135b7ea007715097047">
                                                                 
                                                             </div>
                                                         </div>
@@ -566,7 +566,7 @@
                                                             
                                                             <span>Rudorff: Westermanns illustrierte deutsche Monats-Hefte, 44. Jg. (1899), 87. Bd., S. 385</span>
                                                               
-                                                            <div class="collapse" id="source_a5d51e8aed5a7be3d683aa4527d5f06d">
+                                                            <div class="collapse" id="source_ad3c539488c7b5c246e7d6993c24d637">
                                                                 
                                                             </div>
                                                         </div>
@@ -576,7 +576,7 @@
                                                             
                                                             <span>Rudorff 1900, S. 212–214</span>
                                                               
-                                                            <div class="collapse" id="source_26b9c8e62316ceaf721077b2ae60d0ea">
+                                                            <div class="collapse" id="source_6e6322dc5948b1ccd60b654597ecd847">
                                                                 
                                                             </div>
                                                         </div>
@@ -784,7 +784,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042370.html
+++ b/testing/expected-results/letters/A042370.html
@@ -474,7 +474,7 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XIV), Bl. 83b/v</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_99240774d2c9bbaf557fba779e988ad0">
+                                        <div class="collapse apparatus-details" id="source_0862ad233ea0c32c7935d02a7da4d540">
                                             
                                             
                                             <div>
@@ -718,7 +718,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042418.html
+++ b/testing/expected-results/letters/A042418.html
@@ -515,9 +515,9 @@
                                         
                                         <span>Philadelphia (US), The Historical Society of Pennsylvania Library (US-PHhs)<br /><i>Signatur</i>: Wizter Family Papers, Butler Section, Box 35, Folder 9</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_4ef9d49d8a69096795af205f91292185"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_c75edbfeff7759fa601a463cc49fd1f1"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_4ef9d49d8a69096795af205f91292185">
+                                        <div class="collapse apparatus-details" id="source_c75edbfeff7759fa601a463cc49fd1f1">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S. einschl. Adr.)</li>
@@ -538,9 +538,9 @@
                                                             
                                                             <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. II B, 2ß, Nr. 1a, S. 885-886</span>
                                                             <span>
-                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_5fe74ff0411986f7779a49f14aa898d9"></a>
+                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_ac520deebd13b02f8db2448a0192b5f2"></a>
                                                             </span>  
-                                                            <div class="collapse" id="source_5fe74ff0411986f7779a49f14aa898d9">
+                                                            <div class="collapse" id="source_ac520deebd13b02f8db2448a0192b5f2">
                                                                 <h4 class="media-heading">Quellenbeschreibung</h4>
                                                                         <ul>
                                                                             <li>deutsche Übersetzung</li>
@@ -566,9 +566,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XVII), Bl. 90a/r</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_34b2dee426bd950441d98aea32174d02"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_9329a35c68676a006b8a62385704da42"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_34b2dee426bd950441d98aea32174d02">
+                                        <div class="collapse apparatus-details" id="source_9329a35c68676a006b8a62385704da42">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>mit Randbemerkungen von <a class="preview persons A000194" href="">Carl August Böttiger</a></li>
@@ -1462,7 +1462,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042426.html
+++ b/testing/expected-results/letters/A042426.html
@@ -520,9 +520,9 @@
                                         
                                         <span>San Marino (US), Henry E. Huntington Library and Art Gallery (US-SM)</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_70b44cc66d1881937395fc3b985482e9"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_d25c9956f70bd3c5b5175aa24eb6b995"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_70b44cc66d1881937395fc3b985482e9">
+                                        <div class="collapse apparatus-details" id="source_d25c9956f70bd3c5b5175aa24eb6b995">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S. einschl. Adr.)</li>
@@ -543,9 +543,9 @@
                                                             
                                                             <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. II B, 2ß, Nr. 3, S. 887–889</span>
                                                             <span>
-                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_975cd05e8853b9226e24ce84d546dfcf"></a>
+                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_6d64625ccd2d5025e42af98f78b74ef7"></a>
                                                             </span>  
-                                                            <div class="collapse" id="source_975cd05e8853b9226e24ce84d546dfcf">
+                                                            <div class="collapse" id="source_6d64625ccd2d5025e42af98f78b74ef7">
                                                                 <h4 class="media-heading">Quellenbeschreibung</h4>
                                                                         <ul>
                                                                             <li>dt. Übers.</li>
@@ -558,7 +558,7 @@
                                                             
                                                             <span>MMW II, S. 589–590</span>
                                                               
-                                                            <div class="collapse" id="source_b154dbb06bb9d5a9a8d5e6f1546fe38e">
+                                                            <div class="collapse" id="source_d6a7c1c23bc4620136ad42234493badc">
                                                                 
                                                             </div>
                                                         </div>
@@ -568,7 +568,7 @@
                                                             
                                                             <span>Planché, James Robinson: Recollections and Reflections, Vol.1, London 1872, S. 76–78</span>
                                                               
-                                                            <div class="collapse" id="source_7c132e7699683511e9ea97e624cedd3e">
+                                                            <div class="collapse" id="source_89ce4189da3a7ce6690cf4f49c8b7f8f">
                                                                 
                                                             </div>
                                                         </div>
@@ -578,7 +578,7 @@
                                                             
                                                             <span>Schloss, Albert: MANAGER'S EDITION. | OBERON | KING OF THE FAIRIES, | A ROMANTIC FAIRY OPERA, | IN THREE ACTS. | THE MUSIC | BY C. M. VON WEBER: | THE TEXT ADAPTED TO THE GERMAN STAGE, | BY THEODORE HELL, | (In German and English.) | TO WHICH ARE PREFIXED | THREE UNPUBLISHED LETTERS, WRITTEN IN ENGLISH, | BY THE COMPOSER, | TO | M. PLANCHÉ, | AUTHOR OF THE ORIGINAL OPERA, | NOW PERFORMING AT | THE THEATRE ROYAL DRURY LANE, | UNDER THE DIRECTION OF | HERR SCHUMANN, | DIRECTOR OF THE OPERA AT MAYENCE. | ACTING MANAGER, | MR. BUNN. | PRICE EIGHTEEN PENCE. | LONDON: | A. SCHLOSS, 12, BERNERS ST., OXFORD ST., | Foreign Bookseller and Fancy Stationer, by special appoiniment, to H. R. H., | the Duchess of Kent; | SOLD IN THE THEATRE. | And at all Principal Music and Booksellers, as named on wrappen., London 1841</span>
                                                               
-                                                            <div class="collapse" id="source_55f995564abb0b2d7f8b47b77abfcb4e">
+                                                            <div class="collapse" id="source_af2def97c1044a5ca86f936c799090a6">
                                                                 
                                                             </div>
                                                         </div>
@@ -601,7 +601,7 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XVII), Bl. 90a/v u. 90b/r</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_bcc0a23aaa708caf3364982c6ea765da">
+                                        <div class="collapse apparatus-details" id="source_2dbe244e4e5a9ac95319187b76127e0b">
                                             
                                             
                                             <div>
@@ -2218,7 +2218,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042458.html
+++ b/testing/expected-results/letters/A042458.html
@@ -533,9 +533,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ep. C. M. v. Weber 30</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_708e06e845af01a8def60a7aa7e12f9d"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_fe4a4af43ae70e3db76301d05bacd453"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_708e06e845af01a8def60a7aa7e12f9d">
+                                        <div class="collapse apparatus-details" id="source_fe4a4af43ae70e3db76301d05bacd453">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. einschl. Adr.)</li>
@@ -553,7 +553,7 @@
                                                             
                                                             <span class="tei_bibl">Schmidt, J.P.: „Drei weitere Briefe von C.M.von Weber an Hrn. Hofrath J.P. Schmitt“ in: Caecilia Bd. 9 (1828), Heft 35, S. 145f.</span>
                                                               
-                                                            <div class="collapse" id="source_2396635cdbda1dd37f6be279b90ac527">
+                                                            <div class="collapse" id="source_32996729c367c431b5ee55b78e8b3915">
                                                                 
                                                             </div>
                                                         </div>
@@ -563,7 +563,7 @@
                                                             
                                                             <span class="tei_bibl">La Mara: <span class="preview biblio A111835" data-ref="">„Aus romantischer Zeit“</span> in: Neue MZ 35 (1914), S. 216</span>
                                                               
-                                                            <div class="collapse" id="source_669f9b0c189a5354881712c0842e1cd8">
+                                                            <div class="collapse" id="source_7e3c24b6f826625c91601fd07443e9a9">
                                                                 
                                                             </div>
                                                         </div>
@@ -891,7 +891,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042464.html
+++ b/testing/expected-results/letters/A042464.html
@@ -490,9 +490,9 @@
                                         
                                         <span>Paris (F), Bibliothèque nationale de France, Département de la Musique (F-Pn)<br /><i>Signatur</i>: W.7(14)</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_afdb87a30e28e8aabe4f3e5470353db3"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_308ae396717de2a7917f6193cfb0d1ed"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_afdb87a30e28e8aabe4f3e5470353db3">
+                                        <div class="collapse apparatus-details" id="source_308ae396717de2a7917f6193cfb0d1ed">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>durchgehend lateinisch geschrieben</li>
@@ -512,7 +512,7 @@
                                                             
                                                             <span>Dünnebeil, Hans: Carl Maria von Weber: Ein Brevier. Berlin 1949, S. 316 (im Faks.)</span>
                                                               
-                                                            <div class="collapse" id="source_134ac613929bee20f1ae68c2a5d79b32">
+                                                            <div class="collapse" id="source_e73db9b4e531aef22e85d4c4f30f04ab">
                                                                 
                                                             </div>
                                                         </div>
@@ -535,9 +535,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XVII), Bl. 91v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_d4b859ee748babe312fd6f1444410790"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_7fb8ec74df429e83378513130c630d8b"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_d4b859ee748babe312fd6f1444410790">
+                                        <div class="collapse apparatus-details" id="source_7fb8ec74df429e83378513130c630d8b">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>durchgehend lateinisch geschrieben</li>
@@ -907,7 +907,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042466.html
+++ b/testing/expected-results/letters/A042466.html
@@ -523,9 +523,9 @@
                                         
                                         <span>Washington, D.C. (US), The Library of Congress, Music Division (US-Wc)<br /><i>Signatur</i>: ML95.W394</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_df3c57f0bc76dddec0da9bcfd46552a1"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a88ff7afec219a61b078c21827e75dc3"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_df3c57f0bc76dddec0da9bcfd46552a1">
+                                        <div class="collapse apparatus-details" id="source_a88ff7afec219a61b078c21827e75dc3">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S. einschl. Adr.)</li>
@@ -550,9 +550,9 @@
                                                             
                                                             <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. II B, 2ß, Nr. 5, S. 892–894</span>
                                                             <span>
-                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_5b522322c749d675ab5b38e24a0d7fbc"></a>
+                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_9f81daed3c963800d8a06325b6f3aa78"></a>
                                                             </span>  
-                                                            <div class="collapse" id="source_5b522322c749d675ab5b38e24a0d7fbc">
+                                                            <div class="collapse" id="source_9f81daed3c963800d8a06325b6f3aa78">
                                                                 <h4 class="media-heading">Quellenbeschreibung</h4>
                                                                         <ul>
                                                                             <li>dt. Übers.</li>
@@ -578,7 +578,7 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XVII), Bl. 90b/v u. 91r</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_1d2ab9102d4d64a8d4b261847aeef7ae">
+                                        <div class="collapse apparatus-details" id="source_a57c96dc87c347ff22c88c66b427d263">
                                             
                                             
                                             <div>
@@ -1652,7 +1652,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042486.html
+++ b/testing/expected-results/letters/A042486.html
@@ -475,9 +475,9 @@
                                         
                                         <span>St. Petersburg (RUS), Akademie der Wissenschaften, Institut für russische Literatur, Handschriftenabteilung (RUS-SPil)<br /><i>Signatur</i>: F. 244-1-57 (24536), Album der Fürstin M. A. Galizina, Fond A. S. Puschkin</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_adc6b6f2e2d1b5528b7efbd2a2d13706"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_0e390c750b111f726e85ba4bea5a57fa"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_adc6b6f2e2d1b5528b7efbd2a2d13706">
+                                        <div class="collapse apparatus-details" id="source_0e390c750b111f726e85ba4bea5a57fa">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>am rechten Seitenrand neben dem Datum Jahreszahl von fremder Hand (Tinte) hinzugefügt: „1825“</li>
@@ -661,7 +661,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042511.html
+++ b/testing/expected-results/letters/A042511.html
@@ -504,9 +504,9 @@
                                         
                                         <span class="tei_msName">Entwurf für die beiden gleichlautenden Briefe</span><br /><span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XVI), Bl. 89a/v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_17741d50379a23c84df08d0a0a0de0a5"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_237f24cfbc81be7230c49695be32cfcf"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_17741d50379a23c84df08d0a0a0de0a5">
+                                        <div class="collapse apparatus-details" id="source_237f24cfbc81be7230c49695be32cfcf">
                                             
                                             
                                             <div>
@@ -521,7 +521,7 @@
                                                             
                                                             <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. II B, 2ß, Nr. 19, S. 908-909</span>
                                                               
-                                                            <div class="collapse" id="source_94a181a4f5fce4997f8a8d11a0fba141">
+                                                            <div class="collapse" id="source_3c1b0fd13c579b4c27e60bdd9190172d">
                                                                 
                                                             </div>
                                                         </div>
@@ -542,9 +542,9 @@
                                         
                                         <span class="tei_msName">Original des Briefes für Guilbert de Pixérécourt</span><br /><span>Verbleib unbekannt</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a769151de59bb82465433a0cb3f44b02"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_cc4d722901bee3e87a5c79fba8b67586"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_a769151de59bb82465433a0cb3f44b02">
+                                        <div class="collapse apparatus-details" id="source_cc4d722901bee3e87a5c79fba8b67586">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 S., mit Stempel</li>
@@ -802,7 +802,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042513.html
+++ b/testing/expected-results/letters/A042513.html
@@ -504,9 +504,9 @@
                                         
                                         <span>Verbleib unbekannt</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_c700b08460de091da97848f67e48549e"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e9d41c8f3121b9701ccd765d547a2fee"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_c700b08460de091da97848f67e48549e">
+                                        <div class="collapse apparatus-details" id="source_e9d41c8f3121b9701ccd765d547a2fee">
                                             <h4 class="media-heading">Provenienz</h4>
                                                     <ul>
                                                         <li>Laverdet (Paris): Auktion (<span class="tei_date">7.-13.12. 1854</span>), Nr. 945 (unter <span class="tei_date">15. Oct. 1724</span>!) </li>
@@ -532,9 +532,9 @@
                                         
                                         <span>Cambridge (GB), Fitzwilliam Museum (GB-Cfm)</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_5f437dbefc242a92fe5ff4e975f25218"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_1b1302b13ca172c23915867c717e0de3"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_5f437dbefc242a92fe5ff4e975f25218">
+                                        <div class="collapse apparatus-details" id="source_1b1302b13ca172c23915867c717e0de3">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S.)</li>
@@ -559,7 +559,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="tei_hi_italic">Le Corsaire, Journal des spectacles, de la littérature, des arts, moeurs et modes</span>, Jg. 3, Nr. 925 (22. Januar 1826), S. 3 (dort unter falschem Datum 4. Januar 1826)</span>
                                                               
-                                                            <div class="collapse" id="source_11055444febd4ce5b2f57f1b4cd5eabf">
+                                                            <div class="collapse" id="source_5f7c404f55d151a9cf03eafc0871f398">
                                                                 
                                                             </div>
                                                         </div>
@@ -569,7 +569,7 @@
                                                             
                                                             <span id="letoile" class="tei_bibl"><span class="tei_hi_italic">L’Etoile</span>, Nr. 2099/3000 [sic] (22./23. Januar 1826), S. 4 (dort unter falschem Datum 4. Januar 1826)</span>
                                                               
-                                                            <div class="collapse" id="source_4664069b48abdb3ad5b3177e513e6ba1">
+                                                            <div class="collapse" id="source_92c903146af2f8d3c980886b2fab5101">
                                                                 
                                                             </div>
                                                         </div>
@@ -579,7 +579,7 @@
                                                             
                                                             <span id="kasselsche" class="tei_bibl">(Anonym) in: <span class="tei_hi_italic">Kasselsche Allgemeine Zeitung</span> Nr. 29 (29. Januar 1826), S. 125–126, dt. (unter 15. Dez.)</span>
                                                               
-                                                            <div class="collapse" id="source_2f4e9e312cadfb22f76e18a82577c6a9">
+                                                            <div class="collapse" id="source_51a9343be3a4a983e390fdce4611a06c">
                                                                 
                                                             </div>
                                                         </div>
@@ -589,7 +589,7 @@
                                                             
                                                             <span id="allgemeineZeitung" class="tei_bibl"><span class="tei_hi_italic">Allgemeine Zeitung</span>, Stuttgart/Tübingen, Jg. 1826, Beilage zu Nr. 37 (6. Februar), S. 145 (deutsche Übersetzung innerhalb des anonym publizierten Beitrags „Carl Maria von Weber und Castil-Blaze.“; dort unter falschem Datum 15. Dezember 1825)</span>
                                                               
-                                                            <div class="collapse" id="source_feecc5db16670df4d0eb220437c880ea">
+                                                            <div class="collapse" id="source_4661fd6b1a42f2e42ddedd9e0f90856e">
                                                                 
                                                             </div>
                                                         </div>
@@ -599,7 +599,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="tei_hi_italic">The Harmonicon</span>, vol. IV/1, Nr. 38 (Februar 1826), S. 41 (unter 15. Dez.; in englischer Übersetzung mit faksimilierter Unterschrift)</span>
                                                               
-                                                            <div class="collapse" id="source_fe7bfe8867d4c96490b731f0e5fbf321">
+                                                            <div class="collapse" id="source_37f2659babccb2a5aa25d7267cd8a4f9">
                                                                 
                                                             </div>
                                                         </div>
@@ -609,7 +609,7 @@
                                                             
                                                             <span id="jullien" class="tei_bibl">Adolphe Jullien: <span class="tei_hi_italic">Weber à Paris en 1826</span>, Paris 1877, S. 19–20 (unter 15. Dez. – nach Zeitung??)</span>
                                                               
-                                                            <div class="collapse" id="source_9c26a22b3090187729022d01cb26e1de">
+                                                            <div class="collapse" id="source_2f778d7a269c3fbe68f427bc97f046a3">
                                                                 
                                                             </div>
                                                         </div>
@@ -619,7 +619,7 @@
                                                             
                                                             <span class="tei_bibl">La Mara, <span class="tei_hi_italic">Musikerbriefe</span>, in: <span class="tei_hi_italic">Die neue Rundschau</span>, Jg. 24, Bd. 2, Heft 6 (Juni 1913), S. 809f. (in deutscher Übersetzung); dazu abschriftliche Vorlage von <a class="preview persons A005288" href="">Marie Lipsius</a> (auf Bl. 26f.) sowie korrigierte Druckfahne in <span class="tei_hi_italic">D-B</span>, Mus. ep. La Mara-Konvolut 6</span>
                                                               
-                                                            <div class="collapse" id="source_55cb43162f38cbce0f814b47e3d2cb88">
+                                                            <div class="collapse" id="source_377e4856d0ffa521cdd7668b7f8d2166">
                                                                 
                                                             </div>
                                                         </div>
@@ -629,7 +629,7 @@
                                                             
                                                             <span class="tei_bibl">Heidlberger, <span class="preview biblio A110336" data-ref="">Weber und Berlioz</span>, S. 480f.</span>
                                                               
-                                                            <div class="collapse" id="source_f90bce9f33468f3bcf68d44213bc9bf6">
+                                                            <div class="collapse" id="source_6fa08ae40aa370a754ddd1dc9524dcb8">
                                                                 
                                                             </div>
                                                         </div>
@@ -652,7 +652,7 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XVI), Bl. 89a/r</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_d25864cd448748131c6861b0197ad521">
+                                        <div class="collapse apparatus-details" id="source_35bacbc955d64fc3c428082e3088bc76">
                                             
                                             
                                             <div>
@@ -872,7 +872,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042514.html
+++ b/testing/expected-results/letters/A042514.html
@@ -578,9 +578,9 @@
                                         
                                         <span>New Haven (US), Yale University, Beinecke Rare Book and Manuscript Library (US-NHub), Frederick R. Koch Foundation</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b9efe892e5a2277e2c5e8ebd2e05008e"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e786cc94f501c7cbc65709de26f4763e"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_b9efe892e5a2277e2c5e8ebd2e05008e">
+                                        <div class="collapse apparatus-details" id="source_e786cc94f501c7cbc65709de26f4763e">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. einschl. Adr.)</li>
@@ -600,7 +600,7 @@
                                                             
                                                             <span class="tei_bibl">(Anonym), <span class="tei_hi_italic">Eine Reihenfolge von Briefen C. M. v. Webers</span>, in: <span class="tei_hi_italic">Caecilia</span>, Bd. 7 (1828), Heft 25, S. 36–38 (mit Auslassungen)</span>
                                                               
-                                                            <div class="collapse" id="source_b5255d6f1f3aefeb91e14db25b6067b1">
+                                                            <div class="collapse" id="source_b03d39b0d71ebd77f7d444ff2e058a58">
                                                                 
                                                             </div>
                                                         </div>
@@ -610,7 +610,7 @@
                                                             
                                                             <span>Bollert/Lemke 1972, S. 92–93</span>
                                                               
-                                                            <div class="collapse" id="source_4dc2619fa5726d489dd7cc9500b45838">
+                                                            <div class="collapse" id="source_fe43fc281a6a02646d405a1c2562253d">
                                                                 
                                                             </div>
                                                         </div>
@@ -830,7 +830,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042520.html
+++ b/testing/expected-results/letters/A042520.html
@@ -486,9 +486,9 @@
                                         
                                         <span>New York (US), Public Library (US-NYpl), MNY Bruno Walter Collection<br /><i>Signatur</i>: MNY Bruno Walter Collection</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_94d53541e7329ff5fd1a645a08a4080b"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_fce709ca67b4c13e7f86efd01d3bef5c"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_94d53541e7329ff5fd1a645a08a4080b">
+                                        <div class="collapse apparatus-details" id="source_fce709ca67b4c13e7f86efd01d3bef5c">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (2 b. S. einschl. Adr.)</li>
@@ -510,7 +510,7 @@
                                                             <span id="printKind1832" class="tei_bibl">Kind, Friedrich: <span class="tei_hi_italic">Briefe von Karl Maria v. Weber, an Friedrich Kind</span> in: <span class="tei_hi_italic">Zeitung für die elegante Welt</span>, 32. Jg., Nr. 123 (26.
                         Juni 1832), Sp. 979 (Nr. 15)</span>
                                                               
-                                                            <div class="collapse" id="source_a709fc5cdfa6c9d840883ea4b58b32f1">
+                                                            <div class="collapse" id="source_f7fec2786eb72d9e2aee39e6591fbac0">
                                                                 
                                                             </div>
                                                         </div>
@@ -520,7 +520,7 @@
                                                             
                                                             <span>Kind: Freischütz-Buch, S. 170 (Nr. 36) mit Faks. (Kind zweifelt die Datierung hier an und datiert den Brief in der Fußnote auf 18. oder 19. Dez.)</span>
                                                               
-                                                            <div class="collapse" id="source_d60f42531b17dc44fba58a2194f7cbfb">
+                                                            <div class="collapse" id="source_ebb872f649747b759dbe1563667e12af">
                                                                 
                                                             </div>
                                                         </div>
@@ -531,7 +531,7 @@
                                                             <span id="voerster2023" class="tei_bibl">Antiquariat Voerster, Katalog 51 (<span class="tei_date">Mai 2023</span>), Nr. 328 (Faksimile des Briefs als
                         Beilage zu <a class="preview letters A041890" href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A041890.html">A041890</a>)</span>
                                                               
-                                                            <div class="collapse" id="source_d59fc0c9f41d5e55759eb6f5975a32c0">
+                                                            <div class="collapse" id="source_370bfda2b9441ff475e59561b6086e76">
                                                                 
                                                             </div>
                                                         </div>
@@ -734,7 +734,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042522.html
+++ b/testing/expected-results/letters/A042522.html
@@ -657,9 +657,9 @@
                                         
                                         <span>New Haven (US), Yale University, Beinecke Rare Book and Manuscript Library (US-NHub), Frederick R. Koch Foundation</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6ad59bbd74873ce3e7163f8f377b639b"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e7301ebcc355d84ab5efb54543640734"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_6ad59bbd74873ce3e7163f8f377b639b">
+                                        <div class="collapse apparatus-details" id="source_e7301ebcc355d84ab5efb54543640734">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. einschl. Adr.)</li>
@@ -681,7 +681,7 @@
                                                             
                                                             <span id="printCaecilia1828" class="tei_bibl">(Anonym), <span class="tei_hi_italic">Eine Reihenfolge von Briefen C. M. v. Webers</span>, in: <span class="tei_hi_italic">Caecilia</span>, Bd. 7 (1828), Heft 25, S. 38 (unvollständig), fehlender Teil bei Gottfried Weber, <span class="tei_hi_italic">Weitere Nachrichten über die Echtheit des Mozartschen Requiems</span>, in: <span class="tei_hi_italic">Caecilia</span>, Bd. 4 (1826), Heft 16, S. 302–304</span>
                                                               
-                                                            <div class="collapse" id="source_e2a78ed2257c131d2622612dbecafda5">
+                                                            <div class="collapse" id="source_fb666a8ebbddee27564b5d703f48db1a">
                                                                 
                                                             </div>
                                                         </div>
@@ -691,7 +691,7 @@
                                                             
                                                             <span>MMW II, S. 620–623</span>
                                                               
-                                                            <div class="collapse" id="source_bcc4e8b822e98d94c993abcc63950c6b">
+                                                            <div class="collapse" id="source_f2d8191faa847e3aecad438dce1334c7">
                                                                 
                                                             </div>
                                                         </div>
@@ -701,7 +701,7 @@
                                                             
                                                             <span>Bollert/Lemke 1972, S. 93–96</span>
                                                               
-                                                            <div class="collapse" id="source_0d703e74853bb743199378b313d37eb0">
+                                                            <div class="collapse" id="source_b4caf64b429ae93e759340231064bf13">
                                                                 
                                                             </div>
                                                         </div>
@@ -922,7 +922,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042526.html
+++ b/testing/expected-results/letters/A042526.html
@@ -533,9 +533,9 @@
                                         
                                         <span>Cambridge (GB), Fitzwilliam Museum (GB-Cfm)</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6f30f38c96e5ba4d2e9775512d114744"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_115c21795aa5a0099529f6379d49ca9f"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_6f30f38c96e5ba4d2e9775512d114744">
+                                        <div class="collapse apparatus-details" id="source_115c21795aa5a0099529f6379d49ca9f">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S. einschl. Adr.)</li>
@@ -561,7 +561,7 @@
                                                             
                                                             <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. II B, 2ß, Nr. 11, S. 900–901 (dt. Übers.)</span>
                                                               
-                                                            <div class="collapse" id="source_b24a65eb707cb35769d4fbee57c25368">
+                                                            <div class="collapse" id="source_9f91084d9d907d2bca7e9fd349add430">
                                                                 
                                                             </div>
                                                         </div>
@@ -584,7 +584,7 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XVII), Bl. 92a/r u. v</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_116a27302c396387f6a31656fdcd01aa">
+                                        <div class="collapse apparatus-details" id="source_4a59c0662be83231e3af4576c6b3ec8e">
                                             
                                             
                                             <div>
@@ -1275,7 +1275,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042550.html
+++ b/testing/expected-results/letters/A042550.html
@@ -503,9 +503,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Handschriftenabteilung (D-Bsbha)<br /><i>Signatur</i>: Kgl. Schauspiele Berlin, Nachl. 230</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b680d5e90bc097c510c98f0e5e7d1cc6"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_fe22c0276be0b987b40118566bf48665"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_b680d5e90bc097c510c98f0e5e7d1cc6">
+                                        <div class="collapse apparatus-details" id="source_fe22c0276be0b987b40118566bf48665">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S.)</li>
@@ -533,9 +533,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. theor. 1018, Bl. 2</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_f0d84473ff17863ac2bea3809b045ba1"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a0952058b38dd60177e393999a414eff"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_f0d84473ff17863ac2bea3809b045ba1">
+                                        <div class="collapse apparatus-details" id="source_a0952058b38dd60177e393999a414eff">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Kopisten-Abschrift für Brühls <span class="tei_hi_italic">Acta Privata</span> zum <span class="tei_hi_italic">Oberon</span></li>
@@ -950,7 +950,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042556.html
+++ b/testing/expected-results/letters/A042556.html
@@ -471,9 +471,9 @@
                                         
                                         <span>Paris (F), Bibliothèque nationale de France (F-Pn)<br /><i>Signatur</i>: Lettres autographes, Vol. XX, Bl. 289</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_c7166857fe9fe30cf33dd199ec03b312"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_61c040c5edfef804b03dc3a95085c97f"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_c7166857fe9fe30cf33dd199ec03b312">
+                                        <div class="collapse apparatus-details" id="source_61c040c5edfef804b03dc3a95085c97f">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S. einschl. Adr.)</li>
@@ -706,7 +706,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042563.html
+++ b/testing/expected-results/letters/A042563.html
@@ -503,7 +503,7 @@
                                         <span>Dresden (D), Sächsisches Hauptstaatsarchiv (D-Dla)<br /><i>Signatur</i>: 10047, Amt Dresden, Nr. 3287 (Amtsgericht Dresden, Lit. W. Nr. 124), Bl.
                      16v?</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_df1c3b7f1f06d14007001954f763c74f">
+                                        <div class="collapse apparatus-details" id="source_12d524d4f0c08c658cf38029ff527393">
                                             
                                             
                                             <div>
@@ -717,7 +717,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042568.html
+++ b/testing/expected-results/letters/A042568.html
@@ -502,9 +502,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. V (Mappe XVIII), Abt. 4 A, Nr. 13 B</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_3594edeab430449de85f52a3115ba66a"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_ea6455c720d0c81290d6c8973c8d5498"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_3594edeab430449de85f52a3115ba66a">
+                                        <div class="collapse apparatus-details" id="source_ea6455c720d0c81290d6c8973c8d5498">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>4 Bl. (7 b. S.)</li>
@@ -704,7 +704,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042569.html
+++ b/testing/expected-results/letters/A042569.html
@@ -465,9 +465,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana C. V [Mappe IA], Abt. 3, Nr. 11a</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_f4c4002d9d2ea612a5fa6b39de1fe774"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_702188ac0cf7cb8bbc53531c9665a44d"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_f4c4002d9d2ea612a5fa6b39de1fe774">
+                                        <div class="collapse apparatus-details" id="source_702188ac0cf7cb8bbc53531c9665a44d">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S.)</li>
@@ -656,7 +656,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042582.html
+++ b/testing/expected-results/letters/A042582.html
@@ -467,9 +467,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: 55 Ep 96</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_159fb06b23f0f64e7331c1f7c4efbdf6"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_90d0332f6db68d0a3ddc3a47aafe6112"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_159fb06b23f0f64e7331c1f7c4efbdf6">
+                                        <div class="collapse apparatus-details" id="source_90d0332f6db68d0a3ddc3a47aafe6112">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. einschl. Adr.)</li>
@@ -702,7 +702,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042584.html
+++ b/testing/expected-results/letters/A042584.html
@@ -482,9 +482,9 @@
                                         
                                         <span>In Privatbesitz</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_d5e5f95cc9df481bed04dfe5377dbd47"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_c97bee2d1085b84e3f5187a2e71c6bd7"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_d5e5f95cc9df481bed04dfe5377dbd47">
+                                        <div class="collapse apparatus-details" id="source_c97bee2d1085b84e3f5187a2e71c6bd7">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. o. Adr.)</li>
@@ -683,7 +683,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042586.html
+++ b/testing/expected-results/letters/A042586.html
@@ -492,9 +492,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. V (Mappe IA), Abt. 3, Nr. 14a</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_559ccca53de75d410f0e7b1b4c79735c"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_898a428449b8e81c2218918694a0a926"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_559ccca53de75d410f0e7b1b4c79735c">
+                                        <div class="collapse apparatus-details" id="source_898a428449b8e81c2218918694a0a926">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Dbl., 1 Bl. (6 b. S. einschl. Adr.)</li>
@@ -752,7 +752,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042588.html
+++ b/testing/expected-results/letters/A042588.html
@@ -482,9 +482,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ep. K. Kreutzer 11</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_7ce45be833c5fb69037f1b1adf12475e"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_0f0476d2d590dbb8778bbfe207619872"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_7ce45be833c5fb69037f1b1adf12475e">
+                                        <div class="collapse apparatus-details" id="source_0f0476d2d590dbb8778bbfe207619872">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. einschl. Adr.)</li>
@@ -502,7 +502,7 @@
                                                             
                                                             <span class="tei_bibl">Till Gerrit Waidelich, <span class="tei_title">„Ich will es nicht, wie weiland Carl Maria, machen“. Conradin Kreutzer, Weber, Meyerbeer und Friedrich Kind. Vier Skizzen</span>, in: Weberiana 21 (2011), S. 94f.</span>
                                                               
-                                                            <div class="collapse" id="source_6aad458cb212c8366e40a91452ac003c">
+                                                            <div class="collapse" id="source_9d754eca7e8c8fe179bc58482751c90b">
                                                                 
                                                             </div>
                                                         </div>
@@ -690,7 +690,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042593.html
+++ b/testing/expected-results/letters/A042593.html
@@ -589,9 +589,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ep. P. Lindpaintner 14</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_aa086516f718f29b19a7dd805b83008f"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_9ffbfa106049affb58bb5f643055af41"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_aa086516f718f29b19a7dd805b83008f">
+                                        <div class="collapse apparatus-details" id="source_9ffbfa106049affb58bb5f643055af41">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. o. Adr.)</li>
@@ -607,7 +607,7 @@
                                                             
                                                             <span>Peter von Lindpaintner, Briefe. Gesamtausgabe (1809–1856). Hg. von Reiner Nägele, Göttingen 2001, S. 116–119, Nr. 99</span>
                                                               
-                                                            <div class="collapse" id="source_704042e3f2263b14dccf2ecc965e66cf">
+                                                            <div class="collapse" id="source_7e6ebd120226e8a643962e3d72dedf88">
                                                                 
                                                             </div>
                                                         </div>
@@ -833,7 +833,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042595.html
+++ b/testing/expected-results/letters/A042595.html
@@ -514,7 +514,7 @@
                                         
                                         <span class="biblio-entry book"><span class="author">Robert Prölss</span>, <span class="title">Beiträge zur Geschichte des Hoftheaters zu Dresden in actenmässiger Darstellung</span>, <span class="placeNYear">Erfurt o.J.</span>, S. 3–4</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_a76095611e375839e7cb8f56146702c4">
+                                        <div class="collapse apparatus-details" id="source_1df2c9a1dad737c117f2017f86412e6a">
                                             
                                             
                                             <div>
@@ -710,7 +710,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042599.html
+++ b/testing/expected-results/letters/A042599.html
@@ -487,9 +487,9 @@
                                         
                                         <span>Dresden (D), Sächsisches Hauptstaatsarchiv (D-Dla)<br /><i>Signatur</i>: 10026, Geheimes Kabinett Loc. 15147/02 (Bd.23), Bl. 77ff.</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_53714f9a7919333f0bb637ef79ba5dde"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_187ef930fbe4e0c6a972e95a7dff76ef"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_53714f9a7919333f0bb637ef79ba5dde">
+                                        <div class="collapse apparatus-details" id="source_187ef930fbe4e0c6a972e95a7dff76ef">
                                             
                                             
                                             <div>
@@ -502,7 +502,7 @@
                                                             
                                                             <span>Schneeberger, Bernhard Maria Heinrich, Die Musikerfamilie Fürstenau. Untersuchungen zu Leben und Werk, Teil I, Münster u. Hamburg 1992, S. 290–292</span>
                                                               
-                                                            <div class="collapse" id="source_68230e3eb3a88aa909ff1f952d97dc5e">
+                                                            <div class="collapse" id="source_04a94402c03067327fe14237ae91f78e">
                                                                 
                                                             </div>
                                                         </div>
@@ -691,7 +691,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042603.html
+++ b/testing/expected-results/letters/A042603.html
@@ -548,9 +548,9 @@
                                         
                                         <span>Wien (A), Gesellschaft der Musikfreunde in Wien, Bibliothek (A-Wgm)</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_3972a5d41f275ed0fe9020b6771e4a09"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6d78b7cbdf383fd327d57e69b7471fd1"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_3972a5d41f275ed0fe9020b6771e4a09">
+                                        <div class="collapse apparatus-details" id="source_6d78b7cbdf383fd327d57e69b7471fd1">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>2 Bl. (4 b. S. einschl. Adr.)</li>
@@ -974,7 +974,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042614.html
+++ b/testing/expected-results/letters/A042614.html
@@ -498,9 +498,9 @@
                                         
                                         <span>Erzhausen (D), Archiv des Verlags Robert Lienau (D-ERZrl)<br /><i>Signatur</i>: Kopierbuch Schlesinger 1826–1833, S. 9–10</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b92867f0f75114f1bbe94fa95a883107"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_72751e48e4e89e178672d3c0c0a61341"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_b92867f0f75114f1bbe94fa95a883107">
+                                        <div class="collapse apparatus-details" id="source_72751e48e4e89e178672d3c0c0a61341">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>ohne Unterschrift</li>
@@ -697,7 +697,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042638.html
+++ b/testing/expected-results/letters/A042638.html
@@ -496,7 +496,7 @@
                                         
                                         <span>Erzhausen (D), Archiv des Verlags Robert Lienau (D-ERZrl)<br /><i>Signatur</i>: Kopierbuch Schlesinger 1826–1833, S. 71–72</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_6235cc2f501e256737553153c75ff92d">
+                                        <div class="collapse apparatus-details" id="source_cff3b8ddb40210a4adb0455cc78a4390">
                                             
                                             
                                             <div>
@@ -676,7 +676,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042657.html
+++ b/testing/expected-results/letters/A042657.html
@@ -438,9 +438,9 @@
                                         
                                         <span>Prag (CZ), Národní muzeum – České muzeum hudby (CZ-Pnm)<br /><i>Signatur</i>: NM-ČMH G 13729/94 (Štěpánkovo album)</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a09f5ecb5be89e07f74978b8dbb6daa1"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_ab1b2ade6c940ba523612ec8ec138f17"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_a09f5ecb5be89e07f74978b8dbb6daa1">
+                                        <div class="collapse apparatus-details" id="source_ab1b2ade6c940ba523612ec8ec138f17">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>2 S. mit eigenhändiger Nachschrift</li>
@@ -466,7 +466,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="tei_hi_italic">Correspondenz Stiepanek. Kancelář Stavovského divadla v Praze 1800–1850. Die Kanzlei des Ständetheaters in Prag 1800–1850</span>, hg. von Petra Ježková und Jitka Ludvová, Prag 2023, S. 360f.</span>
                                                               
-                                                            <div class="collapse" id="source_c1f6449a029d9a00ea2d325cbaba2e21">
+                                                            <div class="collapse" id="source_acca90a39fb2cdb09609b99d0cc8b88a">
                                                                 
                                                             </div>
                                                         </div>
@@ -646,7 +646,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042680.html
+++ b/testing/expected-results/letters/A042680.html
@@ -446,9 +446,9 @@
                                         
                                         <span>Verbleib unbekannt</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b83cc48903b92529d56a5aa9ebb71431"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_7d54b9eb8668c88c7c6fb3c5d28a6ddf"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_b83cc48903b92529d56a5aa9ebb71431">
+                                        <div class="collapse apparatus-details" id="source_7d54b9eb8668c88c7c6fb3c5d28a6ddf">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>unterster Streifen eines eigenhändigen Briefes, enthaltend Ort, Datum und Unterschrift</li>
@@ -639,7 +639,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042699.html
+++ b/testing/expected-results/letters/A042699.html
@@ -666,9 +666,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ep. Caroline von Weber 2</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_774f148c41361b6c558fce550481f09c"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_fd140031c50809147931b505408015a4"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_774f148c41361b6c558fce550481f09c">
+                                        <div class="collapse apparatus-details" id="source_fd140031c50809147931b505408015a4">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>2 Bl. (4 b. S. einschl. Adr.)</li>
@@ -946,7 +946,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042706.html
+++ b/testing/expected-results/letters/A042706.html
@@ -615,9 +615,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ep. Caroline von Weber 5</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_5237ba75ed17374400dc3beea8023581"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b958318ed352c2064ce1d60b1999f610"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_5237ba75ed17374400dc3beea8023581">
+                                        <div class="collapse apparatus-details" id="source_b958318ed352c2064ce1d60b1999f610">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. einschl. Adr.)</li>
@@ -850,7 +850,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042724.html
+++ b/testing/expected-results/letters/A042724.html
@@ -714,9 +714,9 @@
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz,
                      Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ep. C. M. v. Weber 221</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b958318ed352c2064ce1d60b1999f610"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6ec0d06681c7b530e8593fdbf8c89f97"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_b958318ed352c2064ce1d60b1999f610">
+                                        <div class="collapse apparatus-details" id="source_6ec0d06681c7b530e8593fdbf8c89f97">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. einschl. Adr.)</li>
@@ -739,7 +739,7 @@
                                                             
                                                             <span>ED: Reise-Briefe 1823/1826, S. l30–135</span>
                                                               
-                                                            <div class="collapse" id="source_158ca3fec9ea9db843297d867bcd7b42">
+                                                            <div class="collapse" id="source_f78a20704f525a6f5e6ae7ffc27212e7">
                                                                 
                                                             </div>
                                                         </div>
@@ -1043,7 +1043,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042739.html
+++ b/testing/expected-results/letters/A042739.html
@@ -890,6 +890,5 @@ sie einen Tag früher gekomen wären, denn <span class="tei_ptr"></span>der dumm
         
         
         
-        
     </body>
 </html>

--- a/testing/expected-results/letters/A042768.html
+++ b/testing/expected-results/letters/A042768.html
@@ -605,9 +605,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ep. C. M. v. Weber 231</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_1028d048080621e6a46a22debb559675"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_cb8806de6cd8191f5d3941358bf9a06b"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_1028d048080621e6a46a22debb559675">
+                                        <div class="collapse apparatus-details" id="source_cb8806de6cd8191f5d3941358bf9a06b">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. einschl. Adr.)</li>
@@ -631,7 +631,7 @@
                                                             
                                                             <span>ED: MMW II, S. 693 (Auszug); Reise-Briefe, S. 179–184</span>
                                                               
-                                                            <div class="collapse" id="source_bd721bf92f7c0637bdf016e0dc1a5798">
+                                                            <div class="collapse" id="source_ce6e8c01e5ea0859db019bd8d58b2904">
                                                                 
                                                             </div>
                                                         </div>
@@ -924,7 +924,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042771.html
+++ b/testing/expected-results/letters/A042771.html
@@ -600,9 +600,9 @@
                                         
                                         <span>Verbleib unbekannt</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_24b9a70a8675c6a66e92f8fb2e81db72"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_5135573debbbb3f90af848b99b993c4e"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_24b9a70a8675c6a66e92f8fb2e81db72">
+                                        <div class="collapse apparatus-details" id="source_5135573debbbb3f90af848b99b993c4e">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S. einschl. Adr.)</li>
@@ -824,7 +824,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042796.html
+++ b/testing/expected-results/letters/A042796.html
@@ -622,9 +622,9 @@ Morgen habe ich <a class="preview orgs A080158" href="/exist/apps/WeGA-WebApp/de
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ep. Caroline von Weber 28</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_5135573debbbb3f90af848b99b993c4e"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_1028d048080621e6a46a22debb559675"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_5135573debbbb3f90af848b99b993c4e">
+                                        <div class="collapse apparatus-details" id="source_1028d048080621e6a46a22debb559675">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. einschl. Adr.)</li>
@@ -873,7 +873,6 @@ Morgen habe ich <a class="preview orgs A080158" href="/exist/apps/WeGA-WebApp/de
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042804.html
+++ b/testing/expected-results/letters/A042804.html
@@ -455,9 +455,9 @@
                                         
                                         <span>Verbleib unbekannt</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_9d8fc4a07a394be3054f40c7f69b7ecc"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_506eced578fb22772b7654428851560d"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_9d8fc4a07a394be3054f40c7f69b7ecc">
+                                        <div class="collapse apparatus-details" id="source_506eced578fb22772b7654428851560d">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S.)</li>
@@ -662,7 +662,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042809.html
+++ b/testing/expected-results/letters/A042809.html
@@ -532,9 +532,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. V (Mappe I A), Abt. 2, Nr. 16</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_92629cab2ff7bff4c5001645b516e2a0"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_649205889cdf42cd6a7e154b63f22268"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_92629cab2ff7bff4c5001645b516e2a0">
+                                        <div class="collapse apparatus-details" id="source_649205889cdf42cd6a7e154b63f22268">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. einschl. Adr.)</li>
@@ -861,7 +861,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A042943.html
+++ b/testing/expected-results/letters/A042943.html
@@ -655,9 +655,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 513</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a020a4c0c9a09cb9fcb3b7c47a4401dc"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_0c2557df702e8719aff308f26990a1cf"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_a020a4c0c9a09cb9fcb3b7c47a4401dc">
+                                        <div class="collapse apparatus-details" id="source_0c2557df702e8719aff308f26990a1cf">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>2 DBl., 1 Bl. (10 b. S. o. Adr.)</li>
@@ -677,7 +677,7 @@
                         Leipzig,</span> in: Weberiana, Heft 10 (2000), S. 13–16
                      </span>
                                                               
-                                                            <div class="collapse" id="source_941704538bd0bc83611b195370bc01c8">
+                                                            <div class="collapse" id="source_72ccea1da6ae30205a98781437f85c43">
                                                                 
                                                             </div>
                                                         </div>
@@ -943,7 +943,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043014.html
+++ b/testing/expected-results/letters/A043014.html
@@ -475,9 +475,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 1076</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_1e17ea4d951e40afa1f979d3be2086cb"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_d22cb4da4aee0b4e99ff9abc72172492"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_1e17ea4d951e40afa1f979d3be2086cb">
+                                        <div class="collapse apparatus-details" id="source_d22cb4da4aee0b4e99ff9abc72172492">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. o. Adr.)</li>
@@ -942,7 +942,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043064.html
+++ b/testing/expected-results/letters/A043064.html
@@ -513,9 +513,9 @@
                                         <span>Dresden (D), Sächsische Landesbibliothek – Staats- und
                      Universitätsbibliothek (D-Dl)<br /><i>Signatur</i>: Mus 4689-H-2</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_eb7751dd0f984e1b88575fd7dfd56183"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_7e44aa37296ad7b63480e11cae6f37c5"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_eb7751dd0f984e1b88575fd7dfd56183">
+                                        <div class="collapse apparatus-details" id="source_7e44aa37296ad7b63480e11cae6f37c5">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S.)</li>
@@ -714,7 +714,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043090.html
+++ b/testing/expected-results/letters/A043090.html
@@ -506,9 +506,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 485</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_439354ed10fe1d2c926ba334356f5a01"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_5650bb98da00a15f48c69ec0f66aaea4"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_439354ed10fe1d2c926ba334356f5a01">
+                                        <div class="collapse apparatus-details" id="source_5650bb98da00a15f48c69ec0f66aaea4">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. o. Adr.)</li>
@@ -739,7 +739,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043114.html
+++ b/testing/expected-results/letters/A043114.html
@@ -757,9 +757,9 @@
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz,
                      Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 50</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_9571c63f3bb0858c2d86c7f0f5eba1af"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_ec6f4d92616b9a3056c9e7ad8f6e5497"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_9571c63f3bb0858c2d86c7f0f5eba1af">
+                                        <div class="collapse apparatus-details" id="source_ec6f4d92616b9a3056c9e7ad8f6e5497">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S. o. Adr.) nebst 2 Bl. Anlagen</li>
@@ -777,9 +777,9 @@
                                                             
                                                             <span class="biblio-entry"><span class="author">Eveline Bartlitz</span>, <span class="title">„Verzeihung für den schlimmen Frager!“ Der
                               Briefwechsel zwischen Friedrich Wilhelm Jähns und Julius
-                              Benedict</span>, in: <span class="journalTitle">Weberiana. Mitteilungen der Internationalen Carl-Maria-von-Weber-Gesellschaft e. V.</span>, Heft 20 (2010), S. 66–72</span>
+                              Benedict</span>, in: <span class="journalTitle">Weberiana. Mitteilungen der Internationalen Carl-Maria-von-Weber-Gesellschaft e. V.</span><span class="imprint">, Heft 20 (2010), S. 66–72</span></span>
                                                               
-                                                            <div class="collapse" id="source_9941d7a60a8f62d153a4a1a057f5ba43">
+                                                            <div class="collapse" id="source_49980549249fc9fd1e08007ae9fddb31">
                                                                 
                                                             </div>
                                                         </div>
@@ -1109,7 +1109,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043123.html
+++ b/testing/expected-results/letters/A043123.html
@@ -519,9 +519,9 @@ dieselben nebst der <span class="tei_hi_latintype">Principal</span>stimme von <s
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 166</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_0e8f7ea8cf84de942a0dbdfab2453f4e"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b10f97e6450ec1f86d131576ddbaad91"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_0e8f7ea8cf84de942a0dbdfab2453f4e">
+                                        <div class="collapse apparatus-details" id="source_b10f97e6450ec1f86d131576ddbaad91">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. o. Adr.)</li>
@@ -734,7 +734,6 @@ dieselben nebst der <span class="tei_hi_latintype">Principal</span>stimme von <s
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043156.html
+++ b/testing/expected-results/letters/A043156.html
@@ -591,9 +591,9 @@
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz,
                      Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ep. Jähns, F. W. 20</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_fc7a148c882023fad443493b333a9761"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_4b6ddccc67b234f4d96bf3b1aa5bd347"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_fc7a148c882023fad443493b333a9761">
+                                        <div class="collapse apparatus-details" id="source_4b6ddccc67b234f4d96bf3b1aa5bd347">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S. einschl. Adr.)</li>
@@ -615,7 +615,7 @@
                         Briefwechsel zwischen Friedrich Wilhelm Jähns und Georg Eduard Goltermann,
                         in: Weberiana 15 (2005), S. 74f. (Auszug)</span>
                                                               
-                                                            <div class="collapse" id="source_1a4a4291808a2b627966ed99a44b42a9">
+                                                            <div class="collapse" id="source_868ab09755dd9c7d243f51b67be48df4">
                                                                 
                                                             </div>
                                                         </div>
@@ -855,7 +855,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043166.html
+++ b/testing/expected-results/letters/A043166.html
@@ -573,9 +573,9 @@
                                         
                                         <span>Dresden (D), Sächsische Landesbibliothek – Staats- und Universitätsbibliothek (D-Dl)<br /><i>Signatur</i>: Mscr.Dresd.h47, Nr. 7 sowie Beilage zu Nr. 6</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b1c1234986172844e43a554735bba0ea"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_214dff8ee2a4fcbe4e557019b7035248"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_b1c1234986172844e43a554735bba0ea">
+                                        <div class="collapse apparatus-details" id="source_214dff8ee2a4fcbe4e557019b7035248">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl., 1 Bl. (5 b. S. o. Adr.), dazu Beilage: 1 DBl. (2 b. S.)</li>
@@ -591,7 +591,7 @@
                                                             
                                                             <span class="tei_bibl">Ortrun Landmann, Eveline Bartlitz, Frank Ziegler, <span class="tei_hi_italic">Aus dem Briefwechsel Friedrich Wilhelm Jähns – Moritz Fürstenau. Eine Auswahl von Briefen und Mitteilungen der Jahre 1863–1885</span>, in: <span class="tei_hi_italic"><span class="preview biblio A110297" data-ref="">Weber-Studien</span></span>, Bd. 3, S. 110–112 (Nr. 11 und 11a)</span>
                                                               
-                                                            <div class="collapse" id="source_186826b1481ea19bb8c92b78d3963291">
+                                                            <div class="collapse" id="source_416058cf0ffb849fe163e1f2bd28df49">
                                                                 
                                                             </div>
                                                         </div>
@@ -815,7 +815,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043224.html
+++ b/testing/expected-results/letters/A043224.html
@@ -609,9 +609,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 706</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_d6333ee542b62fd1d4e3d502e9f07816"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_3c66d06894256a4483ad7649d606e715"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_d6333ee542b62fd1d4e3d502e9f07816">
+                                        <div class="collapse apparatus-details" id="source_3c66d06894256a4483ad7649d606e715">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>2 Bl. (3 b. S. o. Adr.)</li>
@@ -818,7 +818,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043259.html
+++ b/testing/expected-results/letters/A043259.html
@@ -445,9 +445,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 81</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_5ae539a905c80f9f9a0948e86ac86c5e"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_0a732e33cc30a98799b2005d9130e25d"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_5ae539a905c80f9f9a0948e86ac86c5e">
+                                        <div class="collapse apparatus-details" id="source_0a732e33cc30a98799b2005d9130e25d">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S. o. Adr.)</li>
@@ -675,7 +675,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043276.html
+++ b/testing/expected-results/letters/A043276.html
@@ -642,9 +642,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. V (Mappe I A), Abt. 3, Nr. 26c</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b8fa1ccce5952cb83914f9b9cc1d9ae3"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_9c82bd52b3c2258f0541734e8b64557a"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_b8fa1ccce5952cb83914f9b9cc1d9ae3">
+                                        <div class="collapse apparatus-details" id="source_9c82bd52b3c2258f0541734e8b64557a">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>2 DBl. (7 b. S. o. Adr.)</li>
@@ -670,9 +670,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 1099</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_1d2e45cc1083aa65f67d7fe7eb238b64"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_968dbf00a88a80241f3f7b8ef3a9339d"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_1d2e45cc1083aa65f67d7fe7eb238b64">
+                                        <div class="collapse apparatus-details" id="source_968dbf00a88a80241f3f7b8ef3a9339d">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl., 1 Bl. (6 b. S. o. Adr.)</li>
@@ -890,7 +890,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043313.html
+++ b/testing/expected-results/letters/A043313.html
@@ -545,9 +545,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 188</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_8c5f17649c694b01529c0498589e11f9"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_da291b25245634ce8aa29b56d38c3c79"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_8c5f17649c694b01529c0498589e11f9">
+                                        <div class="collapse apparatus-details" id="source_da291b25245634ce8aa29b56d38c3c79">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. o. Adr.)</li>
@@ -564,7 +564,7 @@
                                                             
                                                             <span class="tei_bibl">Ortrun Landmann, Eveline Bartlitz, Frank Ziegler, <span class="tei_hi_italic">Aus dem Briefwechsel Friedrich Wilhelm Jähns – Moritz Fürstenau. Eine Auswahl von Briefen und Mitteilungen der Jahre 1863–1885</span>, in: <span class="tei_hi_italic"><span class="preview biblio A110297" data-ref="">Weber-Studien</span></span>, Bd. 3, S. 114f. (Nr. 16)</span>
                                                               
-                                                            <div class="collapse" id="source_972b9c58818f26fef73c4f4883ac6deb">
+                                                            <div class="collapse" id="source_b8bb81e4533d4ad6669f3c2713065b29">
                                                                 
                                                             </div>
                                                         </div>
@@ -764,7 +764,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043327.html
+++ b/testing/expected-results/letters/A043327.html
@@ -435,9 +435,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 304</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_78e662045cc9d538310e6ecd172e42fc"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_16129a60e0800394aa389b6607721fcd"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_78e662045cc9d538310e6ecd172e42fc">
+                                        <div class="collapse apparatus-details" id="source_16129a60e0800394aa389b6607721fcd">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S. o. Adr.)</li>
@@ -643,7 +643,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043340.html
+++ b/testing/expected-results/letters/A043340.html
@@ -506,9 +506,9 @@
                                         
                                         <span>Hannover (D), Stadt-Archiv (D-HVsta), Autografensammlung<br /><i>Signatur</i>: Nr. 2302</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e672ec89e6b8e4da549d5f67db514c4b"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_26b68741027a79710ce784baa0ff44a0"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_e672ec89e6b8e4da549d5f67db514c4b">
+                                        <div class="collapse apparatus-details" id="source_26b68741027a79710ce784baa0ff44a0">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. o. Adr.)</li>
@@ -692,7 +692,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043376.html
+++ b/testing/expected-results/letters/A043376.html
@@ -467,9 +467,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 576</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b2f5244b2304b04c4a49518fcb72312f"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_299cb604f8a19803d9128747bbeccb58"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_b2f5244b2304b04c4a49518fcb72312f">
+                                        <div class="collapse apparatus-details" id="source_299cb604f8a19803d9128747bbeccb58">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (2 b. S. o. Adr.)</li>
@@ -661,7 +661,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043395.html
+++ b/testing/expected-results/letters/A043395.html
@@ -458,9 +458,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 43</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_f3049e707d8bdb54720b52b82206d365"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_daca8d0ca9335d611749fb508797897d"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_f3049e707d8bdb54720b52b82206d365">
+                                        <div class="collapse apparatus-details" id="source_daca8d0ca9335d611749fb508797897d">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S. o. Adr.)</li>
@@ -692,7 +692,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043401.html
+++ b/testing/expected-results/letters/A043401.html
@@ -446,9 +446,9 @@
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz,
                      Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 180</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_fbaeb20e3bbfd1a63e844141e6c6506d"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_ad92c57e9ebe33cdcbfff43c1f23f3a3"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_fbaeb20e3bbfd1a63e844141e6c6506d">
+                                        <div class="collapse apparatus-details" id="source_ad92c57e9ebe33cdcbfff43c1f23f3a3">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S.)</li>
@@ -644,7 +644,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043402.html
+++ b/testing/expected-results/letters/A043402.html
@@ -561,9 +561,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-DB)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 193</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_0a7c347ccab8ddeda2ac87b2ec341e5e"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e4383deb09144646b80976aa1b7850cf"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_0a7c347ccab8ddeda2ac87b2ec341e5e">
+                                        <div class="collapse apparatus-details" id="source_e4383deb09144646b80976aa1b7850cf">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S. o. Adr.) nebst. Beil. 1 Bl. (2 b. S.)</li>
@@ -579,7 +579,7 @@
                                                             
                                                             <span class="tei_bibl">Ortrun Landmann, Eveline Bartlitz, Frank Ziegler, <span class="tei_hi_italic">Aus dem Briefwechsel Friedrich Wilhelm Jähns – Moritz Fürstenau. Eine Auswahl von Briefen und Mitteilungen der Jahre 1863–1885</span>, in: <span class="tei_hi_italic"><span class="preview biblio A110297" data-ref="">Weber-Studien</span></span>, Bd. 3, S. 121 (Nr. 24)</span>
                                                               
-                                                            <div class="collapse" id="source_8678694c973827d669afcc2c64ce6b47">
+                                                            <div class="collapse" id="source_f431d8d8a4e4848c93fa7e56358e5366">
                                                                 
                                                             </div>
                                                         </div>
@@ -800,7 +800,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043403.html
+++ b/testing/expected-results/letters/A043403.html
@@ -704,9 +704,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 194</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_f28379e3f27e07131c8271c6919b73ff"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_3d7c047f42fcc931b33448f5a7d9f235"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_f28379e3f27e07131c8271c6919b73ff">
+                                        <div class="collapse apparatus-details" id="source_3d7c047f42fcc931b33448f5a7d9f235">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S. o. Adr.) nebst Beil. 2 Bl. (4 b. S.)</li>
@@ -724,7 +724,7 @@
                                                             
                                                             <span class="tei_bibl">Ortrun Landmann, Eveline Bartlitz, Frank Ziegler, <span class="tei_hi_italic">Aus dem Briefwechsel Friedrich Wilhelm Jähns – Moritz Fürstenau. Eine Auswahl von Briefen und Mitteilungen der Jahre 1863–1885</span>, in: <span class="tei_hi_italic"><span class="preview biblio A110297" data-ref="">Weber-Studien</span></span>, Bd. 3, S. 125, 122f., 124f. (Nr. 27, 25a und 26a)</span>
                                                               
-                                                            <div class="collapse" id="source_dce60f15c56b37fb36531d35c5250812">
+                                                            <div class="collapse" id="source_5c7cdb51bb3567d7259de2aa651efcd9">
                                                                 
                                                             </div>
                                                         </div>
@@ -1030,7 +1030,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043405.html
+++ b/testing/expected-results/letters/A043405.html
@@ -468,9 +468,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 220</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_1cf99b26354014a90e06a06ed06bc4e5"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_1dd784b50107d8faed84cf3478801be2"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_1cf99b26354014a90e06a06ed06bc4e5">
+                                        <div class="collapse apparatus-details" id="source_1dd784b50107d8faed84cf3478801be2">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S. o. Adr.)</li>
@@ -676,7 +676,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043406.html
+++ b/testing/expected-results/letters/A043406.html
@@ -543,9 +543,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 229</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_ea0f28cc36a91e6c4e09048c7d48f00b"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_161ad046d5d743e80bcc32c7e2dc464a"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_ea0f28cc36a91e6c4e09048c7d48f00b">
+                                        <div class="collapse apparatus-details" id="source_161ad046d5d743e80bcc32c7e2dc464a">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. einschl. Adr.)</li>
@@ -761,7 +761,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043412.html
+++ b/testing/expected-results/letters/A043412.html
@@ -500,9 +500,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 254</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_2070d1d13dd76dc57ca85958e27906b3"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e9a822907bdbd3eb3897fa81556283b4"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_2070d1d13dd76dc57ca85958e27906b3">
+                                        <div class="collapse apparatus-details" id="source_e9a822907bdbd3eb3897fa81556283b4">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl., 1 DBl. (4 b. S. o. Adr.)</li>
@@ -746,7 +746,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043426.html
+++ b/testing/expected-results/letters/A043426.html
@@ -484,9 +484,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 15</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_41d9fd9df6c73e92383d9fb719184ccd"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_85055f3a16be437f2cf4d7ffcc37e9e1"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_41d9fd9df6c73e92383d9fb719184ccd">
+                                        <div class="collapse apparatus-details" id="source_85055f3a16be437f2cf4d7ffcc37e9e1">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S. o. Adr.)</li>
@@ -710,7 +710,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043436.html
+++ b/testing/expected-results/letters/A043436.html
@@ -593,9 +593,9 @@
                                         <span>Weimar (D), Stiftung Weimarer Klassik, Goethe- und
                      Schiller-Archiv (D-WRgs)<br /><i>Signatur</i>: GSA 83/1329</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_313031af154780e6c461140d7202d28c"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_bab0f45ceec0fc0323de38430d71a8ef"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_313031af154780e6c461140d7202d28c">
+                                        <div class="collapse apparatus-details" id="source_bab0f45ceec0fc0323de38430d71a8ef">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>7 Bl. (13 b. S. o. Adr.)</li>
@@ -936,7 +936,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043496.html
+++ b/testing/expected-results/letters/A043496.html
@@ -417,9 +417,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 107</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_7cb66bae109b6dcf357e4ee878ed0229"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_029012dc9915c2c64a9ed0aedac9931c"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_7cb66bae109b6dcf357e4ee878ed0229">
+                                        <div class="collapse apparatus-details" id="source_029012dc9915c2c64a9ed0aedac9931c">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (2 b. S. o. Adr.)</li>
@@ -598,7 +598,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043522.html
+++ b/testing/expected-results/letters/A043522.html
@@ -561,9 +561,9 @@
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz,
                      Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 1117</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_1e9518b2f69fffd31f018de060df6683"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_0964bd17e08c721b4aa8df638d2b79e2"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_1e9518b2f69fffd31f018de060df6683">
+                                        <div class="collapse apparatus-details" id="source_0964bd17e08c721b4aa8df638d2b79e2">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S. o. Adr.)</li>
@@ -579,9 +579,9 @@
                                                             
                                                             <span class="biblio-entry"><span class="author">Eveline Bartlitz</span>, <span class="title">„Verzeihung für den schlimmen Frager!“ Der
                               Briefwechsel zwischen Friedrich Wilhelm Jähns und Julius
-                              Benedict</span>, in: <span class="journalTitle">Weberiana. Mitteilungen der Internationalen Carl-Maria-von-Weber-Gesellschaft e. V.</span>, Heft 20 (2010), S. 79–80</span>
+                              Benedict</span>, in: <span class="journalTitle">Weberiana. Mitteilungen der Internationalen Carl-Maria-von-Weber-Gesellschaft e. V.</span><span class="imprint">, Heft 20 (2010), S. 79–80</span></span>
                                                               
-                                                            <div class="collapse" id="source_0e4afa3e907d280667fabe12f832b2c0">
+                                                            <div class="collapse" id="source_712a95fda5cb03e5b6a90d545f6b02e9">
                                                                 
                                                             </div>
                                                         </div>
@@ -817,7 +817,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043563.html
+++ b/testing/expected-results/letters/A043563.html
@@ -428,9 +428,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 521</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6f4182de2c0e2aa5832bd4f6c0ea0e93"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_2e194cd62e7925812509a641f4653b05"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_6f4182de2c0e2aa5832bd4f6c0ea0e93">
+                                        <div class="collapse apparatus-details" id="source_2e194cd62e7925812509a641f4653b05">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (2 b. S. o. Adr.)</li>
@@ -636,7 +636,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043705.html
+++ b/testing/expected-results/letters/A043705.html
@@ -476,9 +476,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ep. A. Henselt 20</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_16af85e4705cbb71337e3bb5f790a1b0"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_c25881e8405b3b73545470ea8f3bb498"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_16af85e4705cbb71337e3bb5f790a1b0">
+                                        <div class="collapse apparatus-details" id="source_c25881e8405b3b73545470ea8f3bb498">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. o. Adr.)</li>
@@ -495,7 +495,7 @@
                                                             
                                                             <span class="biblio-entry book"><span class="author">Gebhard Kindl</span>, <span class="title">Adolph von Henselts Briefe.  Erstausgabe des im Henselt-Archiv des Stadtmuseums Schwabach gesammelten Briefwechsels von Adolph und Rosalie Henselt. Transliteriert von Gebhard und Ursula Kindl</span> (<span><span class="seriesTitle">Schriftenreihe des Stadtmuseums Schwabach</span>, Bd. 8</span>), <span class="placeNYear">Schwabach 2010</span>, S. 374–375</span>
                                                               
-                                                            <div class="collapse" id="source_8e0056ad2839a0fb74d41cadfc24d625">
+                                                            <div class="collapse" id="source_8fc7d2a292554ceedd46c024f36dfd7e">
                                                                 
                                                             </div>
                                                         </div>
@@ -731,7 +731,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043721.html
+++ b/testing/expected-results/letters/A043721.html
@@ -517,9 +517,9 @@
                                         
                                         <span>London (GB), The British Library (GB-Lbl)<br /><i>Signatur</i>: Add. MS. 47843, fol. 67–70</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b255ef44312300566779e9f8d746ced0"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a45a6a1ad7a4ad8fae7e32545dc4d5a5"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_b255ef44312300566779e9f8d746ced0">
+                                        <div class="collapse apparatus-details" id="source_a45a6a1ad7a4ad8fae7e32545dc4d5a5">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S. u. Umschlag)</li>
@@ -733,7 +733,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043743.html
+++ b/testing/expected-results/letters/A043743.html
@@ -466,9 +466,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 279</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_60c1e60cd37c63df309439366d7a2911"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a381aecc0d71b4f2706d3d3bcdd611c7"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_60c1e60cd37c63df309439366d7a2911">
+                                        <div class="collapse apparatus-details" id="source_a381aecc0d71b4f2706d3d3bcdd611c7">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. o. Adr.)</li>
@@ -711,7 +711,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043748.html
+++ b/testing/expected-results/letters/A043748.html
@@ -504,9 +504,9 @@
                                         
                                         <span>London (GB), The British Library (GB-Lbl)<br /><i>Signatur</i>: Add. MS. 47843, fol. 71–73</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_9ae3ac9d716b8a37406cbe54f1bb5330"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_62e09e05965abf3dbefb7e876c3be23e"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_9ae3ac9d716b8a37406cbe54f1bb5330">
+                                        <div class="collapse apparatus-details" id="source_62e09e05965abf3dbefb7e876c3be23e">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S. u. 1 Briefumschlag) mit Textverlusten am Rand (Datierung laut Poststempel), </li>
@@ -706,7 +706,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043803.html
+++ b/testing/expected-results/letters/A043803.html
@@ -445,9 +445,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. IV B (Mappe XVII), Nr. 1353 l</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_ae74b3fdea6832bda906ac5581ed79da"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_d81a7eb9f48442eeec6cc1e5ddc1ae89"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_ae74b3fdea6832bda906ac5581ed79da">
+                                        <div class="collapse apparatus-details" id="source_d81a7eb9f48442eeec6cc1e5ddc1ae89">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. o. Adr.)</li>
@@ -652,7 +652,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043817.html
+++ b/testing/expected-results/letters/A043817.html
@@ -486,9 +486,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 639</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_56d91152675f86e2a31957d659b2b1a0"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_4792ff9f00177a79ec13ff596a0cc09b"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_56d91152675f86e2a31957d659b2b1a0">
+                                        <div class="collapse apparatus-details" id="source_4792ff9f00177a79ec13ff596a0cc09b">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. o. Adr.)</li>
@@ -700,7 +700,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043904.html
+++ b/testing/expected-results/letters/A043904.html
@@ -529,9 +529,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 717</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_df562d49da55ad604905b5f23060754c"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_67b360247293e6f38584b7d045d2f6c7"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_df562d49da55ad604905b5f23060754c">
+                                        <div class="collapse apparatus-details" id="source_67b360247293e6f38584b7d045d2f6c7">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S. o. Adr.)</li>
@@ -737,7 +737,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A043965.html
+++ b/testing/expected-results/letters/A043965.html
@@ -501,9 +501,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 328</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_190afced99af909792139568dec7ef87"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6a4595ba8c9bb73abaf1760a679a0b54"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_190afced99af909792139568dec7ef87">
+                                        <div class="collapse apparatus-details" id="source_6a4595ba8c9bb73abaf1760a679a0b54">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. o. Adr.)</li>
@@ -799,7 +799,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044022.html
+++ b/testing/expected-results/letters/A044022.html
@@ -607,9 +607,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 1</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_efa46c8de7bb8c12c2006445b185d359"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_099f2deb13544c8337d6de4bf405e3b8"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_efa46c8de7bb8c12c2006445b185d359">
+                                        <div class="collapse apparatus-details" id="source_099f2deb13544c8337d6de4bf405e3b8">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (2 b. S. o. Adr.)</li>
@@ -809,7 +809,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044033.html
+++ b/testing/expected-results/letters/A044033.html
@@ -497,9 +497,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 153</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a50bf9547c9ada00ae732e666e0c7a05"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b7a384b65e3034a9459a9ffe52c3e2a6"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_a50bf9547c9ada00ae732e666e0c7a05">
+                                        <div class="collapse apparatus-details" id="source_b7a384b65e3034a9459a9ffe52c3e2a6">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl., 1 Bl. (6 b. S. o. Adr.)</li>
@@ -707,7 +707,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044043.html
+++ b/testing/expected-results/letters/A044043.html
@@ -465,9 +465,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 738</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_1a505319af3e44fe6509f76bfdd5d988"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_4dce2e71955e0df2d2078e0565f968c4"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_1a505319af3e44fe6509f76bfdd5d988">
+                                        <div class="collapse apparatus-details" id="source_4dce2e71955e0df2d2078e0565f968c4">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S. o. Adr.)</li>
@@ -663,7 +663,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044089.html
+++ b/testing/expected-results/letters/A044089.html
@@ -480,9 +480,9 @@
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz,
                      Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 313</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_cd42625171287e1483ea502cafa4c82e"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_c6fd64f9882c3465cf95fc114abf53c0"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_cd42625171287e1483ea502cafa4c82e">
+                                        <div class="collapse apparatus-details" id="source_c6fd64f9882c3465cf95fc114abf53c0">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. o. Adr.)</li>
@@ -704,7 +704,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044228.html
+++ b/testing/expected-results/letters/A044228.html
@@ -438,9 +438,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 362</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_63c624a5ded163cc379503d2897800d3"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_9d72a17db3077d2d9248ea4c3c33ae14"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_63c624a5ded163cc379503d2897800d3">
+                                        <div class="collapse apparatus-details" id="source_9d72a17db3077d2d9248ea4c3c33ae14">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S. o. Adr.)</li>
@@ -633,7 +633,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044270.html
+++ b/testing/expected-results/letters/A044270.html
@@ -626,9 +626,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 652</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e883c4d9a18372e73acd5f63f52511a3"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_15b6c79432baa8176f380eadfe076eb1"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_e883c4d9a18372e73acd5f63f52511a3">
+                                        <div class="collapse apparatus-details" id="source_15b6c79432baa8176f380eadfe076eb1">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl., 4 Bl. (9 b. S. o. Adr.)</li>
@@ -648,7 +648,7 @@
                                                             
                                                             <span class="tei_bibl">Tv in: <span class="tei_hi_italic"><span class="preview biblio A110054" data-ref="">Weberiana</span></span> 18 (2008), S. 99f., 103f., 108 (Ausschnitte)</span>
                                                               
-                                                            <div class="collapse" id="source_4cfa5e443395f6bb74c5c476054978e7">
+                                                            <div class="collapse" id="source_b9b43c06dfb808c7994c0462f2598f2b">
                                                                 
                                                             </div>
                                                         </div>
@@ -940,7 +940,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044308.html
+++ b/testing/expected-results/letters/A044308.html
@@ -472,9 +472,9 @@
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz,
                      Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 420</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_ce1615e4b574704c392cea61ed42164f"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_f3049e707d8bdb54720b52b82206d365"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_ce1615e4b574704c392cea61ed42164f">
+                                        <div class="collapse apparatus-details" id="source_f3049e707d8bdb54720b52b82206d365">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S. o. Adr.)</li>
@@ -690,7 +690,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044365.html
+++ b/testing/expected-results/letters/A044365.html
@@ -525,9 +525,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 656</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_37ea4479aca2d1d490ee3a0cc239a4ad"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_3471dc98c80e2d31394245933052cf7e"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_37ea4479aca2d1d490ee3a0cc239a4ad">
+                                        <div class="collapse apparatus-details" id="source_3471dc98c80e2d31394245933052cf7e">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. o. Adr.)</li>
@@ -545,7 +545,7 @@
                                                             
                                                             <span class="tei_bibl">Tv in: <span class="tei_hi_italic"><span class="preview biblio A110054" data-ref="">Weberiana</span></span> 18 (2008), S. 105–107</span>
                                                               
-                                                            <div class="collapse" id="source_cf0b54456e6a480c3b650210a71be71f">
+                                                            <div class="collapse" id="source_4c4c97670ad828b6a4c6707ac9f7b0f2">
                                                                 
                                                             </div>
                                                         </div>
@@ -789,7 +789,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044367.html
+++ b/testing/expected-results/letters/A044367.html
@@ -747,9 +747,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 658</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_97a54fc4f262a8f4bc7102c2628fd477"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e672ec89e6b8e4da549d5f67db514c4b"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_97a54fc4f262a8f4bc7102c2628fd477">
+                                        <div class="collapse apparatus-details" id="source_e672ec89e6b8e4da549d5f67db514c4b">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>2 Dbl. (8 b. S. ohne Adr.) nebst Beilage 2 Dbl., 1 Bl.(9 b. S.) in 4°.</li>
@@ -767,7 +767,7 @@
                                                             
                                                             <span class="tei_bibl">Tv in: <span class="tei_hi_italic"><span class="preview biblio A110054" data-ref="">Weberiana</span></span> 18 (2008), S. 111–116, 133, 140f. (Auszüge)</span>
                                                               
-                                                            <div class="collapse" id="source_4ecf133127320fb511f845f7ec9ea8d4">
+                                                            <div class="collapse" id="source_d330a349cb86bf3f1392e0762476475e">
                                                                 
                                                             </div>
                                                         </div>
@@ -1085,7 +1085,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044369.html
+++ b/testing/expected-results/letters/A044369.html
@@ -987,9 +987,9 @@ sowie die Anzahl derselben, ausfüllen. Dann will ich auch die, bereits von mir 
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Nr. 660</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_774f5c865a521f28d7d0abb32e1f8d73"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_78e662045cc9d538310e6ecd172e42fc"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_774f5c865a521f28d7d0abb32e1f8d73">
+                                        <div class="collapse apparatus-details" id="source_78e662045cc9d538310e6ecd172e42fc">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Dbl., 1 Bl. (6 b. S. ohne Adr.)</li>
@@ -1010,7 +1010,7 @@ sowie die Anzahl derselben, ausfüllen. Dann will ich auch die, bereits von mir 
                                                             
                                                             <span class="tei_bibl">Tv in: <span class="tei_hi_italic"><span class="preview biblio A110054" data-ref="">Weberiana</span></span> 18 (2008), S. 119f., 124–131, 134, 141–143 (Auszüge)</span>
                                                               
-                                                            <div class="collapse" id="source_0d8d7acf5fe90c6b43660504aa88c61f">
+                                                            <div class="collapse" id="source_836b9992782cbfd56d94671819be808a">
                                                                 
                                                             </div>
                                                         </div>
@@ -1560,7 +1560,6 @@ sowie die Anzahl derselben, ausfüllen. Dann will ich auch die, bereits von mir 
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044531.html
+++ b/testing/expected-results/letters/A044531.html
@@ -450,9 +450,9 @@ samt aller Kind- und Kindeskinder und sonstiger Hilfskräfte!</span></p>
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. MMX, Nr. 1712</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b7e7df9afb398f2d99ee28d82db721cd"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_5edd576aba16ab60e7af8a90a69d2901"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_b7e7df9afb398f2d99ee28d82db721cd">
+                                        <div class="collapse apparatus-details" id="source_5edd576aba16ab60e7af8a90a69d2901">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S. einschl. Adr.)</li>
@@ -635,7 +635,6 @@ samt aller Kind- und Kindeskinder und sonstiger Hilfskräfte!</span></p>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044532.html
+++ b/testing/expected-results/letters/A044532.html
@@ -504,9 +504,9 @@
                                         
                                         <span>Verbleib unbekannt</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a03f026c04be180f78da482dcb943afe"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_ec17078cefaacd2e909dd9cdb19b90d1"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_a03f026c04be180f78da482dcb943afe">
+                                        <div class="collapse apparatus-details" id="source_ec17078cefaacd2e909dd9cdb19b90d1">
                                             <h4 class="media-heading">Provenienz</h4>
                                                     <ul>
                                                         <li>? 1906 Wien, ÖNB</li>
@@ -522,7 +522,7 @@
                                                             
                                                             <span class="tei_bibl">Scherber, Ferdinand: „Ein Brief Friedrich Kinds an Peter Joseph Lindpaintner“, in: Neue Musik-Zeitung, Jg. 27, Nr. 18 (31. Mai 1906), S. 372</span>
                                                               
-                                                            <div class="collapse" id="source_33198a39e3b660d03ff928e4d381bfc8">
+                                                            <div class="collapse" id="source_84a7705f224bb8ee132718dbe37a7666">
                                                                 
                                                             </div>
                                                         </div>
@@ -710,7 +710,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044539.html
+++ b/testing/expected-results/letters/A044539.html
@@ -482,9 +482,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. II A e, Nr. 14</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_5e45e432288a1062a0170e0262ebfb41"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e969a1467d5b843fd41542aed34d9441"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_5e45e432288a1062a0170e0262ebfb41">
+                                        <div class="collapse apparatus-details" id="source_e969a1467d5b843fd41542aed34d9441">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S. o. Adr.)</li>
@@ -668,7 +668,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044684.html
+++ b/testing/expected-results/letters/A044684.html
@@ -393,7 +393,7 @@
                                         <span>Brief nicht vorhanden; Korrespondenz über Webers Tagebuch bzw.
                             andere Briefe erschlossen</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_06d3325158b63a4c8cf239ef170ec26f">
+                                        <div class="collapse apparatus-details" id="source_ac09e2746df81ba12707e26e1729f566">
                                             
                                             
                                             <div>
@@ -569,7 +569,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044698.html
+++ b/testing/expected-results/letters/A044698.html
@@ -475,9 +475,9 @@
                                         
                                         <span>Berlin (D), Geheimes Staatsarchiv – Preußischer Kulturbesitz (D-Bga)<br /><i>Signatur</i>: I HA Rep. 100, Nr. 1043, fol. 9–10</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_96e2631d3e62dcb21fa2b030398c6ea0"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_da591ab65b26d1163228d1f0fe92aea1"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_96e2631d3e62dcb21fa2b030398c6ea0">
+                                        <div class="collapse apparatus-details" id="source_da591ab65b26d1163228d1f0fe92aea1">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S.)</li>
@@ -688,7 +688,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044768.html
+++ b/testing/expected-results/letters/A044768.html
@@ -444,9 +444,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. theor. 1018, Bl. 3r</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_bdc832e6b71113f5029a8242540b37b5"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a4ca72d3b3cc600b91c2a0fbd8f90219"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_bdc832e6b71113f5029a8242540b37b5">
+                                        <div class="collapse apparatus-details" id="source_a4ca72d3b3cc600b91c2a0fbd8f90219">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Kopisten-Abschrift für Brühls <span class="tei_hi_italic">Acta Privata</span> zum <span class="tei_hi_italic">Oberon</span></li>
@@ -636,7 +636,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044817.html
+++ b/testing/expected-results/letters/A044817.html
@@ -431,7 +431,7 @@
                                         <span class="biblio-entry book"><span class="editor">Claude Colleer Abbott</span> (Hg.), <span class="title">The Letters of Gerard Manley Hopkins to Robert Bridges.  Ed. with notes and an Introduction<span class="edition">, 2. rev. ed.</span></span>, <span class="placeNYear">London, New York &amp; Toronto 1955</span>, S. 93–99<a class="noteMarker biblioNote" data-toggle="popover" data-ref="#C_01">*</a>
                                                     <div id="C_01" data-title="Bemerkung" style="display:none;">Nr. LXIV, Auszug: S. 98f.</div></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_ba3cbba1478a1fb70eceb707baf0ed5b">
+                                        <div class="collapse apparatus-details" id="source_9c9b01a559c8d468b7c1277c7ca25802">
                                             
                                             
                                             <div>
@@ -611,7 +611,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044840.html
+++ b/testing/expected-results/letters/A044840.html
@@ -385,7 +385,7 @@
                                         
                                         <span>Brief nicht vorhanden; Korrespondenz über Webers Tagebuch erschlossen</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_3b918ed3ca03927f1a7cb83ad885c4c3">
+                                        <div class="collapse apparatus-details" id="source_798e2e3ad2996cbd31c683209af7ad12">
                                             
                                             
                                             <div>
@@ -561,7 +561,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044869.html
+++ b/testing/expected-results/letters/A044869.html
@@ -398,9 +398,9 @@
                                         <span>Brief nicht vorhanden; Korrespondenz über Webers Tagebuch bzw.
                             andere Briefe erschlossen</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_2bfc506691cfdd6b093019cd25ab9ec9"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_f15a09904b98cb2060e55cd0f3de453f"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_2bfc506691cfdd6b093019cd25ab9ec9">
+                                        <div class="collapse apparatus-details" id="source_f15a09904b98cb2060e55cd0f3de453f">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul></ul>
                                                     <h4 class="media-heading">Beilagen</h4>
@@ -582,7 +582,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044924.html
+++ b/testing/expected-results/letters/A044924.html
@@ -482,9 +482,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. theor. 1018, Bl. 28f.</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_39ce4fe568eb6e5ef446a4abe948de20"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_5c11f4575c84257312ebcdfbef25cb1b"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_39ce4fe568eb6e5ef446a4abe948de20">
+                                        <div class="collapse apparatus-details" id="source_5c11f4575c84257312ebcdfbef25cb1b">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>2 Bl. (3 b. S.)</li>
@@ -689,7 +689,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044975.html
+++ b/testing/expected-results/letters/A044975.html
@@ -485,9 +485,9 @@
                                         
                                         <span>Ermlitz (D), Apelsche Kulturstiftung</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_052230e5faa00ec3e8f72f5acafb2199"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_8d743732b1ed36f2f7c03e68367dda39"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_052230e5faa00ec3e8f72f5acafb2199">
+                                        <div class="collapse apparatus-details" id="source_8d743732b1ed36f2f7c03e68367dda39">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S.)</li>
@@ -509,7 +509,7 @@
                                                             
                                                             <span class="tei_bibl">Ausschnitt in: <span class="preview biblio A110482" data-ref="">Bartlitz, <span class="tei_hi_italic">Weberiana</span>, Heft 22 (2012)</span>, S. 49</span>
                                                               
-                                                            <div class="collapse" id="source_dffa30619bf070a671481b5a087d1087">
+                                                            <div class="collapse" id="source_de360bc7a6e9e1389bed574b5844c4d3">
                                                                 
                                                             </div>
                                                         </div>
@@ -708,7 +708,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044987.html
+++ b/testing/expected-results/letters/A044987.html
@@ -460,9 +460,9 @@
                                         
                                         <span>Berlin (D), Archiv der Berlin-Brandenburgischen Akademie der Wissenschaften (D-Bbbaw)<br /><i>Signatur</i>: NL H. von Chézy 675</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_1c88b544bf3e2b6f28478fff90044850"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a9600f1b6e7bbce77c8ee93cab97b2d5"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_1c88b544bf3e2b6f28478fff90044850">
+                                        <div class="collapse apparatus-details" id="source_a9600f1b6e7bbce77c8ee93cab97b2d5">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S. o. Adr.)</li>
@@ -652,7 +652,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A044991.html
+++ b/testing/expected-results/letters/A044991.html
@@ -372,7 +372,7 @@
                                    <h4>Vorausgehend</h4>
                                    <ul>
                                        <li>
-                                           <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A042269.html">1824-03-03</a>:  an  <a href="" class="preview A001473 persons"></a>
+                                           <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A042125.html">1823-06-17</a>:  an  <a href="" class="preview A000288 persons"></a>
                                        </li>
                                             <li>
                                            <a href="/exist/apps/WeGA-WebApp/de/A080005/Korrespondenz/A042080.html">1823-12-04</a>:  von  <a href="" class="preview A080005 orgs"></a>
@@ -381,7 +381,7 @@
                                    <h4>Folgend</h4>
                                    <ul>
                                        <li>
-                                           <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A042302.html">1824-05-27</a>:  an  <a href="" class="preview A000561 persons"></a>
+                                           <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A042269.html">1824-03-03</a>:  an  <a href="" class="preview A001473 persons"></a>
                                        </li>
                                             <li>
                                            <a href="/exist/apps/WeGA-WebApp/de/A000213/Korrespondenz/A042699.html">1826-02-21</a>:  von  <a href="" class="preview A000213 persons"></a>
@@ -393,13 +393,13 @@
                                     <h3>Korrespondenzstelle</h3>
                                     <h4>Vorausgehend</h4>
                                     <ul>
-                                        <li>
-                                            <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A042269.html">1824-03-03</a>:  an  <a href="" class="preview A001473 persons"></a>
-                                        </li>
+                                        
                                     </ul>
                                     <h4>Folgend</h4>
                                     <ul>
-                                        
+                                        <li>
+                                            <a href="/exist/apps/WeGA-WebApp/de/A002068/Korrespondenz/A042269.html">1824-03-03</a>:  an  <a href="" class="preview A001473 persons"></a>
+                                        </li>
                                     </ul>
                                 
                             </div>
@@ -503,9 +503,9 @@
                                         
                                         <span>Dresden (D), Stadtarchiv (D-Dsta), Gesellschaft Harmonie (1780–1940)<br /><i>Signatur</i>: 13.15 (Konvolut 294: Gesellschaft Harmonie)</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_184adb01901ded3f6b8db48576dd968e"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6b97f4b1970193a1bebaadff1f5dc334"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_184adb01901ded3f6b8db48576dd968e">
+                                        <div class="collapse apparatus-details" id="source_6b97f4b1970193a1bebaadff1f5dc334">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S. o. Adr.)</li>
@@ -523,7 +523,7 @@
                                                             
                                                             <span>Hans Stegmann, Die Harmonie zu Dresden 1786-1936, Dresden 1936, S. 35</span>
                                                               
-                                                            <div class="collapse" id="source_2ba415312b6bf364d4fb4cab918fe8d4">
+                                                            <div class="collapse" id="source_322f1066d2ebf58f2dec0e2d51d97e74">
                                                                 
                                                             </div>
                                                         </div>
@@ -719,7 +719,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045029.html
+++ b/testing/expected-results/letters/A045029.html
@@ -499,9 +499,9 @@
                                         
                                         <span>Stuttgart (D), Hauptstaatsarchiv Stuttgart (D-Shsa)<br /><i>Signatur</i>: Prozeßakten Weber G 246, Bü 5, Fasz. 15 (1)</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_c99edc39bab43d5af579956f4d0b289a"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_787db77ab382a26e362fe0b454276886"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_c99edc39bab43d5af579956f4d0b289a">
+                                        <div class="collapse apparatus-details" id="source_787db77ab382a26e362fe0b454276886">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S.), mit Rundstempel „<span class="tei_unclear">VIER...</span> KREUZER“ mit Württemberg. Wappen</li>
@@ -738,7 +738,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045164.html
+++ b/testing/expected-results/letters/A045164.html
@@ -501,9 +501,9 @@ Davon später, wenn Sie es wünschen, einmahl ausführlich. Dem <span class="801
                                         
                                         <span>Leipzig (D), Stadtgeschichtliches Museum, Bibliothek (D-LEsm)<br /><i>Signatur</i>: A/2012/809</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a1a312e444848d6095cc3a14ab053a43"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_f5759e39564a24c4241c038980cf19b6"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_a1a312e444848d6095cc3a14ab053a43">
+                                        <div class="collapse apparatus-details" id="source_f5759e39564a24c4241c038980cf19b6">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. o. Adr.)</li>
@@ -805,7 +805,6 @@ Davon später, wenn Sie es wünschen, einmahl ausführlich. Dem <span class="801
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045181.html
+++ b/testing/expected-results/letters/A045181.html
@@ -554,9 +554,9 @@
                                         
                                         <span>Leipzig (D), Stadtgeschichtliches Museum, Bibliothek (D-LEsm)<br /><i>Signatur</i>: A/808/2010</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_8216df5c33ddcb1e5ef03ab173f01fcd"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_f63bb3923f346dc7d6835b145e58ab85"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_8216df5c33ddcb1e5ef03ab173f01fcd">
+                                        <div class="collapse apparatus-details" id="source_f63bb3923f346dc7d6835b145e58ab85">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>4 Bl. (8 b. S.)</li>
@@ -828,7 +828,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045183.html
+++ b/testing/expected-results/letters/A045183.html
@@ -532,9 +532,9 @@
                                         
                                         <span>Leipzig (D), Stadtgeschichtliches Museum, Bibliothek (D-LEsm)<br /><i>Signatur</i>: A/810/2010</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a274af6eb7dc0786733c86ed36de8295"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_38e0d2a6b9c89d271f012c1e8dcc309f"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_a274af6eb7dc0786733c86ed36de8295">
+                                        <div class="collapse apparatus-details" id="source_38e0d2a6b9c89d271f012c1e8dcc309f">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>4 Bl. (8 b. S.)</li>
@@ -836,7 +836,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045187.html
+++ b/testing/expected-results/letters/A045187.html
@@ -577,9 +577,9 @@
                                         
                                         <span>Leipzig (D), Stadtgeschichtliches Museum, Bibliothek (D-LEsm)<br /><i>Signatur</i>: Beilage zu: A/816/2010 sowie der Briefumschlag A/824/2010</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_acd1e90872ae10dd049cf31c84bd351b"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_0bfb5d48c62e87b2596fbd948427a74f"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_acd1e90872ae10dd049cf31c84bd351b">
+                                        <div class="collapse apparatus-details" id="source_0bfb5d48c62e87b2596fbd948427a74f">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Briefumschlag (Datum des Poststempels) und Beilage (Frage 4) mit 4 Bl. (8 b. S.)</li>
@@ -867,7 +867,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045274.html
+++ b/testing/expected-results/letters/A045274.html
@@ -502,9 +502,9 @@
                                         
                                         <span>Berlin (D), Archiv der Berlin-Brandenburgischen Akademie der Wissenschaften (D-Bbbaw)<br /><i>Signatur</i>: NL H. von Chézy 100</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e960e29a4eeba733fb016428857a2f35"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_1e9a944d4200303dfc769f464d5df5d7"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_e960e29a4eeba733fb016428857a2f35">
+                                        <div class="collapse apparatus-details" id="source_1e9a944d4200303dfc769f464d5df5d7">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. o. Adr.)</li>
@@ -737,7 +737,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045277.html
+++ b/testing/expected-results/letters/A045277.html
@@ -529,9 +529,9 @@
                                         
                                         <span>Berlin (D), Archiv der Berlin-Brandenburgischen Akademie der Wissenschaften (D-Bbbaw)<br /><i>Signatur</i>: NL H. von Chézy 881, Nr. 51 und 42</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_49757edc48c25ec4a04abb9e6b401bd6"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_3a725eabd38128df315d01620e2057bf"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_49757edc48c25ec4a04abb9e6b401bd6">
+                                        <div class="collapse apparatus-details" id="source_3a725eabd38128df315d01620e2057bf">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Brief durch zwei separat nummerierte Fragmente der Nachlassmappe überliefert; aufgrund von formalen (Tintefarbe, Papiertyp und -größe sowie Faltung, Schriftduktus) und inhaltlichen Gesichtspunkten zusammengehörig</li>
@@ -549,7 +549,7 @@
                                                             
                                                             <span class="tei_bibl">Wiedergabe in: Till Gerrit Waidelich, „Durch Webers Betrügerey die Hände so gebunden“. Helmina von Chézys Kampf um die Urheberrechte an ihrem Euryanthe-Libretto in ihrer Korrespondenz und Brief-Entwürfen, in: Weberiana. Mitteilungen der Internationalen Carl-Maria-von-Weber-Gesellschaft e. V., Heft 18 (2008), S. 46–49 (mit kleineren Auslassungen)</span>
                                                               
-                                                            <div class="collapse" id="source_2a8e9d472ef42c21bd93fa94327465d3">
+                                                            <div class="collapse" id="source_e172e8f8ad7c7de41c2d5f4be12ed86b">
                                                                 
                                                             </div>
                                                         </div>
@@ -827,7 +827,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045291.html
+++ b/testing/expected-results/letters/A045291.html
@@ -449,7 +449,7 @@
                                         
                                         <span class="biblio-entry book"><span class="editor">Hermann Uhde</span> (Hg.), <span class="title">Denkwürdigkeiten des Schauspielers, Schauspieldichters und Schauspieldirectors Friedrich Ludwig Schmidt (1772–1841)</span>,  Bd. 2, <span class="placeNYear">Hamburg 1875</span>, S. 254</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_771711aeff56134844a73b6dea178cf0">
+                                        <div class="collapse apparatus-details" id="source_3aeeffc382095f71f710dad1ca3f5e6d">
                                             
                                             
                                             <div>
@@ -643,7 +643,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045306.html
+++ b/testing/expected-results/letters/A045306.html
@@ -435,7 +435,7 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. theor. C. M. v. Weber WFN 5, Bl. 26v</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_c459f0b0a5781ae7f32698d50d43e3b3">
+                                        <div class="collapse apparatus-details" id="source_fa8c3fd75bf5854062a603b3f062f43a">
                                             
                                             
                                             <div>
@@ -623,7 +623,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045317.html
+++ b/testing/expected-results/letters/A045317.html
@@ -433,7 +433,7 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. theor. C. M. v. Weber WFN 5, Bl. 47r</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_1436f7df12ada25a1f42aa3fd4393dc3">
+                                        <div class="collapse apparatus-details" id="source_1ea008348169b01555f98754f99bdfe5">
                                             
                                             
                                             <div>
@@ -641,7 +641,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045335.html
+++ b/testing/expected-results/letters/A045335.html
@@ -436,7 +436,7 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. theor. C. M. v. Weber WFN 5, Bl. 75v</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_83030e0ae457adab250d5c5a3d9ce8ce">
+                                        <div class="collapse apparatus-details" id="source_d80b7ec81fee93c80cf2a2f72aa5ac73">
                                             
                                             
                                             <div>
@@ -616,7 +616,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045347.html
+++ b/testing/expected-results/letters/A045347.html
@@ -451,7 +451,7 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. theor. C. M. v. Weber WFN 5, Bl. 92r</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_8d6edeaf84aa5d7f3e1c25d1bccea466">
+                                        <div class="collapse apparatus-details" id="source_ef59a0298d3e7a354a6a284451bbd047">
                                             
                                             
                                             <div>
@@ -631,7 +631,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045348.html
+++ b/testing/expected-results/letters/A045348.html
@@ -427,7 +427,7 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. theor. C. M. v. Weber WFN 5, Bl. 97r/v</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_0aa50db52543b9f43d31ba1a346a8f7f">
+                                        <div class="collapse apparatus-details" id="source_b87dd93dc4914115604014422891bbc7">
                                             
                                             
                                             <div>
@@ -607,7 +607,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045361.html
+++ b/testing/expected-results/letters/A045361.html
@@ -436,7 +436,7 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. theor. C. M. v. Weber WFN 5, Bl. 155r</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_194cbb3745f7f04df8f863b11a1f7902">
+                                        <div class="collapse apparatus-details" id="source_7ec7a21744a0999ec3e4197b3eb75c5f">
                                             
                                             
                                             <div>
@@ -616,7 +616,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045363.html
+++ b/testing/expected-results/letters/A045363.html
@@ -396,9 +396,9 @@
                                         
                                         <span>verschollen</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_cffed1fab4cf271d7948c2f9a8225d28"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_5167eeb88fcb1a5a06a900bc989fdefc"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_cffed1fab4cf271d7948c2f9a8225d28">
+                                        <div class="collapse apparatus-details" id="source_5167eeb88fcb1a5a06a900bc989fdefc">
                                             <h4 class="media-heading">Provenienz</h4>
                                                     <ul>
                                                         <li>
@@ -583,7 +583,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045397.html
+++ b/testing/expected-results/letters/A045397.html
@@ -494,9 +494,9 @@
                                         
                                         <span>Stuttgart (D), Hauptstaatsarchiv Stuttgart (D-Shsa)<br /><i>Signatur</i>: Prozeßakten Weber, G 246, Bü 5, Fasz. 17</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_46d0a38fcd67788c5a554693235c30a9"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e501e5bc52dae98cd743adc4ac8632cd"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_46d0a38fcd67788c5a554693235c30a9">
+                                        <div class="collapse apparatus-details" id="source_e501e5bc52dae98cd743adc4ac8632cd">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S. einschl. Adr.)</li>
@@ -699,7 +699,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045406.html
+++ b/testing/expected-results/letters/A045406.html
@@ -475,9 +475,9 @@
                                         
                                         <span>Verbleib unbekannt</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_73acabb9b8bbbe41e0b31a6f9f2144dc"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_094ed6e55f31fc90abfac3b374ccf067"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_73acabb9b8bbbe41e0b31a6f9f2144dc">
+                                        <div class="collapse apparatus-details" id="source_094ed6e55f31fc90abfac3b374ccf067">
                                             <h4 class="media-heading">Provenienz</h4>
                                                     <ul>
                                                         <li>ehemals Berlin, Königliche Hausbibliothek, Signatur: M 5609, 
@@ -494,7 +494,7 @@
                                                             
                                                             <span>Carl Maria von Weber. Tanzbüchlein fürs Klavier, hg. von Gottfried Wolters, Köln: Bisping (1939) (mit Faks.)</span>
                                                               
-                                                            <div class="collapse" id="source_27e9660b6be071a90f2a6a0641d60f12">
+                                                            <div class="collapse" id="source_de1b904641b4692ffe392645bf943ded">
                                                                 
                                                             </div>
                                                         </div>
@@ -504,7 +504,7 @@
                                                             
                                                             <span>Musica, Jg. 13 (1959), S. 203 (mit Faks.)</span>
                                                               
-                                                            <div class="collapse" id="source_a206dd0a066a490d991acc659968c06c">
+                                                            <div class="collapse" id="source_691363022167b0f277d8f21188a6203a">
                                                                 
                                                             </div>
                                                         </div>
@@ -684,7 +684,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045428.html
+++ b/testing/expected-results/letters/A045428.html
@@ -469,9 +469,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. theor. 1018, Bl. 3r–3v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_5bf5bd08e3ffc4a3506330a6db0b9f7f"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_46ef7af7976d8b0bd8a8692fcf617503"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_5bf5bd08e3ffc4a3506330a6db0b9f7f">
+                                        <div class="collapse apparatus-details" id="source_46ef7af7976d8b0bd8a8692fcf617503">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Kopisten-Abschrift für Brühls <span class="tei_hi_italic">Acta Privata</span> zum <span class="tei_hi_italic">Oberon</span></li>
@@ -661,7 +661,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045429.html
+++ b/testing/expected-results/letters/A045429.html
@@ -521,9 +521,9 @@
                                         
                                         <span>Frankfurt/Main (D), Universitätsbibliothek (D-F)<br /><i>Signatur</i>: Mus. Autogr. J. A. Benedict  1 </span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6a7e51344d9b6ceff9397a0bc8826d26"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6ed6260870e11c062e3943048796bcb6"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_6a7e51344d9b6ceff9397a0bc8826d26">
+                                        <div class="collapse apparatus-details" id="source_6ed6260870e11c062e3943048796bcb6">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S. einschl. Adr.)</li>
@@ -723,7 +723,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045464.html
+++ b/testing/expected-results/letters/A045464.html
@@ -513,9 +513,9 @@
                                         
                                         <span>Stuttgart (D), Hauptstaatsarchiv Stuttgart (D-Shsa)<br /><i>Signatur</i>: Prozeßakten Weber G 246, Bü 4</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_be0bd6f1ea91f4288ec6254b3d0fb533"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_09ab594c40115b331b86adcba7d4d964"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_be0bd6f1ea91f4288ec6254b3d0fb533">
+                                        <div class="collapse apparatus-details" id="source_09ab594c40115b331b86adcba7d4d964">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (2 b. S.) u. 1 Bl. Einlage (1 b. S.)</li>
@@ -735,7 +735,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045477.html
+++ b/testing/expected-results/letters/A045477.html
@@ -475,9 +475,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. theor. 1018, Bl. 41 sowie (leeres Bl.) zwischen Bl. 46 und 47 (ungezählt)</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_f8ec752a082fe9e2b18ce332ac697061"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_3d6997ec137246cba3453360654788f7"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_f8ec752a082fe9e2b18ce332ac697061">
+                                        <div class="collapse apparatus-details" id="source_3d6997ec137246cba3453360654788f7">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>2 Bl. (2 b. S.)</li>
@@ -494,7 +494,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A110269" data-ref="">Teilveröffentlichung</span>: Joachim Veit, <span class="tei_hi_italic">Wranitzky contra Weber</span> (S. 1447)</span>
                                                               
-                                                            <div class="collapse" id="source_e19d7eb821678e245db694f994e85641">
+                                                            <div class="collapse" id="source_5f04172869a704bfa40f30847f012ef2">
                                                                 
                                                             </div>
                                                         </div>
@@ -689,7 +689,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045540.html
+++ b/testing/expected-results/letters/A045540.html
@@ -490,7 +490,7 @@
                                         
                                         <span>Erzhausen (D), Archiv des Verlags Robert Lienau (D-ERZrl)<br /><i>Signatur</i>: Kopierbuch Schlesinger 1826–1833, S. 226–228</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_2e9cf225d69327b8995dff95c60dfa19">
+                                        <div class="collapse apparatus-details" id="source_dc6a613cf27355047e0ee9815244cd2b">
                                             
                                             
                                             <div>
@@ -720,7 +720,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045605.html
+++ b/testing/expected-results/letters/A045605.html
@@ -490,9 +490,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ep. G. Weber 13</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_3fa6fde3f0b7d9fb753ba9abecf6e160"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_9d1aba550da1c176596bed627f47d0c0"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_3fa6fde3f0b7d9fb753ba9abecf6e160">
+                                        <div class="collapse apparatus-details" id="source_9d1aba550da1c176596bed627f47d0c0">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. o. Adr.)</li>
@@ -701,7 +701,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045668.html
+++ b/testing/expected-results/letters/A045668.html
@@ -470,9 +470,9 @@
                                         
                                         <span>München (D), Theatermuseum, Bibliothek (D-Mth), Nachlaß Birch‑Pfeiffer<br /><i>Signatur</i>: Briefe (No. 27.535)</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_f25c62759ddede91413f501bfd22f793"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_ba0a5b27338937d48d8df08693bdd347"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_f25c62759ddede91413f501bfd22f793">
+                                        <div class="collapse apparatus-details" id="source_ba0a5b27338937d48d8df08693bdd347">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. einschl. Adr.)</li>
@@ -655,7 +655,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045697.html
+++ b/testing/expected-results/letters/A045697.html
@@ -466,9 +466,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ep. Max Maria von Weber 1</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_29e627fdc82544b51e41f48169885af8"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_cd11927399e9c5c60c3057878543761b"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_29e627fdc82544b51e41f48169885af8">
+                                        <div class="collapse apparatus-details" id="source_cd11927399e9c5c60c3057878543761b">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. o. Adr.)</li>
@@ -672,7 +672,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045721.html
+++ b/testing/expected-results/letters/A045721.html
@@ -496,9 +496,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: N. Mus. Nachl. 97, M/22</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_679a55f71fc5514128299b775b99a3d8"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_1d1aad2cab5bf9bedde247e65e7bd97b"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_679a55f71fc5514128299b775b99a3d8">
+                                        <div class="collapse apparatus-details" id="source_1d1aad2cab5bf9bedde247e65e7bd97b">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S.) und 1 Umschlag</li>
@@ -515,7 +515,7 @@
                                                             
                                                             <span>Meyerbeer‑Briefe, Bd. 5 (Henze‑Döhring), S. 57–58</span>
                                                               
-                                                            <div class="collapse" id="source_39d83ed3601581af6aa9bf392498bedd">
+                                                            <div class="collapse" id="source_5a337394c64e7e4024649cd660cc0a14">
                                                                 
                                                             </div>
                                                         </div>
@@ -703,7 +703,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045731.html
+++ b/testing/expected-results/letters/A045731.html
@@ -502,9 +502,9 @@
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz,
                      Musikabteilung (D-B)<br /><i>Signatur</i>: N. Mus. Nachl. 97, M/124</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_ff672b35af53a61693c5ece7f538d6aa"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_2497fe8029f17249ad2fa6e8e996886b"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_ff672b35af53a61693c5ece7f538d6aa">
+                                        <div class="collapse apparatus-details" id="source_2497fe8029f17249ad2fa6e8e996886b">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. einschl. Adr.)</li>
@@ -523,7 +523,7 @@
                                                             
                                                             <span>Meyerbeer‑Briefe, Bd. 5 (Henze‑Döhring), S. 458–459</span>
                                                               
-                                                            <div class="collapse" id="source_ec222585c84c091dfb07340fd17c4b97">
+                                                            <div class="collapse" id="source_16526e647248c78a0aa1cdb25e14bb9a">
                                                                 
                                                             </div>
                                                         </div>
@@ -533,7 +533,7 @@
                                                             
                                                             <span>Weberiana 27(2017), S. 88 (Auszug)</span>
                                                               
-                                                            <div class="collapse" id="source_9ea0525d12e3cd8ed50dd3b385498b2a">
+                                                            <div class="collapse" id="source_7372379bd8801ea24b8d76637d984649">
                                                                 
                                                             </div>
                                                         </div>
@@ -729,7 +729,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045749.html
+++ b/testing/expected-results/letters/A045749.html
@@ -447,9 +447,9 @@
                                         
                                         <span>Leipzig (D), Sächsisches Staatsarchiv, Staatsarchiv Leipzig (D-LEsta)<br /><i>Signatur</i>: Musikverlag Peters, Nr. 5028 (Kopierbuch 1844–1855), S. 520</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_c20970fd134922407b893f20f909c6e1"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_41cc09495c5804876a26d1005369f4ab"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_c20970fd134922407b893f20f909c6e1">
+                                        <div class="collapse apparatus-details" id="source_41cc09495c5804876a26d1005369f4ab">
                                             
                                             
                                             <div>
@@ -462,7 +462,7 @@
                                                             
                                                             <span>Weberiana 10 (2000), S. 59</span>
                                                               
-                                                            <div class="collapse" id="source_7e553e4a0941f0ba3dcac03f28c5cf02">
+                                                            <div class="collapse" id="source_0079034275ba2f4ce3ce9f390cca9407">
                                                                 
                                                             </div>
                                                         </div>
@@ -665,7 +665,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045771.html
+++ b/testing/expected-results/letters/A045771.html
@@ -386,9 +386,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. theor. C. M. v. Weber WFN 7 (13)</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_05801290be6ef6eb104a73ecfd758797"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_df41187e01caf80852bc27f75ba08c12"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_05801290be6ef6eb104a73ecfd758797">
+                                        <div class="collapse apparatus-details" id="source_df41187e01caf80852bc27f75ba08c12">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (2 b. S.)</li>
@@ -568,7 +568,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045779.html
+++ b/testing/expected-results/letters/A045779.html
@@ -631,9 +631,9 @@
                                         
                                         <span>Erzhausen (D), Archiv des Verlags Robert Lienau (D-ERZrl)<br /><i>Signatur</i>: Kopierbuch Schlesinger 1833–1864, S. 799a/r–799c/v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_385ed092a96481517a8f8f8c22995390"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a6e481d94d22ce170643bc4004cda0e4"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_385ed092a96481517a8f8f8c22995390">
+                                        <div class="collapse apparatus-details" id="source_a6e481d94d22ce170643bc4004cda0e4">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul></ul>
                                                     <h4 class="media-heading">Beilagen</h4>
@@ -940,7 +940,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045785.html
+++ b/testing/expected-results/letters/A045785.html
@@ -491,9 +491,9 @@
                                         
                                         <span>New York (US), New York Public Library for the Performing Arts, Music Division (US-NYp)</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_0be4d3f1afc5e8087366acce606f5283"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_3c593883f28285e234a666cf946b3d94"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_0be4d3f1afc5e8087366acce606f5283">
+                                        <div class="collapse apparatus-details" id="source_3c593883f28285e234a666cf946b3d94">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S. o. Adr.)</li>
@@ -684,7 +684,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045806.html
+++ b/testing/expected-results/letters/A045806.html
@@ -574,9 +574,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. V (Mappe XVIII), Abt. 4 B, Nr. 14 D</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_c54e9ef95a83f41178f890300569dbcc"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_60eb717b052397ddf2f328ec878a80a9"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_c54e9ef95a83f41178f890300569dbcc">
+                                        <div class="collapse apparatus-details" id="source_60eb717b052397ddf2f328ec878a80a9">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Wiedergabe des Briefes nach einer Abschrift von Friedrich Wilhelm Jähns mit dessen Annotationen</li>
@@ -847,7 +847,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045850.html
+++ b/testing/expected-results/letters/A045850.html
@@ -439,7 +439,7 @@
                                         
                                         <span>Erzhausen (D), Archiv des Verlags Robert Lienau (D-ERZrl)<br /><i>Signatur</i>: Kopierbuch 1870–1876, Bl. 135</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_6d05df7234b9b6a9e2dd2a3bf9834bdb">
+                                        <div class="collapse apparatus-details" id="source_75ad6740b229604a5d02efd68f567dba">
                                             
                                             
                                             <div>
@@ -619,7 +619,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045851.html
+++ b/testing/expected-results/letters/A045851.html
@@ -442,7 +442,7 @@
                                         
                                         <span>Erzhausen (D), Archiv des Verlags Robert Lienau (D-ERZrl)<br /><i>Signatur</i>: Kopierbuch 1870–1876, Bl. 136</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_de71b376388e5fea5f8c78c67eb5a3ea">
+                                        <div class="collapse apparatus-details" id="source_6348b6d283eae3bb534ed8e8444f8d75">
                                             
                                             
                                             <div>
@@ -622,7 +622,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A045969.html
+++ b/testing/expected-results/letters/A045969.html
@@ -448,9 +448,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XXII), Nr. 2</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_531afcbf158b9cbe96ba9eea838ea136"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_facaa8b45e7529f95ac49d83ccbdaa8f"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_531afcbf158b9cbe96ba9eea838ea136">
+                                        <div class="collapse apparatus-details" id="source_facaa8b45e7529f95ac49d83ccbdaa8f">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S. o. Adr.)</li>
@@ -727,7 +727,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A046006.html
+++ b/testing/expected-results/letters/A046006.html
@@ -648,9 +648,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. V (Mappe XVIII), Abt. 4 B, Nr. 14 B</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_79e13083854c6f4774e7d76b79eda816"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_8e1c642a6461c8c42eea897f75912696"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_79e13083854c6f4774e7d76b79eda816">
+                                        <div class="collapse apparatus-details" id="source_8e1c642a6461c8c42eea897f75912696">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Abschrift von <a class="preview persons A000914" href="/exist/apps/WeGA-WebApp/de/A000914.html">Friedrich Wilhelm Jähns</a> mit dessen Annotationen</li>
@@ -928,7 +928,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A046061.html
+++ b/testing/expected-results/letters/A046061.html
@@ -422,9 +422,9 @@
                                         
                                         <span>Brief nicht vorhanden; Korrespondenz über Webers Tagebuch bzw. andere Briefe erschlossen</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_20d118355613be0ceaf7870e3b99e4e3"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_44a3df38fb841f8c97aa31f85acc238d"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_20d118355613be0ceaf7870e3b99e4e3">
+                                        <div class="collapse apparatus-details" id="source_44a3df38fb841f8c97aa31f85acc238d">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul></ul>
                                                     <h4 class="media-heading">Beilagen</h4>
@@ -605,7 +605,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A046237.html
+++ b/testing/expected-results/letters/A046237.html
@@ -455,9 +455,9 @@
                                         
                                         <span>Dresden (D), Sächsische Landesbibliothek – Staats- und Universitätsbibliothek (D-Dl)<br /><i>Signatur</i>: Mscr. Dresd. App. 2097, 158</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_f25d51fbbd1cf3c3950c31aaeb5b5479"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e00a14de87e3ea4f23067a3cd1eb32da"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_f25d51fbbd1cf3c3950c31aaeb5b5479">
+                                        <div class="collapse apparatus-details" id="source_e00a14de87e3ea4f23067a3cd1eb32da">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>masch. Übertragung nach dem verschollenen Original (Nr. 97E des Konvoluts)</li>
@@ -655,7 +655,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A046277.html
+++ b/testing/expected-results/letters/A046277.html
@@ -478,9 +478,9 @@
                                         
                                         <span>In Privatbesitz</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_ab62d9dba6116d4fe7d0e9980ada33a7"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_22a39fc1aec7d2b56b9fadbcc0701cf7"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_ab62d9dba6116d4fe7d0e9980ada33a7">
+                                        <div class="collapse apparatus-details" id="source_22a39fc1aec7d2b56b9fadbcc0701cf7">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S. einschl. Adr.)</li>
@@ -673,7 +673,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A046474.html
+++ b/testing/expected-results/letters/A046474.html
@@ -476,9 +476,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. theor. 1018, Bl. 62</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_042070e1876cbe1572afd7e5683c4154"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_704b7333fe2bc3d2f9e0a66b50bfc23f"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_042070e1876cbe1572afd7e5683c4154">
+                                        <div class="collapse apparatus-details" id="source_704b7333fe2bc3d2f9e0a66b50bfc23f">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Kopisten-Abschrift für Brühls <span class="tei_hi_italic">Acta Privata</span> zum <span class="tei_hi_italic">Oberon</span></li>
@@ -676,7 +676,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A046493.html
+++ b/testing/expected-results/letters/A046493.html
@@ -424,9 +424,9 @@
                                         
                                         <span>Dresden (D), Stadtmuseum Dresden</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_058a3be132ac5ce2f3355457ae180f06"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_f9f297647ffb79106c43b48b90444b67"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_058a3be132ac5ce2f3355457ae180f06">
+                                        <div class="collapse apparatus-details" id="source_f9f297647ffb79106c43b48b90444b67">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>3 b. S. o. Adr.</li>
@@ -605,7 +605,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A046634.html
+++ b/testing/expected-results/letters/A046634.html
@@ -458,7 +458,7 @@
                                         
                                         <span>Berlin (D), Gesetzlose Gesellschaft<br /><i>Signatur</i>: Protokollbücher</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_1afe962e13aa6989ce6a163eb41969f3">
+                                        <div class="collapse apparatus-details" id="source_749f6fadb276e08a545e0a94b3d5740c">
                                             
                                             
                                             <div>
@@ -638,7 +638,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A047171.html
+++ b/testing/expected-results/letters/A047171.html
@@ -439,9 +439,9 @@
                                         
                                         <span>unbekannt</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_caf12b839af22eee52a5b7ddd861966a"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_213ec1684c5bd32aea246e5744d1b168"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_caf12b839af22eee52a5b7ddd861966a">
+                                        <div class="collapse apparatus-details" id="source_213ec1684c5bd32aea246e5744d1b168">
                                             
                                             
                                             <div>
@@ -454,7 +454,7 @@
                                                             
                                                             <span class="tei_bibl_firstPrint"><span class="tei_supplied"><span class="brackets_supplied">[</span>Anonym<span class="brackets_supplied">]</span></span>, <span class="tei_hi_italic">Zum musikalischen Konversationslexikon</span>, in: <span class="tei_hi_italic">Die Grenzboten</span>. Zeitschrift für Politik, Literatur und Kunst, Jg. 42, 1. Quartal, Leipzig 1883, S.571-579 (Brief auf S. 578)</span>
                                                               
-                                                            <div class="collapse" id="source_2692e2fc9ec29d26f99226ec64e63b5e">
+                                                            <div class="collapse" id="source_29fde0ba2a78648113bfab74c77dc060">
                                                                 
                                                             </div>
                                                         </div>
@@ -634,7 +634,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A047207.html
+++ b/testing/expected-results/letters/A047207.html
@@ -543,9 +543,9 @@
                                         
                                         <span>Krakau (PL), Uniwersytet Jagielloński. Biblioteka Jagiellońska (PL-Kj)<br /><i>Signatur</i>: ML 100</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_30b96a29e658adcde22cd241bd5171fc"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_99c121d67ad199d1ba62ab1c55698187"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_30b96a29e658adcde22cd241bd5171fc">
+                                        <div class="collapse apparatus-details" id="source_99c121d67ad199d1ba62ab1c55698187">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>4 b. S. einschl. Adr.</li>
@@ -792,7 +792,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A047225.html
+++ b/testing/expected-results/letters/A047225.html
@@ -473,9 +473,9 @@
                                         
                                         <span>Marbach  (D), Deutsches Literaturarchiv Marbach (D-MB)<br /><i>Signatur</i>: 63.104/60</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_f8cb5687ca28f96cd6c67b5882fdb9b1"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_44cf3aca4bf5ed887af98fd199c49f9e"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_f8cb5687ca28f96cd6c67b5882fdb9b1">
+                                        <div class="collapse apparatus-details" id="source_44cf3aca4bf5ed887af98fd199c49f9e">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (4 b.S. o.Adr.); Format: 22,3 x 14,1 cm</li>
@@ -681,7 +681,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A047435.html
+++ b/testing/expected-results/letters/A047435.html
@@ -446,9 +446,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: 55 Ep 1931</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_9c0697a76c99cf279428e4fe7a856ec3"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_c747b97671032a79beecae24c865a45e"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_9c0697a76c99cf279428e4fe7a856ec3">
+                                        <div class="collapse apparatus-details" id="source_c747b97671032a79beecae24c865a45e">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. o. Adr.)</li>
@@ -470,7 +470,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A112934" data-ref="">Wolfgang Meister, <span class="tei_hi_italic">Verloren geglaubte Dokumente aus dem Archiv des Harmonischen Vereins</span>, in: <span class="tei_hi_latintype">Weberiana</span> 29 (2019)</span>, S. 21–24</span>
                                                               
-                                                            <div class="collapse" id="source_7047c7df1991fedc9001ca6ce14cd144">
+                                                            <div class="collapse" id="source_6b054efc83788a741fb3d0e50c269304">
                                                                 
                                                             </div>
                                                         </div>
@@ -694,7 +694,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A047436.html
+++ b/testing/expected-results/letters/A047436.html
@@ -468,9 +468,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: 55 Ep 1933</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6298a94f7187c6b7ff8677b01e93e568"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_9bfb532e26e8f9cf629b029e8da5acb2"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_6298a94f7187c6b7ff8677b01e93e568">
+                                        <div class="collapse apparatus-details" id="source_9bfb532e26e8f9cf629b029e8da5acb2">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S. o. Adr.)</li>
@@ -491,7 +491,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A112934" data-ref="">Wolfgang Meister, <span class="tei_hi_italic">Verloren geglaubte Dokumente aus dem Archiv des Harmonischen Vereins</span>, in: <span class="tei_hi_latintype">Weberiana</span> 29 (2019)</span>, S. 28–30 (inkl. Faksimile); dort datiert mit 9. Juli 1811. Das Datum wurde dort dem Brief Carl Maria von Webers an Gottfried Weber vom <a class="preview letters A040415" href="">19. Juli 1811</a> entnommen, in dem der Empfang eines Briefes vom 9. Juli bestätigt und auf den Bezeichnungsvorschlag in den Rundschreiben (Buchstaben bzw. Ziffern) Bezug genommen wird.</span>
                                                               
-                                                            <div class="collapse" id="source_082e3c55516e22f32adb60c3241c4ba4">
+                                                            <div class="collapse" id="source_f76e4e7034a6b4a1b192c19f7b6bf8c6">
                                                                 
                                                             </div>
                                                         </div>
@@ -727,7 +727,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A047540.html
+++ b/testing/expected-results/letters/A047540.html
@@ -554,9 +554,9 @@ ein fröhliches Mahl ein, und sezte darauf meinen <span class="tei_app"><span cl
                                         
                                         <span>Leipzig (D), Leipziger Stadtbibliothek – Musikbibliothek (D-LEm)<br /><i>Signatur</i>: PB 37 (Nr. 2)</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_83b22c8c000a28e6cef4fc20e43dcd98"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_7729e989e62abf5ea6536edfbf4c316f"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_83b22c8c000a28e6cef4fc20e43dcd98">
+                                        <div class="collapse apparatus-details" id="source_7729e989e62abf5ea6536edfbf4c316f">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S.)</li>
@@ -572,7 +572,7 @@ ein fröhliches Mahl ein, und sezte darauf meinen <span class="tei_app"><span cl
                                                             
                                                             <span class="tei_bibl">Rudorff: <span class="tei_hi_italic">Westermanns illustrierte deutsche Monats-Hefte</span>, 44. Jg. (1899), 87. Bd., S. 23–24</span>
                                                               
-                                                            <div class="collapse" id="source_99877126ef8ddb0aaf5a50e6f7e19501">
+                                                            <div class="collapse" id="source_3cc55ad519ea74b1ad100985893ab7c3">
                                                                 
                                                             </div>
                                                         </div>
@@ -582,7 +582,7 @@ ein fröhliches Mahl ein, und sezte darauf meinen <span class="tei_app"><span cl
                                                             
                                                             <span>Rudorff 1900, S. 17–20</span>
                                                               
-                                                            <div class="collapse" id="source_36268b4df6e742ba5a9de6708156af3c">
+                                                            <div class="collapse" id="source_b83a202dacedc3a343da3a425dc19f93">
                                                                 
                                                             </div>
                                                         </div>
@@ -605,7 +605,7 @@ ein fröhliches Mahl ein, und sezte darauf meinen <span class="tei_app"><span cl
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (V), Bl. 36a/v und 37a/r bis 37a/v</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_c5fc4c14841af9f9290272f644b1b169">
+                                        <div class="collapse apparatus-details" id="source_72a1ac71b45c4aaa3e68553cd7c388a0">
                                             
                                             
                                             <div>
@@ -1146,7 +1146,6 @@ ein fröhliches Mahl ein, und sezte darauf meinen <span class="tei_app"><span cl
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A047659.html
+++ b/testing/expected-results/letters/A047659.html
@@ -429,9 +429,9 @@
                                         
                                         <span>ehemals Berlin, Königliche Schauspiele, General-Intendantur<br /><i>Signatur</i>: aus: Acta betreffend den Herrn Baron Friedrich De la Motte Fouqué (seit 1945 verschollen)</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_24614d10e93d73b18318a469ef56bdad"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_7d44676b1098ec39449bb9caeffa7073"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_24614d10e93d73b18318a469ef56bdad">
+                                        <div class="collapse apparatus-details" id="source_7d44676b1098ec39449bb9caeffa7073">
                                             
                                             
                                             <div>
@@ -444,7 +444,7 @@
                                                             
                                                             <span>Friedrich Schnapp, Der Musiker E. T. A. Hoffmann. Ein Dokumentenband, Hildesheim 1981, S. 565 (nach einer vor 1945 angefertigten Abschrift im Besitz von F. Schnapp)</span>
                                                               
-                                                            <div class="collapse" id="source_5a3c097624a69bacfeabd7936f3b1a00">
+                                                            <div class="collapse" id="source_e7505cf5bc20d76f26adf95c8271e608">
                                                                 
                                                             </div>
                                                         </div>
@@ -620,7 +620,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A047714.html
+++ b/testing/expected-results/letters/A047714.html
@@ -512,7 +512,7 @@
                                         
                                         <span class="biblio-entry book"><span class="author">Max Maria von Weber</span>, <span class="title">Carl Maria von Weber. Ein Lebensbild</span>,  Bd. 1, <span class="placeNYear">Leipzig 1864</span>, S. 527–529</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_8e4ae506a429fe554ac767bc9861398b">
+                                        <div class="collapse apparatus-details" id="source_11bccc870b97ea9b8b64cf810d07c0e3">
                                             
                                             
                                             <div>
@@ -533,9 +533,9 @@
                                         
                                         <span>Dresden (D), Sächsisches Hauptstaatsarchiv (D-Dla)<br /><i>Signatur</i>: 10026, Geheimes Kabinett Loc. 15146/03 (Bd. 19), Bl. 358–359</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_9e1535cf7fd9a2d2c4b0073c4c5172b8"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_19cf18df1663c65460b4e15ac7278ba8"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_9e1535cf7fd9a2d2c4b0073c4c5172b8">
+                                        <div class="collapse apparatus-details" id="source_19cf18df1663c65460b4e15ac7278ba8">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S.)</li>
@@ -840,7 +840,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A047718.html
+++ b/testing/expected-results/letters/A047718.html
@@ -500,9 +500,9 @@
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz,
                      Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. X, Beilage zu Nr. 180</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_0a179589e337c924bde973e5da1664da"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_01b374a18122ed40abd14329fb7577bc"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_0a179589e337c924bde973e5da1664da">
+                                        <div class="collapse apparatus-details" id="source_01b374a18122ed40abd14329fb7577bc">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S.)</li>
@@ -695,7 +695,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A047744.html
+++ b/testing/expected-results/letters/A047744.html
@@ -478,9 +478,9 @@
                                         
                                         <span>Berlin (D), Archiv der Berlin-Brandenburgischen Akademie der Wissenschaften (D-Bbbaw)<br /><i>Signatur</i>: NL H. von Chézy 722</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_4c1f24ee8116191abc3f5cc4e376d83e"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_bf868576eaae924a8846d30ab9f15563"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_4c1f24ee8116191abc3f5cc4e376d83e">
+                                        <div class="collapse apparatus-details" id="source_bf868576eaae924a8846d30ab9f15563">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. o. Adr.)</li>
@@ -663,7 +663,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A047869.html
+++ b/testing/expected-results/letters/A047869.html
@@ -515,9 +515,9 @@
                                         
                                         <span>Berlin (D), Archiv der Berlin-Brandenburgischen Akademie der Wissenschaften (D-Bbbaw)<br /><i>Signatur</i>: NL H. von Chézy 772</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_9e5bd67f62eb36cd577f9988f7f383e7"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_c3ff5d55c033815f9c3972648e5b7038"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_9e5bd67f62eb36cd577f9988f7f383e7">
+                                        <div class="collapse apparatus-details" id="source_c3ff5d55c033815f9c3972648e5b7038">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S. o. Adr.)</li>
@@ -741,7 +741,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A047914.html
+++ b/testing/expected-results/letters/A047914.html
@@ -416,7 +416,7 @@
                                         
                                         <span class="biblio-entry book"><span class="author"></span>, <span class="title"><span class="tei_hi_italic">Friedrich Wilhelm Jähns und Max Jähns. Ein Familiengemälde für die Freunde</span></span>, hg. von <span class="editor">Karl Koetschau</span>, <span class="placeNYear">Dresden 1906</span>, S. 228f.</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_36df78f704471c290dc089573b9758c0">
+                                        <div class="collapse apparatus-details" id="source_e92edde0c48e6e14a2ec540dce0f5720">
                                             
                                             
                                             <div>
@@ -610,7 +610,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A047927.html
+++ b/testing/expected-results/letters/A047927.html
@@ -509,9 +509,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Beilage zu Weberiana Cl. X, Nr. 706</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_348bc81bd07ab290440ff9fc94f211b7"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_60d5947b5b227e6207c70f74f3885950"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_348bc81bd07ab290440ff9fc94f211b7">
+                                        <div class="collapse apparatus-details" id="source_60d5947b5b227e6207c70f74f3885950">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S.)</li>
@@ -738,7 +738,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A047961.html
+++ b/testing/expected-results/letters/A047961.html
@@ -492,9 +492,9 @@
                                         
                                         <span>Ermlitz (D), Apelsche Kulturstiftung</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_dbc8bc38b49c7aff797e31b5696445eb"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_950ab36d39c766f9192d2f50406c0e9d"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_dbc8bc38b49c7aff797e31b5696445eb">
+                                        <div class="collapse apparatus-details" id="source_950ab36d39c766f9192d2f50406c0e9d">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (4 b. S.)</li>
@@ -740,7 +740,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A047986.html
+++ b/testing/expected-results/letters/A047986.html
@@ -420,7 +420,7 @@
                                         
                                         <span class="tei_bibl"><span class="tei_bibl"><span class="tei_hi_italic">Aus Schellings Leben. In Briefen</span>, hg. von Gustav Leopold Plitt, Bd. 2, Leipzig 1870, S. 296–298</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_64854e12ea2268639457b04f03d11a83">
+                                        <div class="collapse apparatus-details" id="source_b59935dd713327dd4a7fb0f37721d064">
                                             
                                             
                                             <div>
@@ -600,7 +600,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/letters/A048090.html
+++ b/testing/expected-results/letters/A048090.html
@@ -484,9 +484,9 @@
                                         
                                         <span>Dresden (D), Sächsische Staats- und Universitätsbibliothek (D-Dl)<br /><i>Signatur</i>: Mscr. Dresd. h 37:4, Bd. 64, Nr. 139</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_43e15fe09fc2676b27f10fec170099da"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_934efaa8301a00ea1aa9d545cb3d0a09"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_43e15fe09fc2676b27f10fec170099da">
+                                        <div class="collapse apparatus-details" id="source_934efaa8301a00ea1aa9d545cb3d0a09">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S.)</li>
@@ -681,7 +681,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030034.html
+++ b/testing/expected-results/writings/A030034.html
@@ -486,11 +486,11 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung</span>, Jg. 20, Nr. 51 (23. Dezember 1818), Sp. 877–880</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung</span><span class="imprint">, Jg. 20, Nr. 51 (23. Dezember 1818), Sp. 877–880</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_30b05629d59b544a9bbde115275d02c0"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_51842809dbd5a252cfbbbb3207f7f242"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_30b05629d59b544a9bbde115275d02c0">
+                                        <div class="collapse apparatus-details" id="source_51842809dbd5a252cfbbbb3207f7f242">
                                             
                                             
                                             <div>
@@ -503,7 +503,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 382–386 (Nr. 135)</span>
                                                               
-                                                            <div class="collapse" id="source_f3b415c4322be249856cae9d36a22072">
+                                                            <div class="collapse" id="source_ae4e8f879fac74395bd33858a10ae47d">
                                                                 
                                                             </div>
                                                         </div>
@@ -513,7 +513,7 @@
                                                             
                                                             <span>MMW III, S. 204–207</span>
                                                               
-                                                            <div class="collapse" id="source_982ef56a578ed87143ec82a229598198">
+                                                            <div class="collapse" id="source_1dbcb32ef9f5bb4da9da12835fe992ac">
                                                                 
                                                             </div>
                                                         </div>
@@ -536,7 +536,7 @@
                                         
                                         <span class="tei_msName">Entwurf in zwei Teilen</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_c263a9a430d98df309534c9f957029b9">
+                                        <div class="collapse apparatus-details" id="source_0b745f2d5df0d2727c65eca7ad9ab0ac">
                                             
                                             
                                             <div>
@@ -557,9 +557,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (VIII), Bl. 62b/v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e89f523af0ed3ef7df1c81e9925b0b6c"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_c782940c235dcc574a3e072ab6b34dc4"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_e89f523af0ed3ef7df1c81e9925b0b6c">
+                                        <div class="collapse apparatus-details" id="source_c782940c235dcc574a3e072ab6b34dc4">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>über dem Ms.„Bemerkungen, zur nothwendigen Würdigung der von 
@@ -587,9 +587,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl.II A f 3.25κ</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6093736da7d4690231bc5769faca0767"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_d41d4d283a6a81e9644f88bf8d89304a"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_6093736da7d4690231bc5769faca0767">
+                                        <div class="collapse apparatus-details" id="source_d41d4d283a6a81e9644f88bf8d89304a">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Schluß: auf einzelnem Bl. r (Format 33,3x20,8 cm, WZ: FB?, Kettlinien ca. 2,5–2,7 cm)</li>
@@ -1008,7 +1008,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030057.html
+++ b/testing/expected-results/writings/A030057.html
@@ -424,9 +424,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 1, Nr. 30 (4. Februar 1817), Bl. 2v</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 1, Nr. 30 (4. Februar 1817), Bl. 2v</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_7be646e702cc73ce5756a9dccb35fadc">
+                                        <div class="collapse apparatus-details" id="source_a15012deb86048e7c175b8afb2a028fc">
                                             
                                             
                                             <div>
@@ -606,7 +606,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030107.html
+++ b/testing/expected-results/writings/A030107.html
@@ -518,9 +518,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 1, Nr. 86 (10. April 1817), Bl. 1r</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 1, Nr. 86 (10. April 1817), Bl. 1r</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_aae18c4912f6f192e658dc104594b60e">
+                                        <div class="collapse apparatus-details" id="source_e8af5af690900c95d7197e3d23213100">
                                             
                                             
                                             <div>
@@ -700,7 +700,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030108.html
+++ b/testing/expected-results/writings/A030108.html
@@ -572,9 +572,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 1, Nr. 90 (15. April 1817), Bl. 2v</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 1, Nr. 90 (15. April 1817), Bl. 2v</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_62bf09d5bae6df14bededafdd283005a">
+                                        <div class="collapse apparatus-details" id="source_3d4503e1cc6375d7f6f92e751789a7a0">
                                             
                                             
                                             <div>
@@ -754,7 +754,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030129.html
+++ b/testing/expected-results/writings/A030129.html
@@ -474,11 +474,11 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 1, Nr. 133 (4. Juni 1817), Bl. 2v</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 1, Nr. 133 (4. Juni 1817), Bl. 2v</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e465c00903ae5ec4625032d6350de0e5"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_3da5bfc41b9f618a07c37cd2796a0bf9"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_e465c00903ae5ec4625032d6350de0e5">
+                                        <div class="collapse apparatus-details" id="source_3da5bfc41b9f618a07c37cd2796a0bf9">
                                             
                                             
                                             <div>
@@ -491,7 +491,7 @@
                                                             
                                                             <span>HellS III, S. 108–111</span>
                                                               
-                                                            <div class="collapse" id="source_d05afe10045ce7c6a3f9ad45f558e950">
+                                                            <div class="collapse" id="source_82fafcc7fcda84cc5d727abe68512b75">
                                                                 
                                                             </div>
                                                         </div>
@@ -501,7 +501,7 @@
                                                             
                                                             <span>MMW III, S. 149–151</span>
                                                               
-                                                            <div class="collapse" id="source_234e8068896744f96bf673324de0d41e">
+                                                            <div class="collapse" id="source_0bce18b9959286cfcaa56c2267d54592">
                                                                 
                                                             </div>
                                                         </div>
@@ -511,7 +511,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 294–296 (Nr. 119)</span>
                                                               
-                                                            <div class="collapse" id="source_09eb73d8fd4e6a9f24bf522226e1d024">
+                                                            <div class="collapse" id="source_404189941bf69dea42751455d6e23137">
                                                                 
                                                             </div>
                                                         </div>
@@ -534,9 +534,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (VII), Bl. 53v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_901ff5be8101359791d870ae1248edf1"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_3d5eb44605307b512591b6c13e60508a"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_901ff5be8101359791d870ae1248edf1">
+                                        <div class="collapse apparatus-details" id="source_3d5eb44605307b512591b6c13e60508a">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>über dem Ms Titel: „Dr: m: Notizen pp“; Incipit: „Donnerstag d: 5t. Juni 1817 wird zum erstenmale auf unsrer Bühne gegeben. Das Waisenhaus,“; datiert:  „d: 31t. May und 1t. Juni 1817. Dresden.“</li>
@@ -801,7 +801,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030169.html
+++ b/testing/expected-results/writings/A030169.html
@@ -453,11 +453,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 1, Nr. 210 (2. September 1817), Bl. 2v</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 1, Nr. 210 (2. September 1817), Bl. 2v</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_d4a3abe8c4ef607091a212d4458fb3a6"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_fea161d128d20401902f0b782d411c28"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_d4a3abe8c4ef607091a212d4458fb3a6">
+                                        <div class="collapse apparatus-details" id="source_fea161d128d20401902f0b782d411c28">
                                             
                                             
                                             <div>
@@ -472,9 +472,9 @@
                                                             
                                                             <span>in Privatbesitz</span>
                                                             <span>
-                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_7e9bb65bb534ba87239402126a007325"></a>
+                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_d42864b15691143172f0b0030727b68a"></a>
                                                             </span>  
-                                                            <div class="collapse" id="source_7e9bb65bb534ba87239402126a007325">
+                                                            <div class="collapse" id="source_d42864b15691143172f0b0030727b68a">
                                                                 <h4 class="media-heading">Quellenbeschreibung</h4>
                                                                         <ul>
                                                                             <li>im Wesentlichen mit ED übereinstimmend</li>
@@ -494,7 +494,7 @@
                                                             
                                                             <span>MMW III, S. 157f.</span>
                                                               
-                                                            <div class="collapse" id="source_74cad0ec69c6a23e9b84c93b7b60b5c1">
+                                                            <div class="collapse" id="source_14c850dc8fcbe948433ee9414d990b54">
                                                                 
                                                             </div>
                                                         </div>
@@ -504,7 +504,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 355f. (Nr. 121)</span>
                                                               
-                                                            <div class="collapse" id="source_038f9a15238ab2037120de3ebe0bc110">
+                                                            <div class="collapse" id="source_f579c80d7e266a1cde6c0b11a5f65663">
                                                                 
                                                             </div>
                                                         </div>
@@ -698,7 +698,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030215.html
+++ b/testing/expected-results/writings/A030215.html
@@ -442,9 +442,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 1, Nr. 298 (13. Dezember 1817), Bl. 2v</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 1, Nr. 298 (13. Dezember 1817), Bl. 2v</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_c6a69eafb1624b6ce9996ef5a8c87eb4">
+                                        <div class="collapse apparatus-details" id="source_f5965f85df531c9971d2ff90f4c7eb9a">
                                             
                                             
                                             <div>
@@ -624,7 +624,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030233.html
+++ b/testing/expected-results/writings/A030233.html
@@ -447,9 +447,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 2, Nr. 28 (3. Februar 1818), Bl. 2r</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 2, Nr. 28 (3. Februar 1818), Bl. 2r</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_61a29c06e9a01e245e672586064d51b4">
+                                        <div class="collapse apparatus-details" id="source_98ab37ddc620cbee97152fb2e45fdb19">
                                             
                                             
                                             <div>
@@ -629,7 +629,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030235.html
+++ b/testing/expected-results/writings/A030235.html
@@ -532,9 +532,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 2, Nr. 30 (5. Februar 1818), Bl. 2v</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 2, Nr. 30 (5. Februar 1818), Bl. 2v</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_6d2a3e44d2357f8759510edb17692a5d">
+                                        <div class="collapse apparatus-details" id="source_5ed1a33883ebfd16ffccd81ad34bd9cd">
                                             
                                             
                                             <div>
@@ -714,7 +714,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030264.html
+++ b/testing/expected-results/writings/A030264.html
@@ -510,11 +510,11 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 2, Nr. 142 (16. Juni 1818), Bl. 2v</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 2, Nr. 142 (16. Juni 1818), Bl. 2v</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_31690eac4db356560a0bdcdf82cea06d"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_c53a47ffeed940d1a909aab2bc3cca11"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_31690eac4db356560a0bdcdf82cea06d">
+                                        <div class="collapse apparatus-details" id="source_c53a47ffeed940d1a909aab2bc3cca11">
                                             
                                             
                                             <div>
@@ -527,7 +527,7 @@
                                                             
                                                             <span>HellS III, S. 124–128</span>
                                                               
-                                                            <div class="collapse" id="source_37470f30b92fc76a993bb0ff4ea63666">
+                                                            <div class="collapse" id="source_33f2b7f0431338ae74b60faab8e386f9">
                                                                 
                                                             </div>
                                                         </div>
@@ -537,7 +537,7 @@
                                                             
                                                             <span>MMW III, S. 189–192</span>
                                                               
-                                                            <div class="collapse" id="source_99b1066b91257f8a65c70e9898d94a88">
+                                                            <div class="collapse" id="source_ccfca3cbcaa5f896f7ec3ef484842403">
                                                                 
                                                             </div>
                                                         </div>
@@ -547,7 +547,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 302–304 (Nr. 131)</span>
                                                               
-                                                            <div class="collapse" id="source_6cd0cff6a195296f848cc001afcc5dcf">
+                                                            <div class="collapse" id="source_92106a5c71312bad229ed4db861b4a5d">
                                                                 
                                                             </div>
                                                         </div>
@@ -570,9 +570,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (VIII), Bl. 60r–60v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_c5607c4e9f93640fe31c62b000502d23"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_02fc035774991e8d68e813a5ad7f77f0"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_c5607c4e9f93640fe31c62b000502d23">
+                                        <div class="collapse apparatus-details" id="source_02fc035774991e8d68e813a5ad7f77f0">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>über dem Manuskript Titel: „Dramatisch musikalische Notizen pp.“; Incipit: „Mittwoch d: 17t. Juny 1818 erscheint zum erstenmal auf dem Königl. Hoftheater Mozarts herrliche Schöpfg. Oper. Die Entführung aus dem Serail.“; keine Dat. in A</li>
@@ -891,7 +891,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030332.html
+++ b/testing/expected-results/writings/A030332.html
@@ -519,9 +519,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Charis.  Rheinische Morgenzeitung für gebildete Leser</span>, Jg. 2, Nr. 15 (4. September 1822), S. 2</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Charis.  Rheinische Morgenzeitung für gebildete Leser</span><span class="imprint">, Jg. 2, Nr. 15 (4. September 1822), S. 2</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_595b6103b537e680528ee91706b8d5d1">
+                                        <div class="collapse apparatus-details" id="source_b58972ef505d52c211b6d568ff0645d3">
                                             
                                             
                                             <div>
@@ -715,7 +715,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030355.html
+++ b/testing/expected-results/writings/A030355.html
@@ -471,9 +471,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Dramaturgisches Wochenblatt in nächster Beziehung auf die königlichen Schauspiele zu Berlin</span>, Bd. 2, Heft 47 (24. Mai 1817), S. 373</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Dramaturgisches Wochenblatt in nächster Beziehung auf die königlichen Schauspiele zu Berlin</span><span class="imprint">, Bd. 2, Heft 47 (24. Mai 1817), S. 373</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_5fdf16511b18860f463a3c9d4dc97652">
+                                        <div class="collapse apparatus-details" id="source_f1ebcb05e7910deb37719ef9d5aa7a2e">
                                             
                                             
                                             <div>
@@ -667,7 +667,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030378.html
+++ b/testing/expected-results/writings/A030378.html
@@ -533,11 +533,11 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Extrablatt zu No. 14. des Literarischen Merkurs</span>, Bd. 2, Heft 14 (17. Februar 1820), Bl. 3r–3v</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Extrablatt zu No. 14. des Literarischen Merkurs</span><span class="imprint">, Bd. 2, Heft 14 (17. Februar 1820), Bl. 3r–3v</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_55380dc1a25f91de620d6627b9b5291a"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_21cf89f9a2ba72d4a96940fda7c1aa57"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_55380dc1a25f91de620d6627b9b5291a">
+                                        <div class="collapse apparatus-details" id="source_21cf89f9a2ba72d4a96940fda7c1aa57">
                                             
                                             
                                             <div>
@@ -550,7 +550,7 @@
                                                             
                                                             <span>HellS III, S. XL-XLIII</span>
                                                               
-                                                            <div class="collapse" id="source_a0b80a17667216d54e62d5ca78202af0">
+                                                            <div class="collapse" id="source_a26d6fdb9ba33c65bc0c7696c244f3f9">
                                                                 
                                                             </div>
                                                         </div>
@@ -560,7 +560,7 @@
                                                             
                                                             <span>MMW III, S. 220–221</span>
                                                               
-                                                            <div class="collapse" id="source_401b09fd5138242e1a70df940bf126db">
+                                                            <div class="collapse" id="source_ae8ac8d78d80c43d81e87ecb7cbf9080">
                                                                 
                                                             </div>
                                                         </div>
@@ -570,7 +570,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 398–401 (Nr. 141)</span>
                                                               
-                                                            <div class="collapse" id="source_a502f4c5339041fc04204561091d8585">
+                                                            <div class="collapse" id="source_2faeff0bd3ff9c1ccd189ab24ca1738c">
                                                                 
                                                             </div>
                                                         </div>
@@ -593,9 +593,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (X), Bl. 68r–69v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_9fc42f5244f8bb701ac5c43bb9191d7f"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_af8d4355a81d8ec550bb12b04ea82bdd"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_9fc42f5244f8bb701ac5c43bb9191d7f">
+                                        <div class="collapse apparatus-details" id="source_af8d4355a81d8ec550bb12b04ea82bdd">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>über dem Ms. Titel: „Carl Maria von Webers Berichtigung der Bemerkungen in No. 13 des litt. Merkurs über seine dramatisch musikalische Notiz in No. 17.18 der Abendzeitung.“; Incipit: „Angriffe auf meine Persönlichkeit, und wären sie auch noch bitterer ausgesonnen“; Datierung: (unter dem Ms.) „Dresden d. 15t. Februar 1820.“ </li>
@@ -1047,7 +1047,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030380.html
+++ b/testing/expected-results/writings/A030380.html
@@ -459,9 +459,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span>, Jg. 6, Nr. 71 (23. März 1812), S. 284</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span><span class="imprint">, Jg. 6, Nr. 71 (23. März 1812), S. 284</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_fee9cc7109ca47188fbad1570de45ff9">
+                                        <div class="collapse apparatus-details" id="source_6426879e5937d795bd43aec690717ecb">
                                             
                                             
                                             <div>
@@ -648,7 +648,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030446.html
+++ b/testing/expected-results/writings/A030446.html
@@ -499,9 +499,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Zeitung für die elegante Welt</span>, Jg. 21, Nr. 236 (1. Dezember 1821), Sp. 1887–1888</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Zeitung für die elegante Welt</span><span class="imprint">, Jg. 21, Nr. 236 (1. Dezember 1821), Sp. 1887–1888</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_aacd71bf422e57e0b62dfec2aca3d8d9">
+                                        <div class="collapse apparatus-details" id="source_6072159d474406905e8b0afad1677609">
                                             
                                             
                                             <div>
@@ -701,7 +701,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030448.html
+++ b/testing/expected-results/writings/A030448.html
@@ -431,9 +431,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Zeitung für die elegante Welt</span>, Jg. 22, Nr. 34 (16. Februar 1822), Sp. 270–272</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Zeitung für die elegante Welt</span><span class="imprint">, Jg. 22, Nr. 34 (16. Februar 1822), Sp. 270–272</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_84b602e1fe8f888186d53c7c2482e056">
+                                        <div class="collapse apparatus-details" id="source_d8139b05437537300de14bfa771ee447">
                                             
                                             
                                             <div>
@@ -613,7 +613,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030501.html
+++ b/testing/expected-results/writings/A030501.html
@@ -483,11 +483,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 1, Nr. 281 (24. November 1817), Bl. 1v–2r</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 1, Nr. 281 (24. November 1817), Bl. 1v–2r</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_3baae04b0789ade5929b1afb9fa2338a"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_004fb06283c62cae54f5ff22e8a268b7"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_3baae04b0789ade5929b1afb9fa2338a">
+                                        <div class="collapse apparatus-details" id="source_004fb06283c62cae54f5ff22e8a268b7">
                                             
                                             
                                             <div>
@@ -500,7 +500,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 31–35 (Nr. 125)</span>
                                                               
-                                                            <div class="collapse" id="source_fb14d9d772d38c9e9bc26e14f7e379d8">
+                                                            <div class="collapse" id="source_c89b6d0ee94e1fba90b994e5ac4b5344">
                                                                 
                                                             </div>
                                                         </div>
@@ -712,7 +712,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030502.html
+++ b/testing/expected-results/writings/A030502.html
@@ -487,9 +487,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 2, Nr. 163 (10. Juli 1818), Bl. 2v</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 2, Nr. 163 (10. Juli 1818), Bl. 2v</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_779604d41bdbe68f86111c00ab4f88fe">
+                                        <div class="collapse apparatus-details" id="source_9a37d79d136090e3a73e9ca89018c529">
                                             
                                             
                                             <div>
@@ -677,7 +677,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030598.html
+++ b/testing/expected-results/writings/A030598.html
@@ -433,9 +433,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Privilegirte gemeinnützige Unterhaltungs-Blätter</span>, Bd. 6, Heft 17 (17. April 1811), Sp. 136</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Privilegirte gemeinnützige Unterhaltungs-Blätter</span><span class="imprint">, Bd. 6, Heft 17 (17. April 1811), Sp. 136</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_d0c8d571abe682c54ce8e15e5e3b315f">
+                                        <div class="collapse apparatus-details" id="source_965a4861bd72ed5f7188141f88a9cb4f">
                                             
                                             
                                             <div>
@@ -623,7 +623,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030600.html
+++ b/testing/expected-results/writings/A030600.html
@@ -515,9 +515,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Badisches Magazin</span>, Jg. 1, Nr. 7 (7. März 1811), S. 26–27</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Badisches Magazin</span><span class="imprint">, Jg. 1, Nr. 7 (7. März 1811), S. 26–27</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_3b6926b3fa896e8a77be0ab89c0c2f04">
+                                        <div class="collapse apparatus-details" id="source_cffed1fab4cf271d7948c2f9a8225d28">
                                             
                                             
                                             <div>
@@ -741,7 +741,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030620.html
+++ b/testing/expected-results/writings/A030620.html
@@ -649,11 +649,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Schreibtafel von Mannheim (Als Nicht-politische Beilage zur Rheinischen Correspondenz)</span>, Nr. 15 (17. Oktober 1810), Bl. 1r</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Schreibtafel von Mannheim (Als Nicht-politische Beilage zur Rheinischen Correspondenz)</span><span class="imprint">, Nr. 15 (17. Oktober 1810), Bl. 1r</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a16cd0db0cd75de8f848dcd7aa9969e2"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_194cbb3745f7f04df8f863b11a1f7902"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_a16cd0db0cd75de8f848dcd7aa9969e2">
+                                        <div class="collapse apparatus-details" id="source_194cbb3745f7f04df8f863b11a1f7902">
                                             
                                             
                                             <div>
@@ -666,7 +666,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A110236" data-ref=""><span class="tei_hi_italic">Weber-Studien</span>, Bd. 4/1</span>, S. 88–91</span>
                                                               
-                                                            <div class="collapse" id="source_bc38883ae5581029cb202d5d9323c471">
+                                                            <div class="collapse" id="source_9aa50b8af508d1b2b05e039f84bb404d">
                                                                 
                                                             </div>
                                                         </div>
@@ -971,7 +971,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030623.html
+++ b/testing/expected-results/writings/A030623.html
@@ -454,9 +454,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Heidelbergische Jahrbücher der Literatur</span>, Jg. 5, Nr. 66 (November 1812), S. 1041–1046</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Heidelbergische Jahrbücher der Literatur</span><span class="imprint">, Jg. 5, Nr. 66 (November 1812), S. 1041–1046</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_ddfe05dad54db0c981947c968a9d8236">
+                                        <div class="collapse apparatus-details" id="source_83030e0ae457adab250d5c5a3d9ce8ce">
                                             
                                             
                                             <div>
@@ -704,7 +704,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030665.html
+++ b/testing/expected-results/writings/A030665.html
@@ -574,9 +574,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span>, Jg. 4, Nr. 300 (15. Dezember 1810), S. 1199–1200</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span><span class="imprint">, Jg. 4, Nr. 300 (15. Dezember 1810), S. 1199–1200</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_102c53daad80082a3d6efaf339e734d3">
+                                        <div class="collapse apparatus-details" id="source_9f0b3ae93ccdaa072e1b2c41aedd1277">
                                             
                                             
                                             <div>
@@ -915,7 +915,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030680.html
+++ b/testing/expected-results/writings/A030680.html
@@ -426,9 +426,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 3, Nr. 107 (5. Mai 1819), Bl. 1r</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 3, Nr. 107 (5. Mai 1819), Bl. 1r</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_ceaecc1b0754e3fad189bf7971b9d951">
+                                        <div class="collapse apparatus-details" id="source_efa0a76528f0300e44e7ce80e14a163b">
                                             
                                             
                                             <div>
@@ -622,7 +622,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030695.html
+++ b/testing/expected-results/writings/A030695.html
@@ -494,9 +494,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 6, Nr. 165 (11. Juli 1822), S. 660</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 6, Nr. 165 (11. Juli 1822), S. 660</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_4d1916339b519318ff1e6d2bdc831c1a">
+                                        <div class="collapse apparatus-details" id="source_aab172ad8fb305537628180b0587a090">
                                             
                                             
                                             <div>
@@ -676,7 +676,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030754.html
+++ b/testing/expected-results/writings/A030754.html
@@ -436,9 +436,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 3, Nr. 105 (3. Mai 1819), Bl. 2r</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 3, Nr. 105 (3. Mai 1819), Bl. 2r</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_4a457545e0a31fff2669ce2b779a1862">
+                                        <div class="collapse apparatus-details" id="source_19406406e619e7965533693a388cb630">
                                             
                                             
                                             <div>
@@ -618,7 +618,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030798.html
+++ b/testing/expected-results/writings/A030798.html
@@ -901,9 +901,9 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Die Muse. Monatsschrift für Freunde der Poesie und der mit ihr verschwisterten Künste</span>, Bd. 2, Heft 5 (Mai 1822) Grundlage der vorliegenden Edition, S. 105–129</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Die Muse. Monatsschrift für Freunde der Poesie und der mit ihr verschwisterten Künste</span><span class="imprint">, Bd. 2, Heft 5 (Mai 1822) Grundlage der vorliegenden Edition, S. 105–129</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_048e14dde4e30384a293196dffb15f08">
+                                        <div class="collapse apparatus-details" id="source_f2e8c3b6d9a52754dd308a2e64ef5742">
                                             
                                             
                                             <div>
@@ -929,9 +929,9 @@
                                     <div>
                                         <strong><span>2. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 6, Nr. 46 (22. Februar 1822), S. 184</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 6, Nr. 46 (22. Februar 1822), S. 184</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_b1ab9395b0b2f4e6f2b8755f6ab8dc02">
+                                        <div class="collapse apparatus-details" id="source_fddfaa732d1bffafd2e5ab9a18f7c87a">
                                             
                                             
                                             <div>
@@ -950,9 +950,9 @@
                                     <div>
                                         <strong><span>3. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 6, Nr. 47 (23. Februar 1822) Fortsetzung, S. 188</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 6, Nr. 47 (23. Februar 1822) Fortsetzung, S. 188</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_ea52607d60a8b044219aefc657fa9154">
+                                        <div class="collapse apparatus-details" id="source_ec7d0f6c7ad1c51f676331e763eb0297">
                                             
                                             
                                             <div>
@@ -971,9 +971,9 @@
                                     <div>
                                         <strong><span>4. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Wegweiser im Gebiete der Künste und Wissenschaften (Beilage zur Abend-Zeitung)</span>, Jg. 6, Nr. 47 (23. Februar 1822) Beschluss, S. 61–63</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Wegweiser im Gebiete der Künste und Wissenschaften (Beilage zur Abend-Zeitung)</span><span class="imprint">, Jg. 6, Nr. 47 (23. Februar 1822) Beschluss, S. 61–63</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_fc74163164a4d3e41f45d9011712d578">
+                                        <div class="collapse apparatus-details" id="source_c5f46f55473e889caf165a6f023a3f79">
                                             
                                             
                                             <div>
@@ -2303,7 +2303,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030832.html
+++ b/testing/expected-results/writings/A030832.html
@@ -515,9 +515,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 3, Nr. 101 (28. April 1819), Bl. 2v</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 3, Nr. 101 (28. April 1819), Bl. 2v</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_7b9377c3c6afb5ea014c978b1dcf7d16">
+                                        <div class="collapse apparatus-details" id="source_329af89692b00951e62664a88d432c63">
                                             
                                             
                                             <div>
@@ -697,7 +697,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030849.html
+++ b/testing/expected-results/writings/A030849.html
@@ -425,9 +425,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 3, Nr. 239 (6. Oktober 1819), Bl. 1r</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 3, Nr. 239 (6. Oktober 1819), Bl. 1r</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_a08df484c4de31b613f4642b3eb12118">
+                                        <div class="collapse apparatus-details" id="source_3cc60f81e6d7d27cbcbd42508f0c1c52">
                                             
                                             
                                             <div>
@@ -607,7 +607,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030855.html
+++ b/testing/expected-results/writings/A030855.html
@@ -470,9 +470,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span>, Jg. 5, Nr. 299 (14. Dezember 1811), S. 1196</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span><span class="imprint">, Jg. 5, Nr. 299 (14. Dezember 1811), S. 1196</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_6a18069ffbe9cc1a9f4ad129331d597b">
+                                        <div class="collapse apparatus-details" id="source_c65855c050bd7c67ac78a2cfd06140a2">
                                             
                                             
                                             <div>
@@ -684,7 +684,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030860.html
+++ b/testing/expected-results/writings/A030860.html
@@ -527,9 +527,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 3, Nr. 200 (21. August 1819), Bl. 1r–2r</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 3, Nr. 200 (21. August 1819), Bl. 1r–2r</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_99c7b36cb9f504a276e80c4f0a04d905">
+                                        <div class="collapse apparatus-details" id="source_ab5edd5010b9265a05f08f8486e4545d">
                                             
                                             
                                             <div>
@@ -709,7 +709,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030908.html
+++ b/testing/expected-results/writings/A030908.html
@@ -592,9 +592,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Berliner allgemeine musikalische Zeitung</span>, Jg. 2, Nr. 42 (19. Oktober 1825), S. 336–338</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Berliner allgemeine musikalische Zeitung</span><span class="imprint">, Jg. 2, Nr. 42 (19. Oktober 1825), S. 336–338</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_07dfc9a1dcfe8dfad119c45a912bf1d9">
+                                        <div class="collapse apparatus-details" id="source_0f364bc1f692992e221650a095f046cf">
                                             
                                             
                                             <div>
@@ -782,7 +782,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030909.html
+++ b/testing/expected-results/writings/A030909.html
@@ -484,9 +484,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Wiener Zeitschrift für Kunst, Literatur, Theater und Mode</span>, Jg. 6, Nr. 143 (29. November 1821), S. 1206–1208</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Wiener Zeitschrift für Kunst, Literatur, Theater und Mode</span><span class="imprint">, Jg. 6, Nr. 143 (29. November 1821), S. 1206–1208</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_b253bcbbcb52b0dadcf2065d79f8889f">
+                                        <div class="collapse apparatus-details" id="source_9a2297224c1af8f33311a1ea73ec4039">
                                             
                                             
                                             <div>
@@ -674,7 +674,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030938.html
+++ b/testing/expected-results/writings/A030938.html
@@ -506,11 +506,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Kaiserlich Königlich privilegirte Prager Zeitung</span>, Jg. 3, Nr. 35 (4. Februar 1816), S. 135</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Kaiserlich Königlich privilegirte Prager Zeitung</span><span class="imprint">, Jg. 3, Nr. 35 (4. Februar 1816), S. 135</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e241de04098a93253fb2ab69a58b8374"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_499310c8a09448b305edce16acdbbd3a"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_e241de04098a93253fb2ab69a58b8374">
+                                        <div class="collapse apparatus-details" id="source_499310c8a09448b305edce16acdbbd3a">
                                             
                                             
                                             <div>
@@ -523,7 +523,7 @@
                                                             
                                                             <span>Jaroslav Bužga, Vergessene Aufsätze, Berichte und Mitteilungen aus Carl Maria von Webers Prager Jahren Wirkungszeit (1813–1816), S. 115f.</span>
                                                               
-                                                            <div class="collapse" id="source_0795dd9c7527180060a3bd7fa6b61fe8">
+                                                            <div class="collapse" id="source_3f04abf69394696136ab490e7bcd8dfe">
                                                                 
                                                             </div>
                                                         </div>
@@ -533,7 +533,7 @@
                                                             
                                                             <span>Musicalia v pražském periodickem tisku 1800–1825, hg. von Jiří Berkovec, Pag 2011, S. 166f.</span>
                                                               
-                                                            <div class="collapse" id="source_31320cad5ed3a5c0e8051845b5aef144">
+                                                            <div class="collapse" id="source_f4a2165d9286df1ad4e5a33afd79d48a">
                                                                 
                                                             </div>
                                                         </div>
@@ -747,7 +747,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030947.html
+++ b/testing/expected-results/writings/A030947.html
@@ -415,9 +415,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Gnädigst bewilligter Chemnitzer Anzeiger, ein Intelligenz- und Wochenblatt für Chemnitz und umliegende Gegend. zum Besten des öffentlichen Verkehrs, der vaterländischen Geschichte und gemeinnütiger Gegenstände überhaupt</span>, Jg. 2, Nr. 11 (14. März 1801), S. 58</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Gnädigst bewilligter Chemnitzer Anzeiger, ein Intelligenz- und Wochenblatt für Chemnitz und umliegende Gegend. zum Besten des öffentlichen Verkehrs, der vaterländischen Geschichte und gemeinnütiger Gegenstände überhaupt</span><span class="imprint">, Jg. 2, Nr. 11 (14. März 1801), S. 58</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_28087e4a50274b89561f1184a017571c">
+                                        <div class="collapse apparatus-details" id="source_56405f20161a34b9abf48c216756c48f">
                                             
                                             
                                             <div>
@@ -622,7 +622,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030982.html
+++ b/testing/expected-results/writings/A030982.html
@@ -528,9 +528,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Badisches Magazin</span>, Jg. 1, Nr. 151 (27. August 1811), S. 603–604</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Badisches Magazin</span><span class="imprint">, Jg. 1, Nr. 151 (27. August 1811), S. 603–604</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_cddf52d036fdf03eb180c1cd120e9bee">
+                                        <div class="collapse apparatus-details" id="source_d3a81ac300fd248ffa5a52a7c12b3d95">
                                             
                                             
                                             <div>
@@ -783,7 +783,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030985.html
+++ b/testing/expected-results/writings/A030985.html
@@ -468,9 +468,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (VII), Bl. 56a/r u. v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_3bcd2397df50411332a1d97d2cd1e4fa"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_220b6ec476bba0c5654334f78e4ae43a"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_3bcd2397df50411332a1d97d2cd1e4fa">
+                                        <div class="collapse apparatus-details" id="source_220b6ec476bba0c5654334f78e4ae43a">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Fortsetzung des Aufsatzes; vgl. <a class="preview writings A031244" href="">Weber-Schriften</a>; Format 33,5x20,6 cm, WZ: bekröntes Wappen, Gegenmarke: KIRCHBERG, Kettlinien ca. 2,7 cm; Forts. auf Bl. 1r und v von anderem DBl. (gleiche Papiersorte); Textteil ab „In bezug auf Töne“ bis Schluß herausgeschnitten und vermutlich von <a class="preview persons A002085" href="/exist/apps/WeGA-WebApp/de/A002085.html">Max Maria von Weber</a> kopiert; durch das Herausschneiden teilweise Textverlust auf Bl. 56a/r (es fehlen die von Weber in der linken Spalte notierten Einschübe bzw. Ergänzungen); diese wurden im edierten Text nach HellS ergänzt</li>
@@ -496,9 +496,9 @@
                                         
                                         <span class="biblio-entry book"><span class="title">HellS III</span>, <span class="placeNYear">1828</span>, S. 34–38</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_c94da8ce39a2afd2b87a90652e4dd75d"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_88f41dbc1805ca049e15d138b893838b"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_c94da8ce39a2afd2b87a90652e4dd75d">
+                                        <div class="collapse apparatus-details" id="source_88f41dbc1805ca049e15d138b893838b">
                                             
                                             
                                             <div>
@@ -511,7 +511,7 @@
                                                             
                                                             <span>MMW III, S. 163–165</span>
                                                               
-                                                            <div class="collapse" id="source_f5822318100f661dcdd88971fa82c13e">
+                                                            <div class="collapse" id="source_78d99d2a7839ed0928e41ad23b8cbbe9">
                                                                 
                                                             </div>
                                                         </div>
@@ -521,7 +521,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 374–377 (Nr. 124)</span>
                                                               
-                                                            <div class="collapse" id="source_72eedd279a12aa58f3ada1df27b97860">
+                                                            <div class="collapse" id="source_1472b2ea5c03d02a31e3719d331dd04c">
                                                                 
                                                             </div>
                                                         </div>
@@ -981,7 +981,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030991.html
+++ b/testing/expected-results/writings/A030991.html
@@ -451,9 +451,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 6, Nr. 224 (18. September 1822), S. 896</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 6, Nr. 224 (18. September 1822), S. 896</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_367269ef776df855ed03bf2d69754eb6">
+                                        <div class="collapse apparatus-details" id="source_b6ebfb1a4d7e7270220b19a04c0b7243">
                                             
                                             
                                             <div>
@@ -649,7 +649,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A030998.html
+++ b/testing/expected-results/writings/A030998.html
@@ -638,9 +638,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung, mit besonderer Rücksicht auf den österreichischen Kaiserstaat</span>, Jg. 7, Nr. 89 (5. November 1823), Sp. 705–712</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung, mit besonderer Rücksicht auf den österreichischen Kaiserstaat</span><span class="imprint">, Jg. 7, Nr. 89 (5. November 1823), Sp. 705–712</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_3a8f9b481cfdf1872a6fad242b596849">
+                                        <div class="collapse apparatus-details" id="source_c0c27db143ef7047005c9439e3d09bf0">
                                             
                                             
                                             <div>
@@ -835,7 +835,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031005.html
+++ b/testing/expected-results/writings/A031005.html
@@ -514,9 +514,9 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Badisches Magazin</span>, Jg. 2, Nr. 65 (17. März 1812), S. 259</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Badisches Magazin</span><span class="imprint">, Jg. 2, Nr. 65 (17. März 1812), S. 259</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_409726a086e0d30f7e1618ce80992dcf">
+                                        <div class="collapse apparatus-details" id="source_8280585b982f11ea31c499aaf399fa03">
                                             
                                             
                                             <div>
@@ -535,9 +535,9 @@
                                     <div>
                                         <strong><span>2. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Zeitung für die elegante Welt</span>, Jg. 12, Nr. 70 (7. April 1812), Sp. 559–560</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Zeitung für die elegante Welt</span><span class="imprint">, Jg. 12, Nr. 70 (7. April 1812), Sp. 559–560</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_c032165300d8ab860a7bd14072f6a1e0">
+                                        <div class="collapse apparatus-details" id="source_b3d44d95aefe099fe2dad72e478d6921">
                                             
                                             
                                             <div>
@@ -801,7 +801,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031017.html
+++ b/testing/expected-results/writings/A031017.html
@@ -646,9 +646,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Heidelbergische Jahrbücher der Literatur</span>, Bd. 4, Heft 67 (November 1811), S. 1057–1064</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Heidelbergische Jahrbücher der Literatur</span><span class="imprint">, Bd. 4, Heft 67 (November 1811), S. 1057–1064</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_13747143011bdc4df600a478b9813024">
+                                        <div class="collapse apparatus-details" id="source_7709aecfea9ee4911d14728bcee62e8b">
                                             
                                             
                                             <div>
@@ -952,7 +952,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031040.html
+++ b/testing/expected-results/writings/A031040.html
@@ -557,9 +557,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Wegweiser im Gebiete der Künste und Wissenschaften (Beilage zur Abend-Zeitung)</span>, Jg. 6, Nr. 38 (11. Mai 1822), S. 149–151</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Wegweiser im Gebiete der Künste und Wissenschaften (Beilage zur Abend-Zeitung)</span><span class="imprint">, Jg. 6, Nr. 38 (11. Mai 1822), S. 149–151</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_aee9abe3550e83d195daf72b5c6513de">
+                                        <div class="collapse apparatus-details" id="source_4a4f7b46f242826aa5cd942f9026a323">
                                             
                                             
                                             <div>
@@ -807,7 +807,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031050.html
+++ b/testing/expected-results/writings/A031050.html
@@ -621,9 +621,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Gesellschaftsblatt für gebildete Stände</span>, Jg. 2, Nr. 43 (27. Mai 1812), Sp. 341–344</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Gesellschaftsblatt für gebildete Stände</span><span class="imprint">, Jg. 2, Nr. 43 (27. Mai 1812), Sp. 341–344</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_9b517c30b87aeb19ac4255005f3f024d">
+                                        <div class="collapse apparatus-details" id="source_513642859aeaf0eb479b4a32a6fc1e9a">
                                             
                                             
                                             <div>
@@ -803,7 +803,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031060.html
+++ b/testing/expected-results/writings/A031060.html
@@ -513,9 +513,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 8, Nr. 69 (20. März 1824), S. 276</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 8, Nr. 69 (20. März 1824), S. 276</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_9c83e2b037696b114f17e8bb4b33556b">
+                                        <div class="collapse apparatus-details" id="source_6bf3814d615edd62a71bec1143719a04">
                                             
                                             
                                             <div>
@@ -710,7 +710,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031100.html
+++ b/testing/expected-results/writings/A031100.html
@@ -460,9 +460,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Gnädigst bewilligte Freyberger gemeinnützige Nachrichten für das Chursächsische Erzgebirge</span>, Jg. 2, Nr. 3 (15. Januar 1801), S. 25</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Gnädigst bewilligte Freyberger gemeinnützige Nachrichten für das Chursächsische Erzgebirge</span><span class="imprint">, Jg. 2, Nr. 3 (15. Januar 1801), S. 25</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_a8c06a80b0a5979cc4d2044557357cd3">
+                                        <div class="collapse apparatus-details" id="source_342c9dec4880420605a54a332c9f8b39">
                                             
                                             
                                             <div>
@@ -649,7 +649,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031101.html
+++ b/testing/expected-results/writings/A031101.html
@@ -600,11 +600,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Gnädigst bewilligte Freyberger gemeinnützige Nachrichten für das Chursächsische Erzgebirge</span>, Jg. 2, Nr. 7 (12. Februar 1801, Beilage), S. 69–70</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Gnädigst bewilligte Freyberger gemeinnützige Nachrichten für das Chursächsische Erzgebirge</span><span class="imprint">, Jg. 2, Nr. 7 (12. Februar 1801, Beilage), S. 69–70</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_0857450049d32a869b794b1a08d66b6b"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_28b29870abb3a8925925fab584868ece"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_0857450049d32a869b794b1a08d66b6b">
+                                        <div class="collapse apparatus-details" id="source_28b29870abb3a8925925fab584868ece">
                                             
                                             
                                             <div>
@@ -617,7 +617,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 359–363 (Nr. 01)</span>
                                                               
-                                                            <div class="collapse" id="source_94d162fd6427b5feaddae74bce5604ca">
+                                                            <div class="collapse" id="source_cd9f6dfa450be162063ca4489d3402ae">
                                                                 
                                                             </div>
                                                         </div>
@@ -812,7 +812,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031107.html
+++ b/testing/expected-results/writings/A031107.html
@@ -504,11 +504,11 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung</span>, Jg. 11, Nr. 50 (13. September 1809), Sp. 793–798</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung</span><span class="imprint">, Jg. 11, Nr. 50 (13. September 1809), Sp. 793–798</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_0272a95e874c909338fa964c9399393f"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a891f09a050f77a95bebd1674776dda5"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_0272a95e874c909338fa964c9399393f">
+                                        <div class="collapse apparatus-details" id="source_a891f09a050f77a95bebd1674776dda5">
                                             
                                             
                                             <div>
@@ -521,7 +521,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 161–166 (Nr. 04)</span>
                                                               
-                                                            <div class="collapse" id="source_1972f7b3b8dbcce7ce7ff7184f1f7ecc">
+                                                            <div class="collapse" id="source_57906c8ce2e03f498abc1e3cb64472a0">
                                                                 
                                                             </div>
                                                         </div>
@@ -544,9 +544,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (II), Bl. 16a/r–16b/v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_4b7a3b07bcd26e0d4a413952705743ad"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_7c3d0d411ce2dc2d1c36d3a0a145b78f"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_4b7a3b07bcd26e0d4a413952705743ad">
+                                        <div class="collapse apparatus-details" id="source_7c3d0d411ce2dc2d1c36d3a0a145b78f">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl., 4 b. S.</li>
@@ -565,7 +565,7 @@
                                                             
                                                             <span>HellS II, S. 14–21</span>
                                                               
-                                                            <div class="collapse" id="source_efcd53dcc7d7abdc8f237f949bf06e35">
+                                                            <div class="collapse" id="source_d7bd0cd08b65f5473bb7c8600003d5ee">
                                                                 
                                                             </div>
                                                         </div>
@@ -575,7 +575,7 @@
                                                             
                                                             <span>MMW III, S. 1–5</span>
                                                               
-                                                            <div class="collapse" id="source_359dcb825a2ba1fc7223d5a65b4842f1">
+                                                            <div class="collapse" id="source_ea09d95522681e1431fbb244fca00bdb">
                                                                 
                                                             </div>
                                                         </div>
@@ -1446,7 +1446,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031109.html
+++ b/testing/expected-results/writings/A031109.html
@@ -555,11 +555,11 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Zeitung für die elegante Welt</span>, Jg. 10, Nr. 53 (15. März 1810), Sp. 417–422</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Zeitung für die elegante Welt</span><span class="imprint">, Jg. 10, Nr. 53 (15. März 1810), Sp. 417–422</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_540f80bd62912dcc2183891633ed042d"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_ac72afc552c7736770ff03bbecdb15d2"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_540f80bd62912dcc2183891633ed042d">
+                                        <div class="collapse apparatus-details" id="source_ac72afc552c7736770ff03bbecdb15d2">
                                             
                                             
                                             <div>
@@ -572,7 +572,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 139–145 (Nr. 06)</span>
                                                               
-                                                            <div class="collapse" id="source_017d1c04f8b490c7b85990ad101cb162">
+                                                            <div class="collapse" id="source_e23340c967f62bc84a51e7209a4d3c10">
                                                                 
                                                             </div>
                                                         </div>
@@ -595,9 +595,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (II), Bl. 17a/r bis 18b/v oben</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e7c7cf6815149080bfb4bdb8cf625507"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_bb9139b1554c42e6584cdad61e8ce121"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_e7c7cf6815149080bfb4bdb8cf625507">
+                                        <div class="collapse apparatus-details" id="source_bb9139b1554c42e6584cdad61e8ce121">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>2 DBl. 8 b. S., auf S. 8 befindet sich <a class="preview writings A031113" href="/exist/apps/WeGA-WebApp/de/A002068/Schriften/A031113.html">1810-WeS-02</a></li>
@@ -617,7 +617,7 @@
                                                             
                                                             <span>HellS II, S. 1–13</span>
                                                               
-                                                            <div class="collapse" id="source_deb900016dca015ecbff43fc3e0b20fb">
+                                                            <div class="collapse" id="source_3ac8937aa58c313dded4bd4c196fc5c9">
                                                                 
                                                             </div>
                                                         </div>
@@ -1748,7 +1748,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031112.html
+++ b/testing/expected-results/writings/A031112.html
@@ -536,9 +536,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span>, Jg. 7, Nr. 167 (13. Juli 1812), Sp. 668</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span><span class="imprint">, Jg. 7, Nr. 167 (13. Juli 1812), Sp. 668</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_c2c1eb49f176de6f065ea5fee63ab496">
+                                        <div class="collapse apparatus-details" id="source_e4a9919c657d40f36f4c8c84b05100c8">
                                             
                                             
                                             <div>
@@ -811,7 +811,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031113.html
+++ b/testing/expected-results/writings/A031113.html
@@ -465,9 +465,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (II), Bl. 18b/v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_9a4f259c635b5dcf0085b9ed1e64c618"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_cb09895149aee4a9db939b26e5f58007"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_9a4f259c635b5dcf0085b9ed1e64c618">
+                                        <div class="collapse apparatus-details" id="source_cb09895149aee4a9db939b26e5f58007">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 b. S.; auf letzter Seite des <a class="preview writings A031109" href="/exist/apps/WeGA-WebApp/de/A002068/Schriften/A031109.html">Aufsatzes</a>: Ansicht des gegenwärtigen Zustandes der Kunst und Literatur in <a class="preview places A130012" href="">Stuttgart</a>; von Weber pag. S. 12</li>
@@ -483,7 +483,7 @@
                                                             
                                                             <span>HellS II 1828, S. 42–43</span>
                                                               
-                                                            <div class="collapse" id="source_49441da1b3af76b1a5f180da2c1743a4">
+                                                            <div class="collapse" id="source_c43bea491933287c783336eb771b217c">
                                                                 
                                                             </div>
                                                         </div>
@@ -493,7 +493,7 @@
                                                             
                                                             <span>MMW III, S. 6</span>
                                                               
-                                                            <div class="collapse" id="source_432625b00e45422a7442d58bd6273079">
+                                                            <div class="collapse" id="source_6480c9438161d1de989a8a931d16caae">
                                                                 
                                                             </div>
                                                         </div>
@@ -503,7 +503,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 101 (Nr. 09)</span>
                                                               
-                                                            <div class="collapse" id="source_d064c2375b2a0913978c03e46f3accb1">
+                                                            <div class="collapse" id="source_a0d33c6a1a32f8554076e7e5f88744c8">
                                                                 
                                                             </div>
                                                         </div>
@@ -765,7 +765,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031114.html
+++ b/testing/expected-results/writings/A031114.html
@@ -411,9 +411,9 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Sechs Lieder | mit Begleitung | des Piano-Forté oder der Guitarre | in Musik gesetzt von | J. GAENSBACHER | 9<span class="tei_hi_superscript">tes</span> Werk der Gesangsstücke | No 3004.  Preis f 1 20 Xr. | /: Italienisch und Deutsch :/ | Offenbach <span class="tei_hi_superscript">a</span>/m, bey Joh: André</span> (4. Quartal 1810)</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Sechs Lieder | mit Begleitung | des Piano-Forté oder der Guitarre | in Musik gesetzt von | J. GAENSBACHER | 9<span class="tei_hi_superscript">tes</span> Werk der Gesangsstücke | No 3004.  Preis f 1 20 Xr. | /: Italienisch und Deutsch :/ | Offenbach <span class="tei_hi_superscript">a</span>/m, bey Joh: André</span><span class="imprint"> (4. Quartal 1810)</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_2dfbc7d105a056772a6463c9f364d32f">
+                                        <div class="collapse apparatus-details" id="source_3736da67dc8ac1e573a415d6ae422d16">
                                             
                                             
                                             <div>
@@ -436,9 +436,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (III), Bl. 30r–30v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_448b9c2c39ae1009c014e905cc5df782"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_db639941a978c0c77f41a47c5f4d555f"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_448b9c2c39ae1009c014e905cc5df782">
+                                        <div class="collapse apparatus-details" id="source_db639941a978c0c77f41a47c5f4d555f">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>eigenhändige Abschrift Webers mit vollständigem italienischen und deutschen Text; 1 Bl., 2 b. S., Format 33,1x20,5 cm, WZ: Lilienblüte, Kettlinien ca. 2,8 cm; von Weber paginiert mit 17/18</li>
@@ -456,7 +456,7 @@
                                                             
                                                             <span>HellS I (Vorwort), S. LXXI-LXXIII (nur Rieselnde Quelle und 1810-WeS-00, KS: 19)</span>
                                                               
-                                                            <div class="collapse" id="source_b4d0b748ecb60a7f8d800d7aaf2b1f5c">
+                                                            <div class="collapse" id="source_c6297bf6f07ead0b872f26a80d03605c">
                                                                 
                                                             </div>
                                                         </div>
@@ -466,7 +466,7 @@
                                                             
                                                             <span>MMW I, S. 234–235 (ebenfalls nur Rieselnde Quelle und KS: 19); hier mit Dezember 1810 datiert</span>
                                                               
-                                                            <div class="collapse" id="source_7a73c39bf4d2e6cc8fa1db79dc06b0fc">
+                                                            <div class="collapse" id="source_5b47f940d70b474f9b379e2db46d4ea4">
                                                                 
                                                             </div>
                                                         </div>
@@ -476,7 +476,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 536–538 (Nr. 11 und 19)</span>
                                                               
-                                                            <div class="collapse" id="source_0020ea6b8a5b699c70812f5e9d08b5a1">
+                                                            <div class="collapse" id="source_157ca025b2331f0ff4e61e18117eaf8b">
                                                                 
                                                             </div>
                                                         </div>
@@ -774,7 +774,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031116.html
+++ b/testing/expected-results/writings/A031116.html
@@ -454,11 +454,11 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span>, Jg. 4, Nr. 147 (20. Juni 1810), S. 585–586</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span><span class="imprint">, Jg. 4, Nr. 147 (20. Juni 1810), S. 585–586</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_67b73d2f9e96de19c1b0b76f5012b40c"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_4cab14a6438d4bf34168f5d2b9450085"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_67b73d2f9e96de19c1b0b76f5012b40c">
+                                        <div class="collapse apparatus-details" id="source_4cab14a6438d4bf34168f5d2b9450085">
                                             
                                             
                                             <div>
@@ -471,7 +471,7 @@
                                                             
                                                             <span>Neue Fränkisch-Würzburgische Chronik, Jg. 5, Nr. 28 (14. Juli 1810), Sp. 440–442 ("Bemerkungen über Vogler, und dessen neuestes größeres Meisterwerk"</span>
                                                               
-                                                            <div class="collapse" id="source_3e3fa2de9ace14422d263e262b04af1a">
+                                                            <div class="collapse" id="source_190fd41b56fd983621b0189b3a807b84">
                                                                 
                                                             </div>
                                                         </div>
@@ -481,7 +481,7 @@
                                                             
                                                             <span>HellS II 1828, S. 22–25</span>
                                                               
-                                                            <div class="collapse" id="source_769c148a6f71608b2b6bcf9597f31b5c">
+                                                            <div class="collapse" id="source_c12b6970cb572e55d634b9654eea32b7">
                                                                 
                                                             </div>
                                                         </div>
@@ -491,7 +491,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 321–323 (Nr. 13)</span>
                                                               
-                                                            <div class="collapse" id="source_525b22d0816accea74791ad60824e153">
+                                                            <div class="collapse" id="source_f037c33e99904e62d0852749edcd57ef">
                                                                 
                                                             </div>
                                                         </div>
@@ -514,9 +514,9 @@
                                         
                                         <span>verschollen</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_02ccf7ec04e26452d79a35f3d6fb9454"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_76b39ad48de5a968ccd3b9f6eea16465"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_02ccf7ec04e26452d79a35f3d6fb9454">
+                                        <div class="collapse apparatus-details" id="source_76b39ad48de5a968ccd3b9f6eea16465">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>lt. Auktionskatalog signiert mit „Melos. Aschaffenburg, den 16. Aprill 1810.“; Datierung wird durch TB nicht gestützt</li>
@@ -706,7 +706,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031119.html
+++ b/testing/expected-results/writings/A031119.html
@@ -461,11 +461,11 @@ in 3 Gastrollen, nemlich: als <span class="tei_hi_spaced_out"><span class="66101
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Rheinische Correspondenz</span>, Bd. 2, Heft 179 (30. Juni 1810), S. 713–714</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Rheinische Correspondenz</span><span class="imprint">, Bd. 2, Heft 179 (30. Juni 1810), S. 713–714</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a7385e4ab1bfa36c48a286fae8c88427"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_0267679d829a7de4ce678b428039d536"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_a7385e4ab1bfa36c48a286fae8c88427">
+                                        <div class="collapse apparatus-details" id="source_0267679d829a7de4ce678b428039d536">
                                             
                                             
                                             <div>
@@ -478,7 +478,7 @@ in 3 Gastrollen, nemlich: als <span class="tei_hi_spaced_out"><span class="66101
                                                             
                                                             <span class="tei_bibl">Carl Maria von Weber, <span class="tei_hi_italic">Writings on music</span>, übersetzt von Martin Cooper, hg. von John Warrack, Cambridge u. a. 1981, S. 54</span>
                                                               
-                                                            <div class="collapse" id="source_3ac30b3b235f07a34b65a4d5b0d910c4">
+                                                            <div class="collapse" id="source_6fa8f1b35d2471371b9196cc45763125">
                                                                 
                                                             </div>
                                                         </div>
@@ -678,7 +678,6 @@ in 3 Gastrollen, nemlich: als <span class="tei_hi_spaced_out"><span class="66101
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031120.html
+++ b/testing/expected-results/writings/A031120.html
@@ -432,9 +432,9 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span>, Jg. 4, Nr. 167 (13. Juli 1810), S. 668</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span><span class="imprint">, Jg. 4, Nr. 167 (13. Juli 1810), S. 668</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_d226b9e81ce88fd91397343b1e31136b">
+                                        <div class="collapse apparatus-details" id="source_cc027109c1ef571cc6765c89e878a221">
                                             
                                             
                                             <div>
@@ -453,9 +453,9 @@
                                     <div>
                                         <strong><span>2. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Archiv für Literatur, Kunst und Politik</span>, Jg. 1, Nr. 57 (18. Juli 1810), S. 457f.</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Archiv für Literatur, Kunst und Politik</span><span class="imprint">, Jg. 1, Nr. 57 (18. Juli 1810), S. 457f.</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_df2675a9d01461886919180b543768a0">
+                                        <div class="collapse apparatus-details" id="source_c05c384b117e6c031b1c93afbfb1c885">
                                             
                                             
                                             <div>
@@ -720,7 +720,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031121.html
+++ b/testing/expected-results/writings/A031121.html
@@ -428,9 +428,9 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span>, Jg. 4, Nr. 168 (14. Juli 1810), S. 672</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span><span class="imprint">, Jg. 4, Nr. 168 (14. Juli 1810), S. 672</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_88c6739ec1d418730546efff7a8a96f2">
+                                        <div class="collapse apparatus-details" id="source_dcc81ff48f4f3e99a39aa5ef9365be82">
                                             
                                             
                                             <div>
@@ -449,9 +449,9 @@
                                     <div>
                                         <strong><span>2. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Archiv für Literatur, Kunst und Politik</span>, Jg. 1, Nr. 58 (22. Juli 1810), S. 466</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Archiv für Literatur, Kunst und Politik</span><span class="imprint">, Jg. 1, Nr. 58 (22. Juli 1810), S. 466</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_de52d3f1c18fe695567c5a7a07817379">
+                                        <div class="collapse apparatus-details" id="source_c4ab66a01dfd47343e5168ab3661123b">
                                             
                                             
                                             <div>
@@ -821,7 +821,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031123.html
+++ b/testing/expected-results/writings/A031123.html
@@ -464,11 +464,11 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span>, Jg. 4, Nr. 190 (9. August 1810), S. 757–758</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span><span class="imprint">, Jg. 4, Nr. 190 (9. August 1810), S. 757–758</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_295d6b8f2b1ae2491c2ee5db69b14ea0"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_cc4141f7df73da2644820583b07f9f9f"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_295d6b8f2b1ae2491c2ee5db69b14ea0">
+                                        <div class="collapse apparatus-details" id="source_cc4141f7df73da2644820583b07f9f9f">
                                             
                                             
                                             <div>
@@ -481,7 +481,7 @@
                                                             
                                                             <span class="tei_bibl">mit Ergänzung aus dem Entwurf in: <span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 417–421 (Nr. 16)</span>
                                                               
-                                                            <div class="collapse" id="source_3b6950aba5aa1228b40d739d8c3f11c9">
+                                                            <div class="collapse" id="source_3a24d281d6b5296eb22c51efdd3fc17a">
                                                                 
                                                             </div>
                                                         </div>
@@ -504,9 +504,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (II), Bl. 19a/r–19b/r</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_7affee33252fce9c8923f29fcb3b08a1"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_62c19ac5670040cf91e5888fa80e1a64"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_7affee33252fce9c8923f29fcb3b08a1">
+                                        <div class="collapse apparatus-details" id="source_62c19ac5670040cf91e5888fa80e1a64">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. 3 b. S., S. 4 leer bis auf die auf dem Kopf stehende Überschrift: Literarische Versuche</li>
@@ -524,7 +524,7 @@
                                                             
                                                             <span>HellS II, S. 26–32</span>
                                                               
-                                                            <div class="collapse" id="source_8b35e83379461bfb3ce0727e550c3ca1">
+                                                            <div class="collapse" id="source_c32175b41f248d991c61a568046cb15c">
                                                                 
                                                             </div>
                                                         </div>
@@ -534,7 +534,7 @@
                                                             
                                                             <span>MMW III, S. 19–22</span>
                                                               
-                                                            <div class="collapse" id="source_a22b2bc64974458f0eb880fda2c0fcae">
+                                                            <div class="collapse" id="source_09bb554e0cce9207fee9d60f5d599765">
                                                                 
                                                             </div>
                                                         </div>
@@ -1123,7 +1123,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031127.html
+++ b/testing/expected-results/writings/A031127.html
@@ -457,9 +457,9 @@
                                         
                                         <span>Stadtarchiv Hannover, Autographensammlung (ehemals Kestner-Museum)<br /><i>Signatur</i>: Nr. 2301</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_8bd75c9b630bdf74d33022bfb221e5c2"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_185bb8f2291c0ece477bfece1b899165"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_8bd75c9b630bdf74d33022bfb221e5c2">
+                                        <div class="collapse apparatus-details" id="source_185bb8f2291c0ece477bfece1b899165">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Noten mit Text (Autograph Weber), 1 Bl.</li>
@@ -476,7 +476,7 @@
                                                             
                                                             <span>Hell I 1828 (Vorwort), S. LXXII-LXXIII</span>
                                                               
-                                                            <div class="collapse" id="source_6c68eca47ea23e04255527d65804a850">
+                                                            <div class="collapse" id="source_1598ea62ec6d616d29315c1bb655f537">
                                                                 
                                                             </div>
                                                         </div>
@@ -486,7 +486,7 @@
                                                             
                                                             <span>MMW I, S. 235</span>
                                                               
-                                                            <div class="collapse" id="source_6b34d4beb05c756e4724b8a4c40b7709">
+                                                            <div class="collapse" id="source_b2c6c02aa4c43bab3362574ddd64cd06">
                                                                 
                                                             </div>
                                                         </div>
@@ -496,7 +496,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 536f. (Nr. 19)</span>
                                                               
-                                                            <div class="collapse" id="source_ec9bcf672acf7ce46eb590b040f3d89c">
+                                                            <div class="collapse" id="source_f84b6b2a9b8f0314ca76d6c29ac4f028">
                                                                 
                                                             </div>
                                                         </div>
@@ -506,7 +506,7 @@
                                                             
                                                             <span class="tei_bibl">Faksimile in: <span class="tei_hi_italic">Musik in Heidelberg 1777–1885</span>, Ausstellungskatalog, Redaktion bzw. wiss. Betreuung: Susanne Himmelheber, Barbara Böckmann und Ludwig Finscher, Heidelberg 1985, S. 302 (Kat.-Nr. 159) </span>
                                                               
-                                                            <div class="collapse" id="source_9baadc5ad717fd5f3d563a586d187ecc">
+                                                            <div class="collapse" id="source_7a0bf9dfb973beb02b066ac42d9cb43b">
                                                                 
                                                             </div>
                                                         </div>
@@ -694,7 +694,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031131.html
+++ b/testing/expected-results/writings/A031131.html
@@ -478,11 +478,11 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span>, Jg. 5, Nr. 118 (17. Mai 1811), S. 472</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span><span class="imprint">, Jg. 5, Nr. 118 (17. Mai 1811), S. 472</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_c137b766b72dddcf4cbc2276d744cb96"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_7ea0a02b27bf34e81f283a3bce8600f3"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_c137b766b72dddcf4cbc2276d744cb96">
+                                        <div class="collapse apparatus-details" id="source_7ea0a02b27bf34e81f283a3bce8600f3">
                                             
                                             
                                             <div>
@@ -495,7 +495,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 155–157 (nach ED, ergänzt durch ersten Absatz aus Entwurf) (Nr. 21)</span>
                                                               
-                                                            <div class="collapse" id="source_983d1f26d61aef6f9ca50283c5c65cd4">
+                                                            <div class="collapse" id="source_74b6a74b50e7cd7d32ead210604b71d4">
                                                                 
                                                             </div>
                                                         </div>
@@ -518,9 +518,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (IV), Bl. 34a/r – 34b/r oben</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_8dfd61514e8b1764aa261403ebef64de"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_75d7cb847d58ded8d2e1bf5b23c3589c"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_8dfd61514e8b1764aa261403ebef64de">
+                                        <div class="collapse apparatus-details" id="source_75d7cb847d58ded8d2e1bf5b23c3589c">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>über dem Manuskript „Kunstzustand in Darmstadt“. Incipit: „Ich möchte hier wohl mit dem <span class="7210111611610997110110">Hettmann</span> in <a class="preview works A020715" href="">Benjowsky</a> sprechen“; keine Datierung </li>
@@ -538,7 +538,7 @@
                                                             
                                                             <span>HellS II, S. 65–68</span>
                                                               
-                                                            <div class="collapse" id="source_5267dfda4064347f56d4d90a1af87b0c">
+                                                            <div class="collapse" id="source_e03e202def46a0951eaa62ee8dc0bbf8">
                                                                 
                                                             </div>
                                                         </div>
@@ -548,7 +548,7 @@
                                                             
                                                             <span>MMW I, S. 243–245</span>
                                                               
-                                                            <div class="collapse" id="source_d6648cae1c16ae461b7d51d0060737f4">
+                                                            <div class="collapse" id="source_256735a5b5173e34873043af3b8b86ae">
                                                                 
                                                             </div>
                                                         </div>
@@ -1135,7 +1135,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031134.html
+++ b/testing/expected-results/writings/A031134.html
@@ -453,11 +453,11 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung</span>, Jg. 13, Nr. 22 (29. Mai 1811), Sp. 377–379</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung</span><span class="imprint">, Jg. 13, Nr. 22 (29. Mai 1811), Sp. 377–379</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a79328a96fc80451756b63eba1ed74e4"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_5c6a6e1f933b7c98f486036b68efd917"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_a79328a96fc80451756b63eba1ed74e4">
+                                        <div class="collapse apparatus-details" id="source_5c6a6e1f933b7c98f486036b68efd917">
                                             
                                             
                                             <div>
@@ -470,7 +470,7 @@
                                                             
                                                             <span>MMW III, S. 26–28</span>
                                                               
-                                                            <div class="collapse" id="source_920cf1b237c2bc622c8ba29fdd38b565">
+                                                            <div class="collapse" id="source_a7f89c48c86ea03892f548769518e567">
                                                                 
                                                             </div>
                                                         </div>
@@ -480,7 +480,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 349–351 (Nr. 23)</span>
                                                               
-                                                            <div class="collapse" id="source_2623422d7f5d9c270b71d6b6b0044c3d">
+                                                            <div class="collapse" id="source_6d91fa902e28658e79010c3f44812e57">
                                                                 
                                                             </div>
                                                         </div>
@@ -503,9 +503,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (IV), Bl. 32a/r–32b/r</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_0985529e700824a58cd8e1e75ad8d95c"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e86c5470f5542ce9c552ed36b91b7a19"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_0985529e700824a58cd8e1e75ad8d95c">
+                                        <div class="collapse apparatus-details" id="source_e86c5470f5542ce9c552ed36b91b7a19">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>über dem Manuskript oben „Neuer Versuch zur musikalischen Vervollkommnung der Flöte. Aeußere Ansicht der Flöte, insofern es ohne beigefügte Zeichnung geschehen kann.“; Incipit: „H: F: Nepo: Capeller. Mitglied des hießigen Hoforchesters“; datiert mit „München den 30t Aprill 1811.“ [von Weber Datierung korrigiert aus 18]; </li>
@@ -896,7 +896,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031135.html
+++ b/testing/expected-results/writings/A031135.html
@@ -491,11 +491,11 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Kritischer Anzeiger für Litteratur und Kunst</span>, Bd. 5, Heft 20 (18. Mai 1811), S. 104</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Kritischer Anzeiger für Litteratur und Kunst</span><span class="imprint">, Bd. 5, Heft 20 (18. Mai 1811), S. 104</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6b19ad3c964f2bf6974654b3a2732bc7"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_1245d9c8185ce516f5259396945270e5"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_6b19ad3c964f2bf6974654b3a2732bc7">
+                                        <div class="collapse apparatus-details" id="source_1245d9c8185ce516f5259396945270e5">
                                             
                                             
                                             <div>
@@ -508,7 +508,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 102–104 (Nr. 24)</span>
                                                               
-                                                            <div class="collapse" id="source_7c65e1375a174a4444800bac58b4d001">
+                                                            <div class="collapse" id="source_7a247a8037d6742a3148549dbc9ad88a">
                                                                 
                                                             </div>
                                                         </div>
@@ -531,9 +531,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (IV), Bl. 34b/r–34b/v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_bc72b9755c224bb5a94524e7f8e26f8e"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_ff25c80dabc5885b61137765d9e8fb79"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_bc72b9755c224bb5a94524e7f8e26f8e">
+                                        <div class="collapse apparatus-details" id="source_ff25c80dabc5885b61137765d9e8fb79">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>keine Überschrift, ursprünglicher Titel wurde von Weber erweitert, Incipit: „München am 7t May gab man zum erstenmale Aschenbrödel /:Cendrillon:/ Oper in 3 Akten von Nicolo Isouard de Malthe“;  in A keine Datierung, nur Vermerk über ED von Weber </li>
@@ -551,7 +551,7 @@
                                                             
                                                             <span>HellS II, S. 69–73</span>
                                                               
-                                                            <div class="collapse" id="source_bcbda8c8d54f244a05342017d9cffae9">
+                                                            <div class="collapse" id="source_c6bfe6dd51ffd9081cead65092953cb4">
                                                                 
                                                             </div>
                                                         </div>
@@ -561,7 +561,7 @@
                                                             
                                                             <span>MMW III, S. 28–30</span>
                                                               
-                                                            <div class="collapse" id="source_cad24022a1bdfc9ec79dbb264b992b5b">
+                                                            <div class="collapse" id="source_53d91ad4670999bcd7db9557b7985b51">
                                                                 
                                                             </div>
                                                         </div>
@@ -999,7 +999,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031140.html
+++ b/testing/expected-results/writings/A031140.html
@@ -471,11 +471,11 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Gesellschaftsblatt für gebildete Stände</span>, Jg. 1, Nr. 52 (3. Juli 1811), Sp. 421–424</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Gesellschaftsblatt für gebildete Stände</span><span class="imprint">, Jg. 1, Nr. 52 (3. Juli 1811), Sp. 421–424</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_f00e7d1dfdf21c3dc89211bd6875302a"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_39ae07d74820b8cb8e70c835d80dc97f"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_f00e7d1dfdf21c3dc89211bd6875302a">
+                                        <div class="collapse apparatus-details" id="source_39ae07d74820b8cb8e70c835d80dc97f">
                                             
                                             
                                             <div>
@@ -488,7 +488,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 106–109 (Nr. 28)</span>
                                                               
-                                                            <div class="collapse" id="source_5b77ab088ea3fb14e2c09c3cd005be18">
+                                                            <div class="collapse" id="source_4c544477c74bcd3e0c61f756b3f0cb68">
                                                                 
                                                             </div>
                                                         </div>
@@ -511,9 +511,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (IV), Bl. 33a/v–33b/r</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_980b4f350feaff98c6a7dba1ad7e1ed8"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_60d4b682895b00d2a341cb20d2ed0692"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_980b4f350feaff98c6a7dba1ad7e1ed8">
+                                        <div class="collapse apparatus-details" id="source_60d4b682895b00d2a341cb20d2ed0692">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>über dem Manuskript „Bruchstükk des Briefes eines Reisenden.“; Incipit: „Stelle dir meine Freude vor als ich auf meinem Durchfluge“;  Manuskript undatiert ; unterzeichnet mit: „dein Freund: M=s“</li>
@@ -530,7 +530,7 @@
                                                             
                                                             <span>HellS II, S. 88–93</span>
                                                               
-                                                            <div class="collapse" id="source_8c0355384394c45afb59bf4582b2ce8e">
+                                                            <div class="collapse" id="source_e8626bf6b32d416b5c9e974bf2b03cfc">
                                                                 
                                                             </div>
                                                         </div>
@@ -540,7 +540,7 @@
                                                             
                                                             <span>MMW III, S. 36–38</span>
                                                               
-                                                            <div class="collapse" id="source_1b91b6f6959c1d95331c2a66af1310ac">
+                                                            <div class="collapse" id="source_1432c77c055ae2fa2cfffd832284f771">
                                                                 
                                                             </div>
                                                         </div>
@@ -948,7 +948,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031148.html
+++ b/testing/expected-results/writings/A031148.html
@@ -548,9 +548,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (II), Bl. 20a/r</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_9ff75c30450ba8d4138a8cebd6cddd6f"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_c5ac8b146c7d595b4a42b551ae7be540"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_9ff75c30450ba8d4138a8cebd6cddd6f">
+                                        <div class="collapse apparatus-details" id="source_c5ac8b146c7d595b4a42b551ae7be540">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Manuskript undatiert</li>
@@ -568,7 +568,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A112549" data-ref="">HellS III</span> (Anhang), <a class="preview writings A031990" href="">S. 156–157</a></span>
                                                               
-                                                            <div class="collapse" id="source_0d3208c0ae8bfddb5b4ceffaf0d687b9">
+                                                            <div class="collapse" id="source_856e7ecf20c70bb4a0581c59dfa93678">
                                                                 
                                                             </div>
                                                         </div>
@@ -578,7 +578,7 @@
                                                             
                                                             <span>MMW III, S. 46–47</span>
                                                               
-                                                            <div class="collapse" id="source_566765a100d1babe7b12529b564918ec">
+                                                            <div class="collapse" id="source_fa3f243d8242ebce6d749133ab4226ec">
                                                                 
                                                             </div>
                                                         </div>
@@ -588,7 +588,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 15f. (Nr. 34)</span>
                                                               
-                                                            <div class="collapse" id="source_93a2a35a54cfd491ab4ce5b103102a82">
+                                                            <div class="collapse" id="source_afcddcdf63046e2da5ecee0ff2646e39">
                                                                 
                                                             </div>
                                                         </div>
@@ -857,7 +857,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031149.html
+++ b/testing/expected-results/writings/A031149.html
@@ -572,9 +572,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. II A, Abt. k, Nr. 1</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_1a82b7158f173dba59370050cef08c70"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b7a7daea7bd995b92fca4bd87287ee99"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_1a82b7158f173dba59370050cef08c70">
+                                        <div class="collapse apparatus-details" id="source_b7a7daea7bd995b92fca4bd87287ee99">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Manuskript ohne Titel [im Katalog der Webersammlung von Jähns notierte dieser unter der Rubrik „Reisen Weber’s betreffend“ dazu: „Städte-Verzeichniß für reisende Tonkünstler“ und datierte  mit „(Zürich.) (1811.) (Sept. Oct.)“]; Incipit: „Hamburg. Lübek. Eutin. Schwerin. Berlin. Bremen“</li>
@@ -589,9 +589,9 @@
                                                     <li>
                                                         <div>
                                                             
-                                                            <span class="biblio-entry"><span class="author">Carl Maria von Weber</span>, <span class="title">ohne Titel</span>, in: <span class="journalTitle">Weberiana</span>, Heft 16 (2006), S. 65–67</span>
+                                                            <span class="biblio-entry"><span class="author">Carl Maria von Weber</span>, <span class="title">ohne Titel</span>, in: <span class="journalTitle">Weberiana</span><span class="imprint">, Heft 16 (2006), S. 65–67</span></span>
                                                               
-                                                            <div class="collapse" id="source_94edf15f1e7f1314ad202adc6c4e41b5">
+                                                            <div class="collapse" id="source_9e65ee2ed233c423a7ac0fda2d3124ba">
                                                                 
                                                             </div>
                                                         </div>
@@ -1074,7 +1074,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031155.html
+++ b/testing/expected-results/writings/A031155.html
@@ -647,7 +647,7 @@
                                         
                                         <span class="tei_msName">Original in zwei Teilen</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_71d6b7c7a91ca731025d66970c4f1dae">
+                                        <div class="collapse apparatus-details" id="source_2b733baf33cab6f8f335bd121222b3ec">
                                             
                                             
                                             <div>
@@ -668,9 +668,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ep. C. M. v. Weber Varia 9</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_8366e4c4538065476e6f81fcd1b170a0"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_100ab3a33a566ceb23e4fbc8bb012c49"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_8366e4c4538065476e6f81fcd1b170a0">
+                                        <div class="collapse apparatus-details" id="source_100ab3a33a566ceb23e4fbc8bb012c49">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Manuskript ohne Titel; undatiert</li>
@@ -693,9 +693,9 @@
                                                     <li>
                                                         <div>
                                                             
-                                                            <span class="biblio-entry"><span class="author">Carl Maria von Weber</span>, <span class="title">ohne Titel</span>, in: <span class="journalTitle">Weber-Studien. Bericht über das Symposium „Carl Maria von Weber und das Virtuosentum seiner Zeit“ (Dresden 2011) sowie Beiträge zu Weber in Stuttgart und Gotha</span>, Bd. 9 (2014), S. 57–60</span>
+                                                            <span class="biblio-entry"><span class="author">Carl Maria von Weber</span>, <span class="title">ohne Titel</span>, in: <span class="journalTitle">Weber-Studien. Bericht über das Symposium „Carl Maria von Weber und das Virtuosentum seiner Zeit“ (Dresden 2011) sowie Beiträge zu Weber in Stuttgart und Gotha</span><span class="imprint">, Bd. 9 (2014), S. 57–60</span></span>
                                                               
-                                                            <div class="collapse" id="source_ec83df1255e842dd071ce15f448a202b">
+                                                            <div class="collapse" id="source_7f98c178d5dbfbc699b68ddeaa2c21e8">
                                                                 
                                                             </div>
                                                         </div>
@@ -705,7 +705,7 @@
                                                             
                                                             <span>Faksimile (Fragment 1) in Weberiana, Heft 4 (1995), S. 46f.</span>
                                                               
-                                                            <div class="collapse" id="source_6ce9a3b4be81e3a89a516dd393585bb8">
+                                                            <div class="collapse" id="source_0a658b8837902872f3cf085a4cf8320c">
                                                                 
                                                             </div>
                                                         </div>
@@ -726,9 +726,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XXII), Nr. 3</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_cb9856584988a7011526b1900a7c9756"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_4db9345eba57ea683bf22bc0c0952a2c"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_cb9856584988a7011526b1900a7c9756">
+                                        <div class="collapse apparatus-details" id="source_4db9345eba57ea683bf22bc0c0952a2c">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Incipit: „FinanzWesen Winter. wenn die Opern aufgehört haben,“</li>
@@ -1227,7 +1227,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031159.html
+++ b/testing/expected-results/writings/A031159.html
@@ -508,11 +508,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">HellS II</span> (1828), S. 105</span>
+                                        <span class="biblio-entry"><span class="journalTitle">HellS II</span><span class="imprint"> (1828), S. 105</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_ba7ca00967c20ab7983d7ccaa52fe465"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_7ed26e4d55e9b47a4c26102f2750aa60"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_ba7ca00967c20ab7983d7ccaa52fe465">
+                                        <div class="collapse apparatus-details" id="source_7ed26e4d55e9b47a4c26102f2750aa60">
                                             
                                             
                                             <div>
@@ -525,7 +525,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 245–250 (Nr. 41)</span>
                                                               
-                                                            <div class="collapse" id="source_0317a3e2d3e4e5d9ef563e9f92284a33">
+                                                            <div class="collapse" id="source_3669639877e8691d4e8a5fffd7b6d405">
                                                                 
                                                             </div>
                                                         </div>
@@ -785,7 +785,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031160.html
+++ b/testing/expected-results/writings/A031160.html
@@ -454,11 +454,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung</span>, Jg. 14, Nr. 26 (24. Juni 1812), Sp. 427–432</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung</span><span class="imprint">, Jg. 14, Nr. 26 (24. Juni 1812), Sp. 427–432</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_0107cd8ef9fb4c86290ece960d4cd143"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_237605e45fc4d1c20d1ec476e2d4a24e"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_0107cd8ef9fb4c86290ece960d4cd143">
+                                        <div class="collapse apparatus-details" id="source_237605e45fc4d1c20d1ec476e2d4a24e">
                                             
                                             
                                             <div>
@@ -471,7 +471,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 168–170 (Nr. 42)</span>
                                                               
-                                                            <div class="collapse" id="source_bbf9292f0fe30c377f26380ad52cf5aa">
+                                                            <div class="collapse" id="source_1dc93b5d8ab092824ecd4d4728c0c403">
                                                                 
                                                             </div>
                                                         </div>
@@ -659,7 +659,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031161.html
+++ b/testing/expected-results/writings/A031161.html
@@ -477,11 +477,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung</span>, Jg. 14, Nr. 21 (20. Mai 1812), Sp. 347–349</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung</span><span class="imprint">, Jg. 14, Nr. 21 (20. Mai 1812), Sp. 347–349</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_3364c900b91cda1911db6bff24016139"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_680d722122e0f2592cd8425ae4becd31"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_3364c900b91cda1911db6bff24016139">
+                                        <div class="collapse apparatus-details" id="source_680d722122e0f2592cd8425ae4becd31">
                                             
                                             
                                             <div>
@@ -494,7 +494,7 @@
                                                             
                                                             <span>Musikalische Zeitung für die oesterreichnischen Staaten, Jg. 1, Nr. 5 (25. Juni 1813), S. 36–37</span>
                                                               
-                                                            <div class="collapse" id="source_d0c28cea844fb08ec66d275ec0554085">
+                                                            <div class="collapse" id="source_1e61c8064c6d0f1387c4c0fb7ddefd45">
                                                                 
                                                             </div>
                                                         </div>
@@ -504,7 +504,7 @@
                                                             
                                                             <span>HellS II, S. 101–104</span>
                                                               
-                                                            <div class="collapse" id="source_6a75bce1567fa48d79e1b59862f133f8">
+                                                            <div class="collapse" id="source_94a826cbbea7a29a94e91488dd95b664">
                                                                 
                                                             </div>
                                                         </div>
@@ -514,7 +514,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 120–122 (Nr. 43)</span>
                                                               
-                                                            <div class="collapse" id="source_071774d29ee03f57d100826d8eadbe8a">
+                                                            <div class="collapse" id="source_118261692602c0b60c579cf7874f365d">
                                                                 
                                                             </div>
                                                         </div>
@@ -739,7 +739,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031163.html
+++ b/testing/expected-results/writings/A031163.html
@@ -435,9 +435,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (V), Bl. 36a/r–36a/v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_82ca98c4620f02505c66e80f209d8bda"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_35e807f5889c76b6d77f5fc457558915"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_82ca98c4620f02505c66e80f209d8bda">
+                                        <div class="collapse apparatus-details" id="source_35e807f5889c76b6d77f5fc457558915">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>auf Bl. 1 r und v eines DBl., Format ca. 35,6x21,1 cm, Ränder ausgefranzt, Papier stark vergilbt; WZ: Adler mit gespreizten Flügeln und Orden(?) darunter MATSCHDORF (?), Gegenmarke: CFS, Kettlinien 2,4–2,6 cm; Weber Pag. 59/60</li>
@@ -453,7 +453,7 @@
                                                             
                                                             <span>MMW III 1866, S. 63–65</span>
                                                               
-                                                            <div class="collapse" id="source_9fa19cc4258b21525acd02d57d28f40e">
+                                                            <div class="collapse" id="source_3a3d0ee05df2f6475c45f75080954d8d">
                                                                 
                                                             </div>
                                                         </div>
@@ -463,7 +463,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 325–327 (Nr. 45)</span>
                                                               
-                                                            <div class="collapse" id="source_06f4fef858851026624e2acf1b18856e">
+                                                            <div class="collapse" id="source_3c9217faa55dfcfd60aca02826a6d5ef">
                                                                 
                                                             </div>
                                                         </div>
@@ -849,7 +849,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031164.html
+++ b/testing/expected-results/writings/A031164.html
@@ -456,11 +456,11 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Berlinische Nachrichten von Staats- und gelehrten Sachen</span>, Nr. 107 (5. September 1812)</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Berlinische Nachrichten von Staats- und gelehrten Sachen</span><span class="imprint">, Nr. 107 (5. September 1812)</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_cb23bb0cdeab05e1145606c1a4b4fe9a"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_11087bc94b6b5df91539fe98ce67e575"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_cb23bb0cdeab05e1145606c1a4b4fe9a">
+                                        <div class="collapse apparatus-details" id="source_11087bc94b6b5df91539fe98ce67e575">
                                             
                                             
                                             <div>
@@ -473,7 +473,7 @@
                                                             
                                                             <span class="noDataFound">Keine Angaben gefunden</span>
                                                               
-                                                            <div class="collapse" id="source_f51aeacdd906eb277c1d70a9a6ed9f1f">
+                                                            <div class="collapse" id="source_b1ccfe0a58a2fc51572c2583006cbfe2">
                                                                 
                                                             </div>
                                                         </div>
@@ -483,7 +483,7 @@
                                                             
                                                             <span class="tei_bibl">Badisches Magazin, Jg. 2, Nr. 239 (14. Oktober 1812), S. 945–946 (s. auch <a class="preview writings A031162" href="">Rezension in der AmZ</a>)</span>
                                                               
-                                                            <div class="collapse" id="source_364115173c668f3946fb18034fc8057a">
+                                                            <div class="collapse" id="source_3b4e4c74994305a705ab015a8eeb3826">
                                                                 
                                                             </div>
                                                         </div>
@@ -493,7 +493,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 181f. (Nr. 46)</span>
                                                               
-                                                            <div class="collapse" id="source_b32d6c6fdedf7ab20bfd1aaced49fcf2">
+                                                            <div class="collapse" id="source_d12d4af73b5f3c82e163d4e779d7fb27">
                                                                 
                                                             </div>
                                                         </div>
@@ -516,9 +516,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (V), Bl. 37a/r</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_a8a2b4de4d6c7643fb18a75258700f0f"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_39fe61eefafa4101343306118a8341ed"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_a8a2b4de4d6c7643fb18a75258700f0f">
+                                        <div class="collapse apparatus-details" id="source_39fe61eefafa4101343306118a8341ed">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>über dem Manuskript „Zwölf 4stimmige Gesänge, für 2 Sop:, Tenor und Baß mit begl. P.f. dem H: Abt Vogler pp als Zeichen ausgezeichneter Hochachtung gewidmet von Gottfried Weber. Augsb: Gomb: M: H: in 3 Abtheilungen“; Incipit: „Herr Gottfr: W: in Mannheim der musikalischen Welt rühmlichst bekannt“; datiert: „Berlin d: 29t August [ohne Jahr]“</li>
@@ -888,7 +888,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031167.html
+++ b/testing/expected-results/writings/A031167.html
@@ -449,11 +449,11 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Zeitung für die elegante Welt</span>, Jg. 12, Nr. 198 (3. Oktober 1812), Sp. 1581–1582</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Zeitung für die elegante Welt</span><span class="imprint">, Jg. 12, Nr. 198 (3. Oktober 1812), Sp. 1581–1582</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_2506f709cb81c00df27cdf7cb9971b9e"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_f98b0bd86224fd182659a2a3881b4fbc"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_2506f709cb81c00df27cdf7cb9971b9e">
+                                        <div class="collapse apparatus-details" id="source_f98b0bd86224fd182659a2a3881b4fbc">
                                             
                                             
                                             <div>
@@ -466,7 +466,7 @@
                                                             
                                                             <span class="tei_bibl">mit Ergänzungen nach dem Entwurf in: <span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 29–31 (Nr. 49)</span>
                                                               
-                                                            <div class="collapse" id="source_59d210216bc3af0e265b5d25e2783cdb">
+                                                            <div class="collapse" id="source_c5a0da3e34ec37a5d003c0f866328ac6">
                                                                 
                                                             </div>
                                                         </div>
@@ -489,9 +489,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (V), Bl. 38a/r–38a/v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_81b5bf7bfceeb97c82601b37632fca12"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_5ab4adea2bdf5f984d060c913dd3267a"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_81b5bf7bfceeb97c82601b37632fca12">
+                                        <div class="collapse apparatus-details" id="source_5ab4adea2bdf5f984d060c913dd3267a">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>über dem Manuskript „Dresden.“; Incipit: „- - - des Musikalisch neuen giebt es wenig bey uns,“; datiert: „Gotha d: 27t. Sept. 1812.“; unterzeichnet: „Melos.“</li>
@@ -509,7 +509,7 @@
                                                             
                                                             <span>MMW III, S. 68–70</span>
                                                               
-                                                            <div class="collapse" id="source_43f717346b8e59ca27b0195a4ad611ec">
+                                                            <div class="collapse" id="source_b4f52af0f5af1857e2f5ea9bdce3646e">
                                                                 
                                                             </div>
                                                         </div>
@@ -909,7 +909,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031169.html
+++ b/testing/expected-results/writings/A031169.html
@@ -514,11 +514,11 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Journal des Luxus und der Moden</span>, Bd. 27, Heft 11 (November 1812), S. 724–729</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Journal des Luxus und der Moden</span><span class="imprint">, Bd. 27, Heft 11 (November 1812), S. 724–729</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_1ca1abad2447b8a8d5d7db2eeacb22d2"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b7488a8e09e07843a0cef69f092e6128"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_1ca1abad2447b8a8d5d7db2eeacb22d2">
+                                        <div class="collapse apparatus-details" id="source_b7488a8e09e07843a0cef69f092e6128">
                                             
                                             
                                             <div>
@@ -531,7 +531,7 @@
                                                             
                                                             <span>MMW III, S. 72–75</span>
                                                               
-                                                            <div class="collapse" id="source_a8598774a2bfa66fdfec6a4d7405a7a2">
+                                                            <div class="collapse" id="source_8737bc26e25c90e5074bf7dd02c19296">
                                                                 
                                                             </div>
                                                         </div>
@@ -541,7 +541,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 59–63 (Nr. 52)</span>
                                                               
-                                                            <div class="collapse" id="source_1658f6e971881e539cec1043efa6f645">
+                                                            <div class="collapse" id="source_30b78fb49920267a0935e4e0d1a092e5">
                                                                 
                                                             </div>
                                                         </div>
@@ -564,9 +564,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (V), Bl. 38b/v, Fortsetzung 36b/r–v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_fc4b9c6511d1475512b4e8ac52369e42"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_27fb1fffa02407b7078a438662ef2a58"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_fc4b9c6511d1475512b4e8ac52369e42">
+                                        <div class="collapse apparatus-details" id="source_27fb1fffa02407b7078a438662ef2a58">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>über dem Manuskript „Gotha d: 3t 8ber 1812.“; Incipit: „Bei der Seltenheit mit welcher uns öffentliche Kunstgenüße“</li>
@@ -1077,7 +1077,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031174.html
+++ b/testing/expected-results/writings/A031174.html
@@ -476,9 +476,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span>, Jg. 6, Nr. 303 (18. Dezember 1812), S. 1212</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span><span class="imprint">, Jg. 6, Nr. 303 (18. Dezember 1812), S. 1212</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_48f194193bf882e7601593374dc8cb39">
+                                        <div class="collapse apparatus-details" id="source_0f23fcaeea228feef45b62896dcd94e9">
                                             
                                             
                                             <div>
@@ -690,7 +690,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031178.html
+++ b/testing/expected-results/writings/A031178.html
@@ -456,9 +456,9 @@
                                         
                                         <span>Hamburg (D), Universität Hamburg, Zentrum für Theaterforschung, Theatersammlung (D-Hth)<br /><i>Signatur</i>: in: Mappe 2</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_5e6896d4b0ed8291b1a22a5b7f2baeb8"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6d6d452295f122c68834f6333fb0f7f4"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_5e6896d4b0ed8291b1a22a5b7f2baeb8">
+                                        <div class="collapse apparatus-details" id="source_6d6d452295f122c68834f6333fb0f7f4">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Kopistenabschrift (5 b. S.)</li>
@@ -474,7 +474,7 @@
                                                             
                                                             <span>Nohl 1867, S. 281–283 (ungenau)</span>
                                                               
-                                                            <div class="collapse" id="source_e53ad8db52a85f3a9bccd976e7447fb4">
+                                                            <div class="collapse" id="source_1332e864cefc83400c1061a43dafffec">
                                                                 
                                                             </div>
                                                         </div>
@@ -484,7 +484,7 @@
                                                             
                                                             <span>Hirschberg, Reliquienschrein, S. 85–87 (nach Jähns)</span>
                                                               
-                                                            <div class="collapse" id="source_94641cdf2c6df42d5aa265a23c01ae27">
+                                                            <div class="collapse" id="source_2cfebfc0fa7c884f14f24b10835e8902">
                                                                 
                                                             </div>
                                                         </div>
@@ -494,7 +494,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 519–521 (Nr. 59; hier nur die zwei Tenorstimmen abgedruckt)</span>
                                                               
-                                                            <div class="collapse" id="source_8664fa6e05efd2ea7a3c6377bdc1ac1e">
+                                                            <div class="collapse" id="source_977a2accdcd03c367fea81c618ac0659">
                                                                 
                                                             </div>
                                                         </div>
@@ -504,7 +504,7 @@
                                                             
                                                             <span>Frank Ziegler, JV 180 – Puzzle-Teile zu einem musikalischen Freundschaftsdienst und Anmerkungen zu weiteren dichterisch-musikalischen Eintagsfliegen, in: Weberiana. Mitteilungen der Internationalen Carl-Maria-von-Weber-Gesellschaft e. V., Heft 17 (2007), S. 67–80 (hier Deklamatorium mit musikalischen Einlagen komplett abgedruckt)</span>
                                                               
-                                                            <div class="collapse" id="source_916700ae0555f64285fee21d012b5853">
+                                                            <div class="collapse" id="source_e0168b07ceb04a84a00c3a704f711992">
                                                                 
                                                             </div>
                                                         </div>
@@ -724,7 +724,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031181.html
+++ b/testing/expected-results/writings/A031181.html
@@ -542,11 +542,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">W. G. Beckers Taschenbuch zum geselligen Vergnügen, hg. von Friedrich Kind (unvollst.)</span> (1827), S. 371–385</span>
+                                        <span class="biblio-entry"><span class="journalTitle">W. G. Beckers Taschenbuch zum geselligen Vergnügen, hg. von Friedrich Kind (unvollst.)</span><span class="imprint"> (1827), S. 371–385</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_4518850020a936f3a400bfcfe8392573"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_edf8ac8a7dc88d99479bf754cb1aff42"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_4518850020a936f3a400bfcfe8392573">
+                                        <div class="collapse apparatus-details" id="source_edf8ac8a7dc88d99479bf754cb1aff42">
                                             
                                             
                                             <div>
@@ -559,7 +559,7 @@
                                                             
                                                             <span>HellS I, S. 63–83 (Größere Bruchstücke aus andern Kapiteln II.)</span>
                                                               
-                                                            <div class="collapse" id="source_472aea704e0e35d75c8b21b9725ac35d">
+                                                            <div class="collapse" id="source_d3de63a6dc022e7ba3f07d40970baa3c">
                                                                 
                                                             </div>
                                                         </div>
@@ -569,7 +569,7 @@
                                                             
                                                             <span>MMW III, S. 269–283</span>
                                                               
-                                                            <div class="collapse" id="source_b735115280a73a80f0dcf8f2ac5d5387">
+                                                            <div class="collapse" id="source_fe32c4b67e2d5d146ece38fb93adb856">
                                                                 
                                                             </div>
                                                         </div>
@@ -579,7 +579,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 476–490 (Sechstes Kapitel) (Nr. 160)</span>
                                                               
-                                                            <div class="collapse" id="source_625e2c52cb81938adfa5baf2e38ba21e">
+                                                            <div class="collapse" id="source_eb276f7df202b94056a160e5d011b521">
                                                                 
                                                             </div>
                                                         </div>
@@ -589,7 +589,7 @@
                                                             
                                                             <span class="tei_bibl">Entwurf in: <span class="preview biblio A110173" data-ref="">Jaiser</span>, S. 181–191</span>
                                                               
-                                                            <div class="collapse" id="source_0ee99dd18e8aff6f5c1329ecffcdbbf4">
+                                                            <div class="collapse" id="source_a61043b21a36c58c6a68fd49085f16b4">
                                                                 
                                                             </div>
                                                         </div>
@@ -790,7 +790,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031187.html
+++ b/testing/expected-results/writings/A031187.html
@@ -525,11 +525,11 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Kaiserlich Königlich privilegirte Prager Zeitung</span>, Jg. 2, Nr. 363 (29. Dezember 1815), S. 1475</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Kaiserlich Königlich privilegirte Prager Zeitung</span><span class="imprint">, Jg. 2, Nr. 363 (29. Dezember 1815), S. 1475</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_d96330018f714c03c37730b6a7fa8d2f"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_f9e6117dcbe842b34710763ee87590b3"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_d96330018f714c03c37730b6a7fa8d2f">
+                                        <div class="collapse apparatus-details" id="source_f9e6117dcbe842b34710763ee87590b3">
                                             
                                             
                                             <div>
@@ -542,7 +542,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 63–67 (Nr. 68, 69 und 70)</span>
                                                               
-                                                            <div class="collapse" id="source_6793d0f6b2e95470fdc8a6e439b5096f">
+                                                            <div class="collapse" id="source_9797b5015c778c88cb32b83170d05bf1">
                                                                 
                                                             </div>
                                                         </div>
@@ -565,9 +565,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (VI), Bl. 42r–42v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_00e1b553dd328eb10b4aecb20843fcae"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_cfb9fb9af4ec5bcc0721fffb8721a6ab"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_00e1b553dd328eb10b4aecb20843fcae">
+                                        <div class="collapse apparatus-details" id="source_cfb9fb9af4ec5bcc0721fffb8721a6ab">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>über dem Textbeginn in der linken Spalte „H. Siebert d: 30 Nov.“; Incipit: „Overt. aus Anacreon von Cherubini seelig wogendes Champagner leben“; keine Datierung in A</li>
@@ -586,7 +586,7 @@
                                                             
                                                             <span>HellS II, S. 134–139</span>
                                                               
-                                                            <div class="collapse" id="source_def67f05900bd4235402f67517cf0c38">
+                                                            <div class="collapse" id="source_76edabda02f70f6e086acba5b47d6b5a">
                                                                 
                                                             </div>
                                                         </div>
@@ -596,7 +596,7 @@
                                                             
                                                             <span>MMW III, S. 91–94</span>
                                                               
-                                                            <div class="collapse" id="source_9c18219eba53f4b02cee00e49a07f64f">
+                                                            <div class="collapse" id="source_020203a899162604c738cce610153081">
                                                                 
                                                             </div>
                                                         </div>
@@ -1374,7 +1374,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031194.html
+++ b/testing/expected-results/writings/A031194.html
@@ -464,7 +464,7 @@
                                         
                                         <span class="tei_msName">Meine Ansichten bei Composition der Wohlbrückischen Cantate Kampf und Sieg, für meine Freunde niedergeschrieben den 26. Jänner 1816, in Prag, Separatdruck Berlin 1816</span><br /><span>Leipzig (D), Stadtarchiv (D-LEsa)<br /><i>Signatur</i>: MT/1038/2007</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_ee727cfd751f02041ed1e42c5f8887fc">
+                                        <div class="collapse apparatus-details" id="source_64d5d4f4fba7e45f4a85aab05a88dfa3">
                                             
                                             
                                             <div>
@@ -487,9 +487,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. II A f 3. 21α</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_77cea2787d1933b84c9e1726e2735501"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_98e61870c576a8ae88c087ac0938b9f2"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_77cea2787d1933b84c9e1726e2735501">
+                                        <div class="collapse apparatus-details" id="source_98e61870c576a8ae88c087ac0938b9f2">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>über dem Ms. „Meine Ansichten bey Composition der Wohlbrükschen Cantate, Kampf und Sieg für meine Freunde niedergeschrieben d: 26t. Januar 1816, in Prag. C: M. v Weber.“; Incipit: „Als ich in den lezten Tagen des July, 1815 zu München mit Wohlbrük den Entschluß faßte,“</li>
@@ -508,7 +508,7 @@
                                                             
                                                             <span>HellS II, S. 161–169</span>
                                                               
-                                                            <div class="collapse" id="source_fc99f010188534b02bd306728e7e740e">
+                                                            <div class="collapse" id="source_4e0e399c5382a3d122c9fc2d791df5be">
                                                                 
                                                             </div>
                                                         </div>
@@ -518,7 +518,7 @@
                                                             
                                                             <span>MMW III, S. 94–99</span>
                                                               
-                                                            <div class="collapse" id="source_7d93ae909af3e8ddb6849613e060e27e">
+                                                            <div class="collapse" id="source_64cb5491424489752f6598f1051608a9">
                                                                 
                                                             </div>
                                                         </div>
@@ -528,7 +528,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 199–218 (Nr. 75)</span>
                                                               
-                                                            <div class="collapse" id="source_67ec03ac78c13f76e11e4fa6890a15e4">
+                                                            <div class="collapse" id="source_8a019b3cb38c45dadab7ac37871f4e3c">
                                                                 
                                                             </div>
                                                         </div>
@@ -549,9 +549,9 @@
                                         
                                         <span>London (GB), The British Library (GB-Lbl)<br /><i>Signatur</i>: Add. MS 47843, fol. 60</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_c50ff2d5365cd25ad8afc5770f570566"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_cd7ad7065f0e6d6fb73ff43f4fb74297"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_c50ff2d5365cd25ad8afc5770f570566">
+                                        <div class="collapse apparatus-details" id="source_cd7ad7065f0e6d6fb73ff43f4fb74297">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (durch Gaze restauriert): Kampf- und Sieg-Textabschrift (vermutlich die Beilage zum <a class="preview letters A040878" href="">Rochlitz-Brief</a>)</li>
@@ -1207,7 +1207,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031196.html
+++ b/testing/expected-results/writings/A031196.html
@@ -574,11 +574,11 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Kaiserlich Königlich privilegirte Prager Zeitung</span>, Jg. 3, Nr. 113 (22. April 1816), S. 451</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Kaiserlich Königlich privilegirte Prager Zeitung</span><span class="imprint">, Jg. 3, Nr. 113 (22. April 1816), S. 451</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_f3884afc351e1ca2dda777c0ef254527"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_32a6ce0ac1752217ef6c0ed7f3c31cf0"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_f3884afc351e1ca2dda777c0ef254527">
+                                        <div class="collapse apparatus-details" id="source_32a6ce0ac1752217ef6c0ed7f3c31cf0">
                                             
                                             
                                             <div>
@@ -591,7 +591,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 71–75 (Nr. 77, 78 und 79)</span>
                                                               
-                                                            <div class="collapse" id="source_704d106198d89fd30963a9ba7b5f4390">
+                                                            <div class="collapse" id="source_a3d5d675874a904055868593a8bfac47">
                                                                 
                                                             </div>
                                                         </div>
@@ -614,9 +614,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. II. A f 3. 21η, θ und ι, S. 97f.</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_ce477267dbcb9b18b55a9cb2ef11a0dd"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_0b33d3f92d7f7404b68fd1f6d0404491"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_ce477267dbcb9b18b55a9cb2ef11a0dd">
+                                        <div class="collapse apparatus-details" id="source_0b33d3f92d7f7404b68fd1f6d0404491">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>über dem Ms. „Concert Uebersicht <span class="tei_del_strikethrough">des Winterhalb-Jahres</span> der Fastenzeit 1816“; Niederschrift macht einen geschlossenen Eindruck, aber in drei Teile gegliedert, die durch Absätze und Striche getrennt sind; 1. Teil Incipit: „d: 2t. März gab H: Franz Kral, Mitglied des Orchesters im Landst. Theater. Concert in dem <a class="preview places A130691" href="/exist/apps/WeGA-WebApp/de/A130691.html">Redoutensaale</a>.“ (keine Datierung in A); nach Gedankenstrich 2. Teil Incipit: „Den 6t: März. Concert der Mad. Therese Grünbaum, gebohrne Müller, ebenfalls im <a class="preview places A130691" href="/exist/apps/WeGA-WebApp/de/A130691.html">Redoutensaale</a>.“ (keine Datierung); 3. Teil Incipit: „D: 19t: und 26t. März gaben die Zöglinge des Conserv: der M. Ihre Jährlichen Konzerte.“ (keine Datierung); Webers Notizen zum Konzert am 26. März erfolgten separat, daher am Ende zum Konzert am 19. März Vermerk „die Fortsezzung folgt.“</li>
@@ -633,7 +633,7 @@
                                                             
                                                             <span>HellS II, S. 170–175</span>
                                                               
-                                                            <div class="collapse" id="source_ae6027279ccc966d5d0df286fff78054">
+                                                            <div class="collapse" id="source_1beda7c41f237f57582088cfbe7d3a04">
                                                                 
                                                             </div>
                                                         </div>
@@ -643,7 +643,7 @@
                                                             
                                                             <span>MMW III, S. 104–106</span>
                                                               
-                                                            <div class="collapse" id="source_fdc6016c3964870584fee91763416a2a">
+                                                            <div class="collapse" id="source_8fa3744138103319f840e7f199921b37">
                                                                 
                                                             </div>
                                                         </div>
@@ -1217,7 +1217,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031201.html
+++ b/testing/expected-results/writings/A031201.html
@@ -485,9 +485,9 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung</span>, Jg. 14, Nr. 47 (18. November 1812), Sp. 759–764</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung</span><span class="imprint">, Jg. 14, Nr. 47 (18. November 1812), Sp. 759–764</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_47d002aebec71664d89e89f1ee324f68">
+                                        <div class="collapse apparatus-details" id="source_d2455d90448c1f2ae9446e4eabc6acb6">
                                             
                                             
                                             <div>
@@ -506,10 +506,10 @@
                                     <div>
                                         <strong><span>2. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="author">ohne Verfasserangabe</span>, <span class="journalTitle">Musicalische Zeitung für die österreichischen Staaten</span>, Jg. 2, Nr. 2 (14. Januar 1813), S. 5–6<a class="noteMarker biblioNote" data-toggle="popover" data-ref="#C_22">*</a>
+                                        <span class="biblio-entry"><span class="author">ohne Verfasserangabe</span>,  , in: <span class="journalTitle">Musicalische Zeitung für die österreichischen Staaten</span><span class="imprint">, Jg. 2, Nr. 2 (14. Januar 1813), S. 5–6</span><a class="noteMarker biblioNote" data-toggle="popover" data-ref="#C_22">*</a>
                                                     <div id="C_22" data-title="Bemerkung" style="display:none;">Siehe auch Nr. 3 (21. Januar 1813), S. 9–10.</div></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_6634cc36399d4111343b788cf2a0baef">
+                                        <div class="collapse apparatus-details" id="source_49c46ac66f4cb943996f6c325605a790">
                                             
                                             
                                             <div>
@@ -965,7 +965,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031208.html
+++ b/testing/expected-results/writings/A031208.html
@@ -505,11 +505,11 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Kaiserlich Königlich privilegirte Prager Zeitung</span>, Jg. 3, Nr. 145 (24. Mai 1816), S. 579</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Kaiserlich Königlich privilegirte Prager Zeitung</span><span class="imprint">, Jg. 3, Nr. 145 (24. Mai 1816), S. 579</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_c7e12a625c78454386539847aaa35b54"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_5e89f928b277373f20542bc8e64c7f36"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_c7e12a625c78454386539847aaa35b54">
+                                        <div class="collapse apparatus-details" id="source_5e89f928b277373f20542bc8e64c7f36">
                                             
                                             
                                             <div>
@@ -522,7 +522,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 85–87 (Nr. 89)</span>
                                                               
-                                                            <div class="collapse" id="source_3c84113bcdbdd8b48ccb11dac13e6e08">
+                                                            <div class="collapse" id="source_43c5e883c024002385cea69854473932">
                                                                 
                                                             </div>
                                                         </div>
@@ -545,9 +545,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (VI), Bl. 44a/v–44b/r</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_758b0b7705bf263d6550d8f88bd1ac66"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_7716c9a5f39b3b54f8ff4fb770cfc1b5"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_758b0b7705bf263d6550d8f88bd1ac66">
+                                        <div class="collapse apparatus-details" id="source_7716c9a5f39b3b54f8ff4fb770cfc1b5">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Incipit: „D: 14t. Aprill im St. Theater zum Vorth. des Tonkünstler Witwen und Waisen Institutes“; keine Datierung in A</li>
@@ -565,7 +565,7 @@
                                                             
                                                             <span>HellS II, S. 188–190</span>
                                                               
-                                                            <div class="collapse" id="source_d0f343691a673ad25c04be5f676dda15">
+                                                            <div class="collapse" id="source_e297ba795c8761c61c057c728cf9e5a3">
                                                                 
                                                             </div>
                                                         </div>
@@ -575,7 +575,7 @@
                                                             
                                                             <span>MMW III, S. 115–116</span>
                                                               
-                                                            <div class="collapse" id="source_16f4a1cd8a093a1db77d152dea175fec">
+                                                            <div class="collapse" id="source_23ea84dbe5af156b9a3f82f72d4649fd">
                                                                 
                                                             </div>
                                                         </div>
@@ -855,7 +855,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031224.html
+++ b/testing/expected-results/writings/A031224.html
@@ -442,9 +442,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (VI), Bl. 47b/r</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_aad8b8623031ebe15f6d94c2f70d9c4a"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_29ee48fe2eaa2d1f6151c8e88db4a6c1"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_aad8b8623031ebe15f6d94c2f70d9c4a">
+                                        <div class="collapse apparatus-details" id="source_29ee48fe2eaa2d1f6151c8e88db4a6c1">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>auf Bl. 2r  von DBl., Format 34,8x20,8 cm, WZ: Lilienblüte, Gegenmarke durch Beschnitt nicht mehr vollständig: B?, Kettlinien ca. 2,5 cm; im Entwurf Anfang und Ende des Textes mit Sternchen in Rötel markiert</li>
@@ -468,9 +468,9 @@
                                                             
                                                             <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Kopie: Weberiana, Cl.II B, 4, Nr. 3, S. 941–942 (unter 20. Dez.)</span>
                                                             <span>
-                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_e895f40f7b52eac8ac6194c897f0b0ba"></a>
+                                                                <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed apparatus-details" role="button" href="#source_c712a9027516871a7d024ffb4320cb6c"></a>
                                                             </span>  
-                                                            <div class="collapse" id="source_e895f40f7b52eac8ac6194c897f0b0ba">
+                                                            <div class="collapse" id="source_c712a9027516871a7d024ffb4320cb6c">
                                                                 <h4 class="media-heading">Quellenbeschreibung</h4>
                                                                         <ul>
                                                                             <li>Kopie von Jähns mit eigenhändigem Vermerk: Nach einer für <span class="tei_hi_latintype">Max von Weber</span> angefertigten Abschrift copirt. F.W.J.</li>
@@ -483,7 +483,7 @@
                                                             
                                                             <span>MMW III 1866, S. 120–121</span>
                                                               
-                                                            <div class="collapse" id="source_ba9a8af867ac9c20efbaad92fe78c29b">
+                                                            <div class="collapse" id="source_9fc88da5e20fbcaf88006df217d73b7e">
                                                                 
                                                             </div>
                                                         </div>
@@ -493,7 +493,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 364f. (Nr. 105)</span>
                                                               
-                                                            <div class="collapse" id="source_9af5488533e963052af2600afd993e9d">
+                                                            <div class="collapse" id="source_a6830ad89cbee6f6ce0a11128107b850">
                                                                 
                                                             </div>
                                                         </div>
@@ -821,7 +821,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031251.html
+++ b/testing/expected-results/writings/A031251.html
@@ -488,9 +488,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (II), Bl. 24a/r–25b/v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_268b6055c19da99c698fe10a955dc7ef"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_8dec603f3f640633092fbc072670b98d"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_268b6055c19da99c698fe10a955dc7ef">
+                                        <div class="collapse apparatus-details" id="source_8dec603f3f640633092fbc072670b98d">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Aufsatz auf zwei DBl. jeweils Bl. 1 und 2 r und v (Format 33,3x20,6 cm, WZ: bekröntes Wappen; Gegenmarke: KIRCHBERG, Kettlinien ca. 2,6 cm), mit vielen Korrekturen Webers 
@@ -508,7 +508,7 @@
                                                             
                                                             <span class="tei_bibl"><a class="preview writings A031961" href="">HellS I, S. L-LXVI</a></span>
                                                               
-                                                            <div class="collapse" id="source_73223a91503cda16c660c67f89ea2f54">
+                                                            <div class="collapse" id="source_8e5ecc02e28d7a7ddb5c46bf31d20b30">
                                                                 
                                                             </div>
                                                         </div>
@@ -518,7 +518,7 @@
                                                             
                                                             <span>MMW III, S. 180–189</span>
                                                               
-                                                            <div class="collapse" id="source_35e194a20f7e130ab62fe18cf178fbcc">
+                                                            <div class="collapse" id="source_a939b949b1ee86fa1780baf3d19e98f4">
                                                                 
                                                             </div>
                                                         </div>
@@ -528,7 +528,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 426–436 (Nr. 130)</span>
                                                               
-                                                            <div class="collapse" id="source_b39fc6fcdaa27608effdfae985586f7a">
+                                                            <div class="collapse" id="source_a4e6e440f0841c6e059098bbc3f2d1f4">
                                                                 
                                                             </div>
                                                         </div>
@@ -1529,7 +1529,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031261.html
+++ b/testing/expected-results/writings/A031261.html
@@ -422,9 +422,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (II), Bl. 25b/v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_1d431f24703cbe23f22f2749bb1dcec7"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e56a7cae1bdbf9dcb1d52acb3db7f3c5"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_1d431f24703cbe23f22f2749bb1dcec7">
+                                        <div class="collapse apparatus-details" id="source_e56a7cae1bdbf9dcb1d52acb3db7f3c5">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>auf Bl. 2 v von DBl. (Format 33,3x20,6 cm, WZ: bekröntes Wappen; Gegenmarke: KIRCHBERG, Kettlinien ca. 2,6 cm)</li>
@@ -440,7 +440,7 @@
                                                             
                                                             <span>HellS I, S. LXXVI-LXXVIII</span>
                                                               
-                                                            <div class="collapse" id="source_763a30a6c708e1ff3d1029cf9988f1d3">
+                                                            <div class="collapse" id="source_21944461538651126f86bdaf4159c433">
                                                                 
                                                             </div>
                                                         </div>
@@ -450,7 +450,7 @@
                                                             
                                                             <span>MMW II, S. 216–217</span>
                                                               
-                                                            <div class="collapse" id="source_cb5fe6616a7da5d87d378824e29ff478">
+                                                            <div class="collapse" id="source_377b8b42251deadd167cf12be8ec667c">
                                                                 
                                                             </div>
                                                         </div>
@@ -460,7 +460,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 531f. (Nr. 138)</span>
                                                               
-                                                            <div class="collapse" id="source_a6fb0fc66fcce8c9310d8d17614bc7c3">
+                                                            <div class="collapse" id="source_45314ce97276260cf66734bb440c421f">
                                                                 
                                                             </div>
                                                         </div>
@@ -763,7 +763,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031275.html
+++ b/testing/expected-results/writings/A031275.html
@@ -607,9 +607,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XIV), Bl. 84c/r – 84d/r</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_46368b38ba8f5765a135ac05f3625fee"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_02a7ea922c36136ac7311c60cdc45deb"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_46368b38ba8f5765a135ac05f3625fee">
+                                        <div class="collapse apparatus-details" id="source_02a7ea922c36136ac7311c60cdc45deb">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Ms datiert: „<a class="preview places A130003" href="">Dresden</a> im März 1824.“</li>
@@ -631,7 +631,7 @@
                                                             
                                                             <span class="tei_bibl"><a class="preview writings A032049" href="/exist/apps/WeGA-WebApp/de/A002068/Schriften/A032049.html">AmZ 1848, Jg. 50, Nr. 8, S. 123–127</a></span>
                                                               
-                                                            <div class="collapse" id="source_db499f95482aa93de72adce441d9547d">
+                                                            <div class="collapse" id="source_de7f4741872caee87b46f48618ac3e36">
                                                                 
                                                             </div>
                                                         </div>
@@ -641,7 +641,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 220–225 (Nr. 151)</span>
                                                               
-                                                            <div class="collapse" id="source_05d503dc3890c2a3c72e59d10363fc64">
+                                                            <div class="collapse" id="source_f92c12801cde4586940d1c676ec4b870">
                                                                 
                                                             </div>
                                                         </div>
@@ -937,7 +937,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031281.html
+++ b/testing/expected-results/writings/A031281.html
@@ -435,11 +435,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Baierische National-Zeitung</span>, Nr. 178 (31. Juli 1815), S. 752</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Baierische National-Zeitung</span><span class="imprint">, Nr. 178 (31. Juli 1815), S. 752</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_78a30eb4c9cfa56b5de1b7ac6aef458d"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_1ccda9b8e16bf8dac99b84a7e19ef78a"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_78a30eb4c9cfa56b5de1b7ac6aef458d">
+                                        <div class="collapse apparatus-details" id="source_1ccda9b8e16bf8dac99b84a7e19ef78a">
                                             
                                             
                                             <div>
@@ -450,9 +450,9 @@
                                                     <li>
                                                         <div>
                                                             
-                                                            <span class="biblio-entry"><span class="journalTitle">Baierische National-Zeitung</span>, Nr. 179 (1. August 1815), S. 756</span>
+                                                            <span class="biblio-entry"><span class="journalTitle">Baierische National-Zeitung</span><span class="imprint">, Nr. 179 (1. August 1815), S. 756</span></span>
                                                               
-                                                            <div class="collapse" id="source_8ff5760ed1fffd3416b655ace69fac5e">
+                                                            <div class="collapse" id="source_75faea4155be2668e99186f660ff93fc">
                                                                 
                                                             </div>
                                                         </div>
@@ -460,9 +460,9 @@
                                                             <li>
                                                         <div>
                                                             
-                                                            <span class="biblio-entry"><span class="journalTitle">Baierische National-Zeitung</span>, Nr. 180 (2. August 1815), S. 760</span>
+                                                            <span class="biblio-entry"><span class="journalTitle">Baierische National-Zeitung</span><span class="imprint">, Nr. 180 (2. August 1815), S. 760</span></span>
                                                               
-                                                            <div class="collapse" id="source_bf3f5d116fb20c78bf00c8ced1e6f35d">
+                                                            <div class="collapse" id="source_34c258c2b594c12a35970485d6576b75">
                                                                 
                                                             </div>
                                                         </div>
@@ -650,7 +650,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031285.html
+++ b/testing/expected-results/writings/A031285.html
@@ -500,9 +500,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (I), Bl. 5r–6v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_f2846afc9eb83b53494f263b7162eaf1"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_275c86e7bce5d03b9e2f75464b93bcba"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_f2846afc9eb83b53494f263b7162eaf1">
+                                        <div class="collapse apparatus-details" id="source_275c86e7bce5d03b9e2f75464b93bcba">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>2 Bl. (4 b. S.); Text unvollständig</li>
@@ -521,7 +521,7 @@
                                                             
                                                             <span>"Fragment aus einer musikalischen Reise, die vielleicht erscheinen wird", in: Morgenblatt für gebildete Stände, Jg. 3, Nr. 309 (27. Dezember 1809), S. 1233f.</span>
                                                               
-                                                            <div class="collapse" id="source_b5231c56a8738176e3889fdc1e7b3135">
+                                                            <div class="collapse" id="source_f10b08ad5fcb7b2761ee74bc5c777263">
                                                                 
                                                             </div>
                                                         </div>
@@ -531,7 +531,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="tei_hi_italic">Minerva als Beilage zum allg. musik. Anzeiger</span>, Jg. 1, Nr. 37 (14. März 1827), S. 289–293, bezeichnet als "Traum von Carl Maria von Weber"</span>
                                                               
-                                                            <div class="collapse" id="source_e4c58f13e9d2be5113b904ed037bc626">
+                                                            <div class="collapse" id="source_e9b149ff46333139f167ff0d2fd972a3">
                                                                 
                                                             </div>
                                                         </div>
@@ -541,7 +541,7 @@
                                                             
                                                             <span>HellS I, S. 41–47 (Zum zwei und zwanzigsten Kapitel. Fragment aus einer musikalischen Reise, die vielleicht erscheinen wird.)</span>
                                                               
-                                                            <div class="collapse" id="source_13ad2e553473f423c03cafa57f757623">
+                                                            <div class="collapse" id="source_2265db4f7bff39fe673aca30267a084f">
                                                                 
                                                             </div>
                                                         </div>
@@ -551,7 +551,7 @@
                                                             
                                                             <span>MMW III, S. 256–260 (Zum zweiundzwanzigsten Kapitel)</span>
                                                               
-                                                            <div class="collapse" id="source_f052339996c2571cd764c2db08c4974a">
+                                                            <div class="collapse" id="source_b5d906df2467e0e3359cad2eca88fb90">
                                                                 
                                                             </div>
                                                         </div>
@@ -561,7 +561,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 462–466 (Viertes Kapitel) (Nr. 160)</span>
                                                               
-                                                            <div class="collapse" id="source_27ec38ebd719a81976418d21eacf9c61">
+                                                            <div class="collapse" id="source_867e6ded885d38373f1e11956f50e66a">
                                                                 
                                                             </div>
                                                         </div>
@@ -571,7 +571,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A110173" data-ref="">Jaiser</span>, S. 172/174/176</span>
                                                               
-                                                            <div class="collapse" id="source_db84e2acbbb60a62f1b085a63f54b2c1">
+                                                            <div class="collapse" id="source_9aa2470c33feda802f1ceb4f29454533">
                                                                 
                                                             </div>
                                                         </div>
@@ -1488,7 +1488,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031309.html
+++ b/testing/expected-results/writings/A031309.html
@@ -561,9 +561,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Wiener Modespiegel. Wochenschrift für Mode, schöne Literatur, Novellistik, Kunst und Theater</span>, Jg. 1, Nr. 6 (10. Februar 1853), S. 87–89</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Wiener Modespiegel. Wochenschrift für Mode, schöne Literatur, Novellistik, Kunst und Theater</span><span class="imprint">, Jg. 1, Nr. 6 (10. Februar 1853), S. 87–89</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_737020267acf56a7db1cc25a8d8b8e50">
+                                        <div class="collapse apparatus-details" id="source_53a92d122bfda5476ecf3c975c829826">
                                             
                                             
                                             <div>
@@ -788,7 +788,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031324.html
+++ b/testing/expected-results/writings/A031324.html
@@ -471,9 +471,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (I), Bl. 15a/v–15b/r und 12a/r–12b/v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_559e8a784bd505284c4d339f039503e9"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_5abcc82faf50ae681270f6533e417990"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_559e8a784bd505284c4d339f039503e9">
+                                        <div class="collapse apparatus-details" id="source_5abcc82faf50ae681270f6533e417990">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (davon 2 b. S.) und 1 DBl. (4 b. S.)</li>
@@ -491,7 +491,7 @@
                                                             
                                                             <span class="biblio-entry"><span class="author">Carl Maria von Weber</span>, <span class="title">Bruchstücke aus: Tonkünstlers Leben. Eine Arabeske von Carl Maria von Weber. (Fortsetzung)</span>, in: <span class="collectionTitle">Die Muse</span><span class="vol">, Bd. 1</span><span class="issue">, Heft 3</span>, <span class="placeNYear">1821</span>, S. 81–98</span>
                                                               
-                                                            <div class="collapse" id="source_014b389c96225eaff5b46c45b2ec03e8">
+                                                            <div class="collapse" id="source_7f663c0443a15f61a32310a4931967d5">
                                                                 
                                                             </div>
                                                         </div>
@@ -501,7 +501,7 @@
                                                             
                                                             <span class="tei_bibl">Ausschnitt vorab in AMZ, Jg. 19, Nr. 12 (19. März 1817), Sp. 202–204 (innerhalb Webers <a class="preview writings A030013" href="">„Undine“-Rezension</a>)</span>
                                                               
-                                                            <div class="collapse" id="source_665d7a56789045a0c9c87e445dab70cd">
+                                                            <div class="collapse" id="source_ca154e99480756f8e986cef889c6cb13">
                                                                 
                                                             </div>
                                                         </div>
@@ -511,7 +511,7 @@
                                                             
                                                             <span>HellS I, S. 48–62 (Größere Bruchstücke aus andern Kapiteln I.)</span>
                                                               
-                                                            <div class="collapse" id="source_b4f880ac218e45c51342e36e65f7a32a">
+                                                            <div class="collapse" id="source_4b54d4479e424fcbbd1b623e8951e0b5">
                                                                 
                                                             </div>
                                                         </div>
@@ -521,7 +521,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="tei_hi_italic">Großes Instrumental- und Vokal-Concert. Eine musikalische Anthologie</span>, hg. von Ernst Ortlepp, Bd. 13 (<span class="tei_hi_italic">Bibliothek des Frohsinns</span>, Neue Folge, III. Sektion, Bd. 5), Stuttgart 1841, S. 124–126 (Ausschnitt: Parodie der Kapuzinerpredigt aus <span class="tei_hi_italic">Wallensteins Lager</span>)</span>
                                                               
-                                                            <div class="collapse" id="source_090827b228449d6964384131c09e522d">
+                                                            <div class="collapse" id="source_dd8fff9a4b509f2c2ae5f03f0e6c2ba0">
                                                                 
                                                             </div>
                                                         </div>
@@ -531,7 +531,7 @@
                                                             
                                                             <span>MMW III, S. 260–269</span>
                                                               
-                                                            <div class="collapse" id="source_75f77b696008518726007ab45043ae9e">
+                                                            <div class="collapse" id="source_87f128750e10c11f7ef544930b68d178">
                                                                 
                                                             </div>
                                                         </div>
@@ -541,7 +541,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 466–476 (Fünftes Kapitel) (Nr. 160)</span>
                                                               
-                                                            <div class="collapse" id="source_1e3882a3f463f2ca4b1366f9fad24a12">
+                                                            <div class="collapse" id="source_e915e89ba76d637d6b32676e1cd830d1">
                                                                 
                                                             </div>
                                                         </div>
@@ -551,7 +551,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A110173" data-ref="">Jaiser</span>, S. 213–218</span>
                                                               
-                                                            <div class="collapse" id="source_d8024a80ae2f5040c5a073e862b00c1e">
+                                                            <div class="collapse" id="source_6a153e028481d96d5c3af2b98b572de7">
                                                                 
                                                             </div>
                                                         </div>
@@ -1100,7 +1100,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031341.html
+++ b/testing/expected-results/writings/A031341.html
@@ -528,9 +528,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span>, Jg. 16, Nr. 32 (6. Februar 1822), S. 127–128</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span><span class="imprint">, Jg. 16, Nr. 32 (6. Februar 1822), S. 127–128</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_7f38a1287c357ee9d1c012c7e6d2cd3a">
+                                        <div class="collapse apparatus-details" id="source_64619c6a64d1951437fc67eb31871775">
                                             
                                             
                                             <div>
@@ -718,7 +718,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031352.html
+++ b/testing/expected-results/writings/A031352.html
@@ -453,9 +453,9 @@
                                         
                                         <span>Berlin, Institut für Theaterwissenschaft der Freien Universität Berlin (Archiv)</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_183131100811a0caf6ac924820cb37f8"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_9c74d5b8bebf4ac53b88db7142ef3076"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_183131100811a0caf6ac924820cb37f8">
+                                        <div class="collapse apparatus-details" id="source_9c74d5b8bebf4ac53b88db7142ef3076">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S.)</li>
@@ -753,7 +753,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031362.html
+++ b/testing/expected-results/writings/A031362.html
@@ -515,9 +515,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Allgemeiner Deutscher Theater-Anzeiger</span>, Jg. 4 (1814), Nr. 6 (Fortsetzung zu Jg. 3.1813), S. 22–24</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Allgemeiner Deutscher Theater-Anzeiger</span><span class="imprint">, Jg. 4 (1814), Nr. 6 (Fortsetzung zu Jg. 3.1813), S. 22–24</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_135af5ca841f7492ec4b32730937c4c1">
+                                        <div class="collapse apparatus-details" id="source_beae49034885c1c87c99a5581da27cb6">
                                             
                                             
                                             <div>
@@ -705,7 +705,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031367.html
+++ b/testing/expected-results/writings/A031367.html
@@ -478,9 +478,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Österreichischer Beobachter</span>, Jg. 5, Nr. 62 (3. März 1815), S. 344</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Österreichischer Beobachter</span><span class="imprint">, Jg. 5, Nr. 62 (3. März 1815), S. 344</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_630734c3eccc91cca566134581eff917">
+                                        <div class="collapse apparatus-details" id="source_fd982694f19508e07b70396d425ad906">
                                             
                                             
                                             <div>
@@ -708,7 +708,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031385.html
+++ b/testing/expected-results/writings/A031385.html
@@ -458,9 +458,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Badisches Magazin</span>, Jg. 1, Nr. 238 (7. Dezember 1811), S. 951</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Badisches Magazin</span><span class="imprint">, Jg. 1, Nr. 238 (7. Dezember 1811), S. 951</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_bae56bddc78ca0c3b50c33cdce8f0168">
+                                        <div class="collapse apparatus-details" id="source_76f265f1efa540da3e5c5b7e97c8b11d">
                                             
                                             
                                             <div>
@@ -654,7 +654,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031392.html
+++ b/testing/expected-results/writings/A031392.html
@@ -512,9 +512,9 @@
                                     <div>
                                         <strong><span>1. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung</span>, Jg. 14, Nr. 45 (4. November 1812), Sp. 738–740</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung</span><span class="imprint">, Jg. 14, Nr. 45 (4. November 1812), Sp. 738–740</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_c3b0ca8bfa9bb6eccf18fe769a9caf0c">
+                                        <div class="collapse apparatus-details" id="source_9fa6c23ad2934257bed5681580ed5444">
                                             
                                             
                                             <div>
@@ -533,10 +533,10 @@
                                     <div>
                                         <strong><span>2. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="author">ohne Verfasserangabe</span>, <span class="title">Nachrichten</span>, in: <span class="journalTitle">Musicalische Zeitung für die österreichischen Staaten</span>, Jg. 1, Nr. 16 (30. November 1812), S. 122<a class="noteMarker biblioNote" data-toggle="popover" data-ref="#C_22">*</a>
+                                        <span class="biblio-entry"><span class="author">ohne Verfasserangabe</span>, <span class="title">Nachrichten</span>, in: <span class="journalTitle">Musicalische Zeitung für die österreichischen Staaten</span><span class="imprint">, Jg. 1, Nr. 16 (30. November 1812), S. 122</span><a class="noteMarker biblioNote" data-toggle="popover" data-ref="#C_22">*</a>
                                                     <div id="C_22" data-title="Bemerkung" style="display:none;">Siehe auch Nr. 3 (21. Januar 1813), S. 9–10.</div></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_7e4aa1789271127bf7039c4dd83ec254">
+                                        <div class="collapse apparatus-details" id="source_388bb8b249dfdd0c103404ac564d5c0a">
                                             
                                             
                                             <div>
@@ -846,7 +846,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031425.html
+++ b/testing/expected-results/writings/A031425.html
@@ -473,11 +473,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Zeitung</span>, Jg. 27, Nr. 123 (1. Juli 1824), S. 494</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Zeitung</span><span class="imprint">, Jg. 27, Nr. 123 (1. Juli 1824), S. 494</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_027b2df6c8f25e9d3723a5d8cf390645"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_306263a37fbd1da8140485cba5b94eea"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_027b2df6c8f25e9d3723a5d8cf390645">
+                                        <div class="collapse apparatus-details" id="source_306263a37fbd1da8140485cba5b94eea">
                                             
                                             
                                             <div>
@@ -488,9 +488,9 @@
                                                     <li>
                                                         <div>
                                                             
-                                                            <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung (Intelligenzblatt)</span>, Jg. 26, Nr. 7 (August 1824) bis auf orthographische Unterschiede und Sperrungen identische Version; Preisangabe hier auch zusätzlich in 5 Thlr. 20 Gr., Sp. 30–32</span>
+                                                            <span class="biblio-entry">, in: <span class="journalTitle">Allgemeine Musikalische Zeitung (Intelligenzblatt)</span><span class="imprint">, Jg. 26, Nr. 7 (August 1824) bis auf orthographische Unterschiede und Sperrungen identische Version; Preisangabe hier auch zusätzlich in 5 Thlr. 20 Gr., Sp. 30–32</span></span>
                                                               
-                                                            <div class="collapse" id="source_96238ce47f9e7a898ae4e204dd309ebf">
+                                                            <div class="collapse" id="source_0256ded1edad87f224a5f793a1532b8d">
                                                                 
                                                             </div>
                                                         </div>
@@ -670,7 +670,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031462.html
+++ b/testing/expected-results/writings/A031462.html
@@ -508,9 +508,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Zeitung für die elegante Welt</span>, Jg. 26, Nr. 117 (19. Juni 1826), Sp. 937–941</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Zeitung für die elegante Welt</span><span class="imprint">, Jg. 26, Nr. 117 (19. Juni 1826), Sp. 937–941</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_d20d62edff76b1102c94f49ee65ac8cf">
+                                        <div class="collapse apparatus-details" id="source_adc923ba6b762051450230801dd51453">
                                             
                                             
                                             <div>
@@ -742,7 +742,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031469.html
+++ b/testing/expected-results/writings/A031469.html
@@ -448,9 +448,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Zeitung für die elegante Welt</span>, Jg. 27, Nr. 15 (20. Januar 1827), Sp. 113–115</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Zeitung für die elegante Welt</span><span class="imprint">, Jg. 27, Nr. 15 (20. Januar 1827), Sp. 113–115</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_f763861e1ef8825d8c9c2fff65d47eaa">
+                                        <div class="collapse apparatus-details" id="source_ddcce53ea46db96361344da64d785ebc">
                                             
                                             
                                             <div>
@@ -637,7 +637,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031473.html
+++ b/testing/expected-results/writings/A031473.html
@@ -532,9 +532,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Der Berliner Courier, ein Morgenblatt für Theater, Mode, Eleganz, Stadtleben und Localität</span>, Jg. 2, Nr. 432 (11. Juli 1828), S. 1–3</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Der Berliner Courier, ein Morgenblatt für Theater, Mode, Eleganz, Stadtleben und Localität</span><span class="imprint">, Jg. 2, Nr. 432 (11. Juli 1828), S. 1–3</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_6aa7e8097e4e03e835b2a67ed4d389f1">
+                                        <div class="collapse apparatus-details" id="source_931c1d49e63c97064b559720b7f8984f">
                                             
                                             
                                             <div>
@@ -744,7 +744,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031485.html
+++ b/testing/expected-results/writings/A031485.html
@@ -577,9 +577,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Literarisches Conversations-Blatt für das Jahr 1824</span>, Nr. 174 (29. Juli 1824), Sp. 693–696</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Literarisches Conversations-Blatt für das Jahr 1824</span><span class="imprint">, Nr. 174 (29. Juli 1824), Sp. 693–696</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_a5184a3bc602e646c651fafe4b977c8f">
+                                        <div class="collapse apparatus-details" id="source_5d0dc63c1cb4ee19bb7d06aa8b5c08ae">
                                             
                                             
                                             <div>
@@ -798,7 +798,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031487.html
+++ b/testing/expected-results/writings/A031487.html
@@ -1142,7 +1142,7 @@
                                         
                                         <span class="biblio-entry book"><span class="editor"></span> (Hg.), <span class="title">Klopstock᾽s hundertjähriges Ehrengedächtniß, gefeiert in seiner Vaterstadt am zweiten Julius 1824.  Allen Verehrern des deutschen Barden gewidmet</span>, <span class="placeNYear">Quedlinburg &amp; Leipzig 1824</span>, S. 14–58</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_6f7c486d766f488371e17a35deda69f7">
+                                        <div class="collapse apparatus-details" id="source_3f7c87983ac8b76a9b549d09146ad41c">
                                             
                                             
                                             <div>
@@ -1426,7 +1426,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031498.html
+++ b/testing/expected-results/writings/A031498.html
@@ -442,9 +442,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 8, Nr. 135 (5. Juni 1824), S. 540</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 8, Nr. 135 (5. Juni 1824), S. 540</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_e04aa57f580965847703240f07f4a707">
+                                        <div class="collapse apparatus-details" id="source_b841647227f333afe07e98edcc35c06a">
                                             
                                             
                                             <div>
@@ -624,7 +624,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031574.html
+++ b/testing/expected-results/writings/A031574.html
@@ -498,9 +498,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Freiburger Wochen- oder Unterhaltungs-Blatt</span>, Nr. 28 (6. April 1824), S. 110–112</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Freiburger Wochen- oder Unterhaltungs-Blatt</span><span class="imprint">, Nr. 28 (6. April 1824), S. 110–112</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_9faeaff3b4e3b0411e6d0a63a2a20604">
+                                        <div class="collapse apparatus-details" id="source_2addad6f385f3043f3ef2e5988cd8402">
                                             
                                             
                                             <div>
@@ -732,7 +732,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031592.html
+++ b/testing/expected-results/writings/A031592.html
@@ -497,9 +497,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung, mit besonderer Rücksicht auf den österreichischen Kaiserstaat</span>, Jg. 7, Nr. 57 (16. Juli 1823), Sp. 455–456</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung, mit besonderer Rücksicht auf den österreichischen Kaiserstaat</span><span class="imprint">, Jg. 7, Nr. 57 (16. Juli 1823), Sp. 455–456</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_5f49044c0eebd93eddf00fbe5c1df2d1">
+                                        <div class="collapse apparatus-details" id="source_8d6edeaf84aa5d7f3e1c25d1bccea466">
                                             
                                             
                                             <div>
@@ -693,7 +693,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031595.html
+++ b/testing/expected-results/writings/A031595.html
@@ -666,9 +666,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (I), Bl. 8a/r–10b/r</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_754aaedc60073c8bb6b837b4cac0e7e2"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_725e9b3089481fb3aba207f19eb9315b"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_754aaedc60073c8bb6b837b4cac0e7e2">
+                                        <div class="collapse apparatus-details" id="source_725e9b3089481fb3aba207f19eb9315b">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>3 DBl. (9 b. S.)</li>
@@ -687,7 +687,7 @@
                                                             
                                                             <span class="biblio-entry"><span class="author">Carl Maria von Weber</span>, <span class="title">12. Dichterreliquie. Viertes Bruchstück aus: Tonkünstlers Leben. Eine Arabeske. Von Carl Maria von Weber</span>, in: <span class="collectionTitle">W. G. Beckers Taschenbuch zum geselligen Vergnügen</span>, hg. von <span class="editor">Friedrich Kind</span>, <span class="placeNYear">Leipzig 1827</span>, S. 371–385</span>
                                                               
-                                                            <div class="collapse" id="source_8cbf79648addb225d9a50138f20a22f2">
+                                                            <div class="collapse" id="source_3ec742343d2881bceef2030c303d12a9">
                                                                 
                                                             </div>
                                                         </div>
@@ -697,7 +697,7 @@
                                                             
                                                             <span>HellS I, S. 63–83 (Größere Bruchstücke aus andern Kapiteln II.)</span>
                                                               
-                                                            <div class="collapse" id="source_e6366e16bd377315b401d4b705b905c5">
+                                                            <div class="collapse" id="source_d21bfffb321ee4b80c3bf7053c7fbee3">
                                                                 
                                                             </div>
                                                         </div>
@@ -707,7 +707,7 @@
                                                             
                                                             <span>MMW III, S. 269–283</span>
                                                               
-                                                            <div class="collapse" id="source_18631a340ae0f526da9ebea5636ce7b7">
+                                                            <div class="collapse" id="source_92d455dcf7616c81a4cfe93c63ad2ac5">
                                                                 
                                                             </div>
                                                         </div>
@@ -717,7 +717,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 476–490 (Sechstes Kapitel) (Nr. 160)</span>
                                                               
-                                                            <div class="collapse" id="source_2e402662103ed0fcea1ce41fcdef9a46">
+                                                            <div class="collapse" id="source_02431b0e12a6185fb277b961a9062372">
                                                                 
                                                             </div>
                                                         </div>
@@ -727,7 +727,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A110173" data-ref="">Jaiser</span>, S. 181–191</span>
                                                               
-                                                            <div class="collapse" id="source_efe3dc783948f6aa24238884dd583e6e">
+                                                            <div class="collapse" id="source_07ee71677eff6edc4fd00fb8e79b7c96">
                                                                 
                                                             </div>
                                                         </div>
@@ -1792,7 +1792,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031612.html
+++ b/testing/expected-results/writings/A031612.html
@@ -540,9 +540,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Berliner allgemeine musikalische Zeitung</span>, Jg. 3, Nr. 3 (18. Januar 1826), S. 21–23</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Berliner allgemeine musikalische Zeitung</span><span class="imprint">, Jg. 3, Nr. 3 (18. Januar 1826), S. 21–23</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_6924c1cfb6cf477cd696908355a1e178">
+                                        <div class="collapse apparatus-details" id="source_ba3cbba1478a1fb70eceb707baf0ed5b">
                                             
                                             
                                             <div>
@@ -722,7 +722,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031629.html
+++ b/testing/expected-results/writings/A031629.html
@@ -477,9 +477,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 11, Nr. 46 (22. Februar 1827), S. 184</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 11, Nr. 46 (22. Februar 1827), S. 184</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_184996a7f506748992c257e45b66129d">
+                                        <div class="collapse apparatus-details" id="source_ddf4699d0efda10060e113cc69217d1b">
                                             
                                             
                                             <div>
@@ -666,7 +666,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031662.html
+++ b/testing/expected-results/writings/A031662.html
@@ -496,9 +496,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Berliner Conversations-Blatt für Poesie, Literatur und Kritik</span>, Jg. 2, Nr. 13 (18. Januar 1828), S. 49–51</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Berliner Conversations-Blatt für Poesie, Literatur und Kritik</span><span class="imprint">, Jg. 2, Nr. 13 (18. Januar 1828), S. 49–51</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_fce9bfd93293c92433435b3a383e1c12">
+                                        <div class="collapse apparatus-details" id="source_37505c62f7c3dd8a19f2df8fa0a15a36">
                                             
                                             
                                             <div>
@@ -678,7 +678,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031667.html
+++ b/testing/expected-results/writings/A031667.html
@@ -712,9 +712,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">The Quarterly Musical Magazine and Review</span>, Jg. 8 (1826), S. 84–101</span>
+                                        <span class="biblio-entry"><span class="journalTitle">The Quarterly Musical Magazine and Review</span><span class="imprint">, Jg. 8 (1826), S. 84–101</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_da4b75b66935b241334cc08950903d84">
+                                        <div class="collapse apparatus-details" id="source_2bfc506691cfdd6b093019cd25ab9ec9">
                                             
                                             
                                             <div>
@@ -914,7 +914,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031675.html
+++ b/testing/expected-results/writings/A031675.html
@@ -567,9 +567,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung, mit besonderer Rücksicht auf den österreichischen Kaiserstaat</span>, Jg. 7, Nr. 90 (8. November 1823), S. 713–719</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung, mit besonderer Rücksicht auf den österreichischen Kaiserstaat</span><span class="imprint">, Jg. 7, Nr. 90 (8. November 1823), S. 713–719</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_3b5645316cd22a736d8ef06448df46af">
+                                        <div class="collapse apparatus-details" id="source_307ecb252675b00d173667d36d541636">
                                             
                                             
                                             <div>
@@ -772,7 +772,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031689.html
+++ b/testing/expected-results/writings/A031689.html
@@ -463,9 +463,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. II A. g, Nr. 2</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_9e4fcc648fbb55761fa9643d3a49fbf3"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_14430b1b18e45a8e17508ae71f050e62"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_9e4fcc648fbb55761fa9643d3a49fbf3">
+                                        <div class="collapse apparatus-details" id="source_14430b1b18e45a8e17508ae71f050e62">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>2 b. S.</li>
@@ -481,7 +481,7 @@
                                                             
                                                             <span class="tei_bibl">Georg Schünemann, Einleitung, in: <span class="tei_hi_italic">Der Freischütz. Nachbildung d. Eigenschrift aus dem Besitz der Preußischen Staatsbibliothek; zur Zweihundertjahrfeier der Berliner Staatsoper 1742–1942</span>, hg. von Georg Schünemann, Berlin 1942, S. 64f.</span>
                                                               
-                                                            <div class="collapse" id="source_61ed4dfad29c5cf2893b094f0aa1fdb5">
+                                                            <div class="collapse" id="source_898a81ba4d749290cd07e06b16d74737">
                                                                 
                                                             </div>
                                                         </div>
@@ -491,7 +491,7 @@
                                                             
                                                             <span class="biblio-entry book"><span class="author">Carl Maria von Weber</span> und <span class="author">Friedrich Kind</span>, <span class="title">Der Freischütz. Kritische Textbuch-Edition</span>, hg. von <span class="editor">Solveig Schreiter</span>, <span class="placeNYear">München 2007</span>, S. 244–246</span>
                                                               
-                                                            <div class="collapse" id="source_03c3011144a6ce0a0caa842069476706">
+                                                            <div class="collapse" id="source_04606d02a7a5c86fecd6d8a046fc9d35">
                                                                 
                                                             </div>
                                                         </div>
@@ -717,7 +717,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031691.html
+++ b/testing/expected-results/writings/A031691.html
@@ -454,9 +454,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Kaiserlich Königlich privilegirte Prager Zeitung</span>, Jg. 1, Nr. 16 (17. April 1814), S. 61</span>
+                                        <span class="biblio-entry">, in: <span class="journalTitle">Kaiserlich Königlich privilegirte Prager Zeitung</span><span class="imprint">, Jg. 1, Nr. 16 (17. April 1814), S. 61</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_42f234f7c6b1b1cce160d1436ffd4cc8">
+                                        <div class="collapse apparatus-details" id="source_a20dde7d5745051f7b46d7a0d0804753">
                                             
                                             
                                             <div>
@@ -636,7 +636,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031694.html
+++ b/testing/expected-results/writings/A031694.html
@@ -456,9 +456,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Der Aehrenleser auf dem Felde der Geschichte, Literatur und Kunst</span>, Jg. 3 (Januar bis März 1823), S. 91–92</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Der Aehrenleser auf dem Felde der Geschichte, Literatur und Kunst</span><span class="imprint">, Jg. 3 (Januar bis März 1823), S. 91–92</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_8d191884ff0a5d48485a591302955f46">
+                                        <div class="collapse apparatus-details" id="source_5ba644e30dba3282067cfa5e568cd035">
                                             
                                             
                                             <div>
@@ -638,7 +638,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031702.html
+++ b/testing/expected-results/writings/A031702.html
@@ -560,9 +560,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Einheimisches, Beilage zur Abend-Zeitung</span>, Jg. 10, Nr. 11 (15. Juni 1826), S. 41–44</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Einheimisches, Beilage zur Abend-Zeitung</span><span class="imprint">, Jg. 10, Nr. 11 (15. Juni 1826), S. 41–44</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_591f37f428b310d27650de38ad2a5a96">
+                                        <div class="collapse apparatus-details" id="source_162875228db06c560bf6b42102578c43">
                                             
                                             
                                             <div>
@@ -764,7 +764,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031706.html
+++ b/testing/expected-results/writings/A031706.html
@@ -576,9 +576,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Allgemeiner Deutscher Theater-Anzeiger</span>, Jg. 4 (1814), Nr. 24, S. 94–96</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Allgemeiner Deutscher Theater-Anzeiger</span><span class="imprint">, Jg. 4 (1814), Nr. 24, S. 94–96</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_a6d3c4e958fd43decce470e832d03113">
+                                        <div class="collapse apparatus-details" id="source_531c41990babd9dd37c4857825480da8">
                                             
                                             
                                             <div>
@@ -766,7 +766,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031753.html
+++ b/testing/expected-results/writings/A031753.html
@@ -494,9 +494,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Allgemeiner Deutscher Theater-Anzeiger</span>, Jg. 4 (1814), Nr. 19, S. 74–75</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Allgemeiner Deutscher Theater-Anzeiger</span><span class="imprint">, Jg. 4 (1814), Nr. 19, S. 74–75</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_be8ec3f637d324e40565e23c4214cf13">
+                                        <div class="collapse apparatus-details" id="source_30d4b9672b4428f06dad8843ceba0a7a">
                                             
                                             
                                             <div>
@@ -684,7 +684,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031766.html
+++ b/testing/expected-results/writings/A031766.html
@@ -621,9 +621,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Cäcilia, eine Zeitschrift für die musikalische Welt</span>, Bd. 2 (1825), Heft 5, S. 42–65</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Cäcilia, eine Zeitschrift für die musikalische Welt</span><span class="imprint">, Bd. 2 (1825), Heft 5, S. 42–65</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_263d445ebaf942ac0594bd6f429484f4">
+                                        <div class="collapse apparatus-details" id="source_6ba7fd7602710c43bc9cb2518d926074">
                                             
                                             
                                             <div>
@@ -838,7 +838,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031793.html
+++ b/testing/expected-results/writings/A031793.html
@@ -533,9 +533,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Wiener Zeitschrift für Kunst, Literatur, Theater und Mode</span>, Jg. 8, Nr. 138 (18. November 1823), S. 1137–1144</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Wiener Zeitschrift für Kunst, Literatur, Theater und Mode</span><span class="imprint">, Jg. 8, Nr. 138 (18. November 1823), S. 1137–1144</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_8fcb38e73863cebe1c27170e3feb6c8c">
+                                        <div class="collapse apparatus-details" id="source_5c375820acd9ac639eca974a10f2f7fd">
                                             
                                             
                                             <div>
@@ -783,7 +783,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031798.html
+++ b/testing/expected-results/writings/A031798.html
@@ -495,9 +495,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span>, Jg. 7, Nr. 112 (11. Mai 1813), S. 448</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span><span class="imprint">, Jg. 7, Nr. 112 (11. Mai 1813), S. 448</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_8e92aba81297b1d9d67c2cf08b7d1265">
+                                        <div class="collapse apparatus-details" id="source_819a21eeb5d84994bbe1eeaf94b6ff7c">
                                             
                                             
                                             <div>
@@ -685,7 +685,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031800.html
+++ b/testing/expected-results/writings/A031800.html
@@ -474,9 +474,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span>, Jg. 12, Nr. 258 (28. Oktober 1818), S. 1031–1032</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span><span class="imprint">, Jg. 12, Nr. 258 (28. Oktober 1818), S. 1031–1032</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_d816e89841f33754ae57f1915506404e">
+                                        <div class="collapse apparatus-details" id="source_6e4ded9753519a43a2508f5458b42c15">
                                             
                                             
                                             <div>
@@ -664,7 +664,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031801.html
+++ b/testing/expected-results/writings/A031801.html
@@ -595,9 +595,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (I), Bl. 1r–1v und 2a/v</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_734b8b05bdaf647885fffe3479c039fd"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_540a99331f44b649ebe38c833b9311d9"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_734b8b05bdaf647885fffe3479c039fd">
+                                        <div class="collapse apparatus-details" id="source_540a99331f44b649ebe38c833b9311d9">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2 b. S.) und 1 DBl. (davon 1 b. S.)</li>
@@ -616,7 +616,7 @@
                                                             
                                                             <span>HellS I, S. 7–13</span>
                                                               
-                                                            <div class="collapse" id="source_cbbd1169227929b9b487ebe05af48093">
+                                                            <div class="collapse" id="source_7ccb2459e5a47c3ba6b8cd0f688e9a76">
                                                                 
                                                             </div>
                                                         </div>
@@ -626,7 +626,7 @@
                                                             
                                                             <span>MMW III, S. 236–241</span>
                                                               
-                                                            <div class="collapse" id="source_3376bc31f90ba1114f004a196e752c68">
+                                                            <div class="collapse" id="source_b0270574daa62a68f5352896a1162ca9">
                                                                 
                                                             </div>
                                                         </div>
@@ -636,7 +636,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 440–444 (Nr. 160)</span>
                                                               
-                                                            <div class="collapse" id="source_78c899074a1e16f6d6e0fee596e15065">
+                                                            <div class="collapse" id="source_506d7ca08132241df8dc145f62218e1d">
                                                                 
                                                             </div>
                                                         </div>
@@ -646,7 +646,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A110173" data-ref="">Jaiser</span>, S. 204–208</span>
                                                               
-                                                            <div class="collapse" id="source_3971ae4d8ede2e115fef33e77b7e0e75">
+                                                            <div class="collapse" id="source_fbe14953810bcd7d6621e30ebdfa938d">
                                                                 
                                                             </div>
                                                         </div>
@@ -1063,7 +1063,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031814.html
+++ b/testing/expected-results/writings/A031814.html
@@ -555,9 +555,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Allgemeiner Deutscher Theater-Anzeiger</span>, Jg. 4 (1814), Nr. 3 (Fortsetzung zu Jg. 3.1813), S. 10–11</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Allgemeiner Deutscher Theater-Anzeiger</span><span class="imprint">, Jg. 4 (1814), Nr. 3 (Fortsetzung zu Jg. 3.1813), S. 10–11</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_d3a60f197db260e5a9934b04111cfcba">
+                                        <div class="collapse apparatus-details" id="source_f5c7419eba9fef533c4f2fa01f3bcf11">
                                             
                                             
                                             <div>
@@ -757,7 +757,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031849.html
+++ b/testing/expected-results/writings/A031849.html
@@ -465,9 +465,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung</span>, Jg. 25, Nr. 52 (24. Dezember 1823), Sp. 861–865</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung</span><span class="imprint">, Jg. 25, Nr. 52 (24. Dezember 1823), Sp. 861–865</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_2ed480cc1ff5064dd9ba6303533a5d02">
+                                        <div class="collapse apparatus-details" id="source_8f9a2733829daa803a6f7696353b27e2">
                                             
                                             
                                             <div>
@@ -655,7 +655,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031861.html
+++ b/testing/expected-results/writings/A031861.html
@@ -490,9 +490,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Archiv für Geschichte, Statistik, Literatur und Kunst</span>, Jg. 14, Nr. 143 (28. November 1823), S. 763–764</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Archiv für Geschichte, Statistik, Literatur und Kunst</span><span class="imprint">, Jg. 14, Nr. 143 (28. November 1823), S. 763–764</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_01e99cd69db56985d99702612748e9eb">
+                                        <div class="collapse apparatus-details" id="source_b53241abd449922282983ce5f05dc8b0">
                                             
                                             
                                             <div>
@@ -701,7 +701,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031874.html
+++ b/testing/expected-results/writings/A031874.html
@@ -1135,9 +1135,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Signale für die musikalische Welt</span>, Jg. 7 (1849), Nr. 37, S. 289–292</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Signale für die musikalische Welt</span><span class="imprint">, Jg. 7 (1849), Nr. 37, S. 289–292</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_bdc167c585441ed11c6e693bff2c494c">
+                                        <div class="collapse apparatus-details" id="source_8c9584aecd4ec6b4fc2a3745f1323951">
                                             
                                             
                                             <div>
@@ -1317,7 +1317,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031878.html
+++ b/testing/expected-results/writings/A031878.html
@@ -503,9 +503,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. V [Mappe XVIII], Abt. 4C, Nr. 44a</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e6892167f2479f11b2d893413fbabbd7"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_ad49140e8fbc6eceed39309682098722"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_e6892167f2479f11b2d893413fbabbd7">
+                                        <div class="collapse apparatus-details" id="source_ad49140e8fbc6eceed39309682098722">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>2 DBl. und 1 Bl. (9 b. S.)</li>
@@ -845,7 +845,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031879.html
+++ b/testing/expected-results/writings/A031879.html
@@ -549,9 +549,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">The Quarterly Musical Magazine and Review</span>, Bd. 8 (1826), S. 139–146</span>
+                                        <span class="biblio-entry"><span class="journalTitle">The Quarterly Musical Magazine and Review</span><span class="imprint">, Bd. 8 (1826), S. 139–146</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_04ecac75f5ea7643d582bd637d33c8a9">
+                                        <div class="collapse apparatus-details" id="source_88092f72a07030a402db287c2611846c">
                                             
                                             
                                             <div>
@@ -739,7 +739,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031897.html
+++ b/testing/expected-results/writings/A031897.html
@@ -601,9 +601,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Neue Zeitschrift für Musik</span>, Jg. 7, Bd. 13, Nr. 3 (8. Juli 1840), S. 9–10</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Neue Zeitschrift für Musik</span><span class="imprint">, Jg. 7, Bd. 13, Nr. 3 (8. Juli 1840), S. 9–10</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_3a1f9d022f3709e34578261f445b557c">
+                                        <div class="collapse apparatus-details" id="source_1f9f0984f859d40130221a65a83f830b">
                                             
                                             
                                             <div>
@@ -809,7 +809,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031929.html
+++ b/testing/expected-results/writings/A031929.html
@@ -493,9 +493,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Wiener Theater-Zeitung</span>, Jg. 9, Nr. 47 (12. Juni 1816), S. 180–181</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Wiener Theater-Zeitung</span><span class="imprint">, Jg. 9, Nr. 47 (12. Juni 1816), S. 180–181</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_95d2bad54aae8ddba0d5d8b64073e427">
+                                        <div class="collapse apparatus-details" id="source_677399955b3b800d048922865514104d">
                                             
                                             
                                             <div>
@@ -694,7 +694,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031942.html
+++ b/testing/expected-results/writings/A031942.html
@@ -550,9 +550,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Wiener Theater-Zeitung</span>, Jg. 9, Nr. 71 (4. September 1816), S. 281–283</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Wiener Theater-Zeitung</span><span class="imprint">, Jg. 9, Nr. 71 (4. September 1816), S. 281–283</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_42873c0b85307f0adcb96a9daef5f698">
+                                        <div class="collapse apparatus-details" id="source_2bb9de864285b8e4924749d6d3cb3448">
                                             
                                             
                                             <div>
@@ -785,7 +785,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031946.html
+++ b/testing/expected-results/writings/A031946.html
@@ -460,9 +460,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Journal für Literatur, Kunst, Luxus und Mode</span>, Jg. 38, Nr. 115 (Dezember 1823), S. 937–939</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Journal für Literatur, Kunst, Luxus und Mode</span><span class="imprint">, Jg. 38, Nr. 115 (Dezember 1823), S. 937–939</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_a031c5acb7983d39e46f4f71fb0adb07">
+                                        <div class="collapse apparatus-details" id="source_b5678c41ce252aa996b122aa4adf60f5">
                                             
                                             
                                             <div>
@@ -664,7 +664,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031952.html
+++ b/testing/expected-results/writings/A031952.html
@@ -568,9 +568,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Wiener Modespiegel. Wochenschrift für Mode, schöne Literatur, Novellistik, Kunst und Theater</span>, Jg. 1, Nr. 4 (27. Januar 1853), S. 52–56</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Wiener Modespiegel. Wochenschrift für Mode, schöne Literatur, Novellistik, Kunst und Theater</span><span class="imprint">, Jg. 1, Nr. 4 (27. Januar 1853), S. 52–56</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_35c7abceae4b8a41ef96b5e684e2823e">
+                                        <div class="collapse apparatus-details" id="source_2d958e0261a488c37631bd4aabf9fcdd">
                                             
                                             
                                             <div>
@@ -819,7 +819,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031955.html
+++ b/testing/expected-results/writings/A031955.html
@@ -471,9 +471,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Didaskalia oder Blätter für Geist, Gemüth und Publizität</span>, Jg. 2, Nr. 175 (23. Juni 1824), S. 2–4</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Didaskalia oder Blätter für Geist, Gemüth und Publizität</span><span class="imprint">, Jg. 2, Nr. 175 (23. Juni 1824), S. 2–4</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_97bd35b245d21a40a1014e4fb468738d">
+                                        <div class="collapse apparatus-details" id="source_9327696198ec7e06e8921077ac0a3675">
                                             
                                             
                                             <div>
@@ -671,7 +671,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031966.html
+++ b/testing/expected-results/writings/A031966.html
@@ -599,9 +599,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Wiener Modespiegel. Wochenschrift für Mode, schöne Literatur, Novellistik, Kunst und Theater</span>, Jg. 1, Nr. 5 (3. Februar 1853), S. 70–73</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Wiener Modespiegel. Wochenschrift für Mode, schöne Literatur, Novellistik, Kunst und Theater</span><span class="imprint">, Jg. 1, Nr. 5 (3. Februar 1853), S. 70–73</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_0b51609ae979d4afe44b21902a787e61">
+                                        <div class="collapse apparatus-details" id="source_ff818db04ce57689a97b41595cde1ad4">
                                             
                                             
                                             <div>
@@ -862,7 +862,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031972.html
+++ b/testing/expected-results/writings/A031972.html
@@ -469,9 +469,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="title">Den 3.<span class="brackets_supplied">[sic!]</span> Mai 1822 | Urteil über den „Freischützen“ | Eine Stimme aus Weimar</span>, in: <span class="journalTitle">Johannes Falk Geheimes Tagebuch 1818–1826.  Aus dem Nachlaß herausgegeben von Ernst Schering unter Mitwirkung von Georg Mlynek</span> (1964)</span>
+                                        <span class="biblio-entry"><span class="title">Den 3.<span class="brackets_supplied">[sic!]</span> Mai 1822 | Urteil über den „Freischützen“ | Eine Stimme aus Weimar</span>, in: <span class="journalTitle">Johannes Falk Geheimes Tagebuch 1818–1826.  Aus dem Nachlaß herausgegeben von Ernst Schering unter Mitwirkung von Georg Mlynek</span><span class="imprint"> (1964)</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_4fd9e196338ad6a555f01f5ab916651d">
+                                        <div class="collapse apparatus-details" id="source_042070e1876cbe1572afd7e5683c4154">
                                             
                                             
                                             <div>
@@ -679,7 +679,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031977.html
+++ b/testing/expected-results/writings/A031977.html
@@ -547,9 +547,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Merkur.  Mittheilungen aus Vorräthen der Heimath und der Fremde, für Wissenschaft, Kunst und Leben</span>, Jg. 1824, Nr. 43 (8. April), S. 169–172</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Merkur.  Mittheilungen aus Vorräthen der Heimath und der Fremde, für Wissenschaft, Kunst und Leben</span><span class="imprint">, Jg. 1824, Nr. 43 (8. April), S. 169–172</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_9654ef829d8deae5dc85a3c379c0840d">
+                                        <div class="collapse apparatus-details" id="source_e9d1aeeb725808ccd0286de8321e258b">
                                             
                                             
                                             <div>
@@ -769,7 +769,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031982.html
+++ b/testing/expected-results/writings/A031982.html
@@ -412,9 +412,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Der Freischütz. Volksoper in drei Aufzügen. Ausgabe letzter Hand</span> (1843), S. 179f.</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Der Freischütz. Volksoper in drei Aufzügen. Ausgabe letzter Hand</span><span class="imprint"> (1843), S. 179f.</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_05364a42652da801dc34e3dfceeb9e16">
+                                        <div class="collapse apparatus-details" id="source_c7b36bc92bc237ab019114afcb39ff13">
                                             
                                             
                                             <div>
@@ -602,7 +602,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031995.html
+++ b/testing/expected-results/writings/A031995.html
@@ -1112,9 +1112,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">The Quarterly Musical Magazine and Review</span>, Bd. 8 (1826), S. 160–184</span>
+                                        <span class="biblio-entry"><span class="journalTitle">The Quarterly Musical Magazine and Review</span><span class="imprint">, Bd. 8 (1826), S. 160–184</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_da78b94af75553f29737dcbe934cd308">
+                                        <div class="collapse apparatus-details" id="source_df07906730c47750a3abe4e45672b33f">
                                             
                                             
                                             <div>
@@ -1302,7 +1302,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A031999.html
+++ b/testing/expected-results/writings/A031999.html
@@ -561,9 +561,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Der Sammler.  Ein Unterhaltungsblatt</span>, Jg. 6, Nr. 29 (19. Februar 1814), S. 116</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Der Sammler.  Ein Unterhaltungsblatt</span><span class="imprint">, Jg. 6, Nr. 29 (19. Februar 1814), S. 116</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_0044f16249ba3bfceee97be39ceccf8e">
+                                        <div class="collapse apparatus-details" id="source_82fe3dbb9c4b752eb99816e7da279efa">
                                             
                                             
                                             <div>
@@ -751,7 +751,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032017.html
+++ b/testing/expected-results/writings/A032017.html
@@ -505,9 +505,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Didaskalia oder Blätter für Geist, Gemüth und Publizität</span>, Jg. 9, Nr. 65 (6. März 1831)</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Didaskalia oder Blätter für Geist, Gemüth und Publizität</span><span class="imprint">, Jg. 9, Nr. 65 (6. März 1831)</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_df8814c956b90df7d4075d61fdf810f7">
+                                        <div class="collapse apparatus-details" id="source_62d1f3221784a541151c6f44235eb505">
                                             
                                             
                                             <div>
@@ -721,7 +721,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032033.html
+++ b/testing/expected-results/writings/A032033.html
@@ -522,9 +522,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Münchener allgemeine Musik-Zeitung</span>, Jg. 1, Nr. 47 (23. August 1828), Sp. 744–748</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Münchener allgemeine Musik-Zeitung</span><span class="imprint">, Jg. 1, Nr. 47 (23. August 1828), Sp. 744–748</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_27aecee9a34962728081a8447e0e28f8">
+                                        <div class="collapse apparatus-details" id="source_595181c07675d131a722a495f144d200">
                                             
                                             
                                             <div>
@@ -738,7 +738,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032041.html
+++ b/testing/expected-results/writings/A032041.html
@@ -475,9 +475,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span>, Jg. 20, Nr. 35 (10. Februar 1826), S. 140</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span><span class="imprint">, Jg. 20, Nr. 35 (10. Februar 1826), S. 140</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_b55a9ea05ae450677118227c7635fa9e">
+                                        <div class="collapse apparatus-details" id="source_8e7c9e97095b34bca03d37861b6de613">
                                             
                                             
                                             <div>
@@ -696,7 +696,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032047.html
+++ b/testing/expected-results/writings/A032047.html
@@ -479,9 +479,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Journal für Literatur, Kunst, Luxus und Mode</span>, Jg. 39, Nr. 13 (Februar 1824), S. 101f.</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Journal für Literatur, Kunst, Luxus und Mode</span><span class="imprint">, Jg. 39, Nr. 13 (Februar 1824), S. 101f.</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_bea5bddc8ed1adc28761f9ec315d97f1">
+                                        <div class="collapse apparatus-details" id="source_bfd5399a6d066120c58ea791b8b461a9">
                                             
                                             
                                             <div>
@@ -684,7 +684,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032049.html
+++ b/testing/expected-results/writings/A032049.html
@@ -642,11 +642,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung</span>, Jg. 50, Nr. 8 (23. Februar 1848), S. 123–127</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung</span><span class="imprint">, Jg. 50, Nr. 8 (23. Februar 1848), S. 123–127</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6606f48d7d0d4b6dc12c29f0a6f48c78"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_e3ac0d2563522e9ffb99df906678e09b"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_6606f48d7d0d4b6dc12c29f0a6f48c78">
+                                        <div class="collapse apparatus-details" id="source_e3ac0d2563522e9ffb99df906678e09b">
                                             
                                             
                                             <div>
@@ -659,7 +659,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A111886" data-ref="">Kaiser (Schriften)</span>, S. 220–225 (Nr. 151)</span>
                                                               
-                                                            <div class="collapse" id="source_de0bc4def17ca3e802505fe580be5990">
+                                                            <div class="collapse" id="source_700e4a2fc7449663636f13c6de9d3d4a">
                                                                 
                                                             </div>
                                                         </div>
@@ -855,7 +855,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032058.html
+++ b/testing/expected-results/writings/A032058.html
@@ -493,9 +493,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Didaskalia oder Blätter für Geist, Gemüth und Publizität</span>, Jg. 2, Nr. 179 (27. Juni 1824), S. 3f.</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Didaskalia oder Blätter für Geist, Gemüth und Publizität</span><span class="imprint">, Jg. 2, Nr. 179 (27. Juni 1824), S. 3f.</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_215ac77678971e8c30235227165e1f10">
+                                        <div class="collapse apparatus-details" id="source_12ca232d6d2d46652ec7b9ac37103904">
                                             
                                             
                                             <div>
@@ -701,7 +701,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032063.html
+++ b/testing/expected-results/writings/A032063.html
@@ -484,9 +484,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. II A. i, Nr. 5</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_3c85579894dda15ba74b7b4bdfe29267"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_24933a161518b9ac934c0ec30d120966"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_3c85579894dda15ba74b7b4bdfe29267">
+                                        <div class="collapse apparatus-details" id="source_24933a161518b9ac934c0ec30d120966">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>½ Bl. (2 b. S. o.Adr.)</li>
@@ -503,7 +503,7 @@
                                                             
                                                             <span>Faks.: Artikel "Hellwig, Karl Friedrich Ludwig", in: MGG, B. 6 (1957), Sp. 119–120</span>
                                                               
-                                                            <div class="collapse" id="source_1e090f54699b40a6ab60f56f9e1cd43d">
+                                                            <div class="collapse" id="source_5c075be5169bd08b990460593e1f88c8">
                                                                 
                                                             </div>
                                                         </div>
@@ -717,7 +717,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032076.html
+++ b/testing/expected-results/writings/A032076.html
@@ -498,9 +498,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Didaskalia oder Blätter für Geist, Gemüth und Publizität</span>, Nr. 358 (24. Dezember 1825), S. 3f.</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Didaskalia oder Blätter für Geist, Gemüth und Publizität</span><span class="imprint">, Nr. 358 (24. Dezember 1825), S. 3f.</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_1af64adf17de9bc6b66340cf8ae1f8ba">
+                                        <div class="collapse apparatus-details" id="source_bb89daa0f5ce4020738eafa271746ad6">
                                             
                                             
                                             <div>
@@ -713,7 +713,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032080.html
+++ b/testing/expected-results/writings/A032080.html
@@ -450,9 +450,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Rheinische Flora, Blätter für Kunst, Leben, Wissen und Verkehr</span>, Bd. 1, Nr. 51 (29. März 1825) Beilage zu No. 51, Bl. 1v</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Rheinische Flora, Blätter für Kunst, Leben, Wissen und Verkehr</span><span class="imprint">, Bd. 1, Nr. 51 (29. März 1825) Beilage zu No. 51, Bl. 1v</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_f5d84dd4a88e5e18e9c9104c8b8d7408">
+                                        <div class="collapse apparatus-details" id="source_5b0120888edfb7025daa76310370b72f">
                                             
                                             
                                             <div>
@@ -640,7 +640,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032096.html
+++ b/testing/expected-results/writings/A032096.html
@@ -565,9 +565,9 @@
                                         
                                         <span>Mainz Musikwissenschaftliches Institut der Universität Mainz (D-MZmi), Nachlass Arno Lemke</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_1680994e93c1e18398e643a92afdf2c2"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_8cf3bb43124f8873ffc96d2b53091418"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_1680994e93c1e18398e643a92afdf2c2">
+                                        <div class="collapse apparatus-details" id="source_8cf3bb43124f8873ffc96d2b53091418">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>6 maschinenschriftliche Seiten</li>
@@ -591,9 +591,9 @@
                                         
                                         <span>In Privatbesitz</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_7f49638b062cf7172c512100d5498232"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_d6746fc2726e488a7af4addc77d4d85b"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_7f49638b062cf7172c512100d5498232">
+                                        <div class="collapse apparatus-details" id="source_d6746fc2726e488a7af4addc77d4d85b">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Verworfenes Konzept und engültige Version Wilhelm Kleinschmidts in Privatbesitz (Info: 2019)</li>
@@ -816,7 +816,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032111.html
+++ b/testing/expected-results/writings/A032111.html
@@ -417,9 +417,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Mus. ms. autogr. theor. C. M. v. Weber WFN 6 (XXII), Nr. 4</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_eb17b68d6236e7d4088c6dc3035d3975"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_4d0a6acdae8d17c684875d9fb718bdca"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_eb17b68d6236e7d4088c6dc3035d3975">
+                                        <div class="collapse apparatus-details" id="source_4d0a6acdae8d17c684875d9fb718bdca">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (1 b. S.)</li>
@@ -710,7 +710,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032143.html
+++ b/testing/expected-results/writings/A032143.html
@@ -467,9 +467,9 @@
                                         
                                         <span>Berlin (D), Archiv der Berlin-Brandenburgischen Akademie der Wissenschaften (D-Bbbaw)<br /><i>Signatur</i>: NL H. von Chézy 100</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_423c5efeb694f62501eca1c29aac5c4a"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_017ee38310662b468f3c65072a779dc3"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_423c5efeb694f62501eca1c29aac5c4a">
+                                        <div class="collapse apparatus-details" id="source_017ee38310662b468f3c65072a779dc3">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 DBl. (3 b. S.)</li>
@@ -739,7 +739,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032163.html
+++ b/testing/expected-results/writings/A032163.html
@@ -871,9 +871,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">The Harmonicon</span>, Bd. 4/1, Nr. 42 (Juni 1826), S. 141–146</span>
+                                        <span class="biblio-entry"><span class="journalTitle">The Harmonicon</span><span class="imprint">, Bd. 4/1, Nr. 42 (Juni 1826), S. 141–146</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_8aafcd2d5baa4c5f1cd9c3221283f31f">
+                                        <div class="collapse apparatus-details" id="source_1288004d1e47b2f75ae2873c141ec001">
                                             
                                             
                                             <div>
@@ -1061,7 +1061,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032172.html
+++ b/testing/expected-results/writings/A032172.html
@@ -462,9 +462,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Regierungs-Blatt für das Königreich Bayern</span>, Jg. 1826, Nr. 27 (1. Juli 1826), Sp. 521–524</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Regierungs-Blatt für das Königreich Bayern</span><span class="imprint">, Jg. 1826, Nr. 27 (1. Juli 1826), Sp. 521–524</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_4f79318c01743952a464a9feef9be8e4">
+                                        <div class="collapse apparatus-details" id="source_9281cf362a19f7eab2a849c675e5db3d">
                                             
                                             
                                             <div>
@@ -644,7 +644,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032173.html
+++ b/testing/expected-results/writings/A032173.html
@@ -393,9 +393,9 @@
                                         
                                         <span>Berlin (D), Archiv der Berlin-Brandenburgischen Akademie der Wissenschaften (D-Bbbaw)<br /><i>Signatur</i>: NL H. von Chézy 7</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_3a963504e9335bca57ed1ffe8d477cb5"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b25e146f0cfdb3d135e4e84207eb200b"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_3a963504e9335bca57ed1ffe8d477cb5">
+                                        <div class="collapse apparatus-details" id="source_b25e146f0cfdb3d135e4e84207eb200b">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Fragment, 15 b. S., Abschrift von <a class="preview persons A000F25" href="">Bertha Borngräber</a></li>
@@ -411,7 +411,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="tei_hi_italic">Unvergessenes. Denkwürdigkeiten aus dem Leben von Helmina von Chezy. Von ihr selbst erzählt</span>, 2. Theil, Leipzig 1858, <a href="https://digital.staatsbibliothek-berlin.de/werkansicht?PPN=PPN1047637006&amp;PHYSID=PHYS_0098&amp;DMDID=DMDLOG_0001&amp;view=picture-single">S. 86–95 <i class="fa fa-external-link" aria-hidden="true"></i></a>, <a href="https://digital.staatsbibliothek-berlin.de/werkansicht?PPN=PPN1047637006&amp;PHYSID=PHYS_0230&amp;DMDID=DMDLOG_0001&amp;view=picture-single">218f. <i class="fa fa-external-link" aria-hidden="true"></i></a>, S. <a href="https://digital.staatsbibliothek-berlin.de/werkansicht?PPN=PPN1047637006&amp;PHYSID=PHYS_0241&amp;DMDID=DMDLOG_0001&amp;view=picture-single">229–234 <i class="fa fa-external-link" aria-hidden="true"></i></a> sowie <a href="https://digital.staatsbibliothek-berlin.de/werkansicht?PPN=PPN1047637006&amp;PHYSID=PHYS_0261&amp;DMDID=DMDLOG_0001&amp;view=picture-single">249–265 <i class="fa fa-external-link" aria-hidden="true"></i></a></span>
                                                               
-                                                            <div class="collapse" id="source_7b3ab54bb01a0406f87ef074f6fed413">
+                                                            <div class="collapse" id="source_c37c35101d897a05eb36272ef16ae5e0">
                                                                 
                                                             </div>
                                                         </div>
@@ -587,7 +587,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032213.html
+++ b/testing/expected-results/writings/A032213.html
@@ -502,9 +502,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Der Sammler.  Ein Unterhaltungsblatt</span>, Jg. 7, Nr. 143 (30. November 1815), S. 588</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Der Sammler.  Ein Unterhaltungsblatt</span><span class="imprint">, Jg. 7, Nr. 143 (30. November 1815), S. 588</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_aca78960c9244b6fbcc268ef1e87477c">
+                                        <div class="collapse apparatus-details" id="source_b5e8c9693b05b9f7fa296e8258ed60c7">
                                             
                                             
                                             <div>
@@ -706,7 +706,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032215.html
+++ b/testing/expected-results/writings/A032215.html
@@ -423,11 +423,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Augsburgische Ordinari Postzeitung</span>, Nr. 290 (4. Dezember 1802)</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Augsburgische Ordinari Postzeitung</span><span class="imprint">, Nr. 290 (4. Dezember 1802)</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_4be9a90b20b6d19f64a7fb29bc77dcce"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_8d5a3c919f269bda569356ea9abf7aef"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_4be9a90b20b6d19f64a7fb29bc77dcce">
+                                        <div class="collapse apparatus-details" id="source_8d5a3c919f269bda569356ea9abf7aef">
                                             
                                             
                                             <div>
@@ -440,7 +440,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="tei_hi_italic">Wiener Zeitung</span>, Jg. 1802, Nr. 101 (18. Dezember), S. 4552 (Textübernahme mit leicht verändertem Beginn: „Ein junger Tonkünstler, Namens Karl Marie v. Weber hat sich kürzlich in Hamburg auf dem Forte piano öffentlich hören lassen; man …)“</span>
                                                               
-                                                            <div class="collapse" id="source_7c5cce6f52e5c1f8bad5311e4d1f8c25">
+                                                            <div class="collapse" id="source_9bde399b970bb45756dce4df86690dc0">
                                                                 
                                                             </div>
                                                         </div>
@@ -640,7 +640,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032227.html
+++ b/testing/expected-results/writings/A032227.html
@@ -463,9 +463,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 11, Nr. 282 (24. November 1827), S. 1128</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 11, Nr. 282 (24. November 1827), S. 1128</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_d15907787bdf1e57b04fb761f99816a7">
+                                        <div class="collapse apparatus-details" id="source_b2b27029e84aa7f53089d80995e67218">
                                             
                                             
                                             <div>
@@ -665,7 +665,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032236.html
+++ b/testing/expected-results/writings/A032236.html
@@ -449,9 +449,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Dresdner Anzeigen</span>, Nr. 181 (13. Dezember 1824), Sp. 2511f.</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Dresdner Anzeigen</span><span class="imprint">, Nr. 181 (13. Dezember 1824), Sp. 2511f.</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_5f8ad4872ba88b91e321ac798428a57c">
+                                        <div class="collapse apparatus-details" id="source_017793cd1aeacde0b90cfc53915d8958">
                                             
                                             
                                             <div>
@@ -631,7 +631,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032237.html
+++ b/testing/expected-results/writings/A032237.html
@@ -498,11 +498,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Beilage zur Allgemeinen Zeitung</span>, Jg. 25, Nr. 204 (6. Dezember 1822), S. 813f.</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Beilage zur Allgemeinen Zeitung</span><span class="imprint">, Jg. 25, Nr. 204 (6. Dezember 1822), S. 813f.</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6c02098347910fdf36335c6b68a5cd27"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_759b7468f2c69a6a077d7ed579674382"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_6c02098347910fdf36335c6b68a5cd27">
+                                        <div class="collapse apparatus-details" id="source_759b7468f2c69a6a077d7ed579674382">
                                             
                                             
                                             <div>
@@ -515,7 +515,7 @@
                                                             
                                                             <span class="tei_bibl">Wiederabdruck in: <span class="tei_hi_italic">Münchener Politische Zeitung</span>, Nr. 291 (7. Dezember 1822), S. 1565, Nr. 292 (9. Dezember 1822), S. 1573f., Nr. 293 (10. Dezember 1822), S. 1577</span>
                                                               
-                                                            <div class="collapse" id="source_84a65efb5227febc69c284e4bdf3387a">
+                                                            <div class="collapse" id="source_31017754045f3bdf90c320ff2ddd92d7">
                                                                 
                                                             </div>
                                                         </div>
@@ -709,7 +709,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032238.html
+++ b/testing/expected-results/writings/A032238.html
@@ -497,9 +497,9 @@
                                         
                                         <span>Berlin (D), Archiv der Berlin-Brandenburgischen Akademie der Wissenschaften (D-Bbbaw)<br /><i>Signatur</i>: NL H. von Chézy 100</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b6e88a73527369299a8ac7cc7e58e8f3"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_ddf75f23a710b366c47e58243ea72af1"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_b6e88a73527369299a8ac7cc7e58e8f3">
+                                        <div class="collapse apparatus-details" id="source_ddf75f23a710b366c47e58243ea72af1">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl</li>
@@ -517,7 +517,7 @@
                                                             
                                                             <span class="tei_bibl">Wiedergabe in: Till Gerrit Waidelich, <span class="tei_hi_italic">„Durch Webers Betrügerey die Hände so gebunden“. Helmina von Chézys Kampf um die Urheberrechte an ihrem Euryanthe-Libretto in ihrer Korrespondenz und Brief-Entwürfen</span>, in: <span class="tei_hi_italic">Weberiana. Mitteilungen der Internationalen Carl-Maria-von-Weber-Gesellschaft e. V.</span>, Heft 18 (2008), S. 68 (nur Beginn bis Fußnote)</span>
                                                               
-                                                            <div class="collapse" id="source_9ddbe9a2e1a4a21488822ecd18bb0584">
+                                                            <div class="collapse" id="source_d3ed649d46395b268be2d46055e0ce7a">
                                                                 
                                                             </div>
                                                         </div>
@@ -935,7 +935,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032240.html
+++ b/testing/expected-results/writings/A032240.html
@@ -573,9 +573,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span>, Jg. 12, Nr. 142 (15. Juni 1818), S. 568</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span><span class="imprint">, Jg. 12, Nr. 142 (15. Juni 1818), S. 568</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_c13a3069143ac5e4109cfb68073c10b7">
+                                        <div class="collapse apparatus-details" id="source_fcc9ec235f09a2b5d760569ee888db58">
                                             
                                             
                                             <div>
@@ -805,7 +805,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032257.html
+++ b/testing/expected-results/writings/A032257.html
@@ -518,9 +518,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Zeitung für die elegante Welt</span>, Jg. 5, Nr. 50 (25. April 1805), Sp. 399</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Zeitung für die elegante Welt</span><span class="imprint">, Jg. 5, Nr. 50 (25. April 1805), Sp. 399</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_4c8c63780880328d831f775fc668e966">
+                                        <div class="collapse apparatus-details" id="source_4a267033dc35349672eeb6529cd0471d">
                                             
                                             
                                             <div>
@@ -753,7 +753,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032280.html
+++ b/testing/expected-results/writings/A032280.html
@@ -422,9 +422,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Wiener allgemeine musikalische Zeitung</span>, Jg. 1, Nr. 15 (10. April 1813), Sp. 232</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Wiener allgemeine musikalische Zeitung</span><span class="imprint">, Jg. 1, Nr. 15 (10. April 1813), Sp. 232</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_a07019e99b296f6916544e4092e892b6">
+                                        <div class="collapse apparatus-details" id="source_fd309fe869c1e5207ed1cb8983fc844c">
                                             
                                             
                                             <div>
@@ -612,7 +612,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032281.html
+++ b/testing/expected-results/writings/A032281.html
@@ -444,9 +444,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Bemerker Nr. 9, Beilage zu: Der Gesellschafter oder Blätter für Geist und Herz</span>, Jg. 8, Nr. 48 (24. März 1824), S. 238</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Bemerker Nr. 9, Beilage zu: Der Gesellschafter oder Blätter für Geist und Herz</span><span class="imprint">, Jg. 8, Nr. 48 (24. März 1824), S. 238</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_8ca7f00567a90914be63a99eba924540">
+                                        <div class="collapse apparatus-details" id="source_b1de0d23458a3eb11378acbdec9d60ab">
                                             
                                             
                                             <div>
@@ -633,7 +633,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032294.html
+++ b/testing/expected-results/writings/A032294.html
@@ -442,9 +442,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">The Harmonicon</span>, Bd. 4/1, Nr. 47 (November 1826), S. 224</span>
+                                        <span class="biblio-entry"><span class="journalTitle">The Harmonicon</span><span class="imprint">, Bd. 4/1, Nr. 47 (November 1826), S. 224</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_86cf93ee9c32da9ea5fb68d42632f085">
+                                        <div class="collapse apparatus-details" id="source_cd6742f8712925e1366eed60b73fa280">
                                             
                                             
                                             <div>
@@ -624,7 +624,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032307.html
+++ b/testing/expected-results/writings/A032307.html
@@ -420,11 +420,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Dresdner Anzeigen</span>, Nr. 25 (2. März 1821), Sp. 351</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Dresdner Anzeigen</span><span class="imprint">, Nr. 25 (2. März 1821), Sp. 351</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_b4011695b7a307c98217b0fb788dd20d"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_3d753818098e1dcac798f028e4a720cc"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_b4011695b7a307c98217b0fb788dd20d">
+                                        <div class="collapse apparatus-details" id="source_3d753818098e1dcac798f028e4a720cc">
                                             
                                             
                                             <div>
@@ -437,7 +437,7 @@
                                                             
                                                             <span class="tei_bibl">Wiederholung in Nr. 29 (12. März 1821), Sp. 399 mit genauer Angabe des Konzertdatums und -ortes (<a class="preview places A130880" href="">Hôtel de Pologne</a>) sowie Preisangaben</span>
                                                               
-                                                            <div class="collapse" id="source_37d61e670fbf533d0e996032ce58e18f">
+                                                            <div class="collapse" id="source_345aa4863c53a8b1a1e48664986aea8f">
                                                                 
                                                             </div>
                                                         </div>
@@ -617,7 +617,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032315.html
+++ b/testing/expected-results/writings/A032315.html
@@ -764,9 +764,9 @@
                                         
                                         <span>Berlin (D), Archiv der Berlin-Brandenburgischen Akademie der Wissenschaften (D-Bbbaw)<br /><i>Signatur</i>: NL H. von Chézy 100</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6efe61f2195c760dfc208ce7d74f3f93"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_8072550b3f5858fabcf37be89531e784"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_6efe61f2195c760dfc208ce7d74f3f93">
+                                        <div class="collapse apparatus-details" id="source_8072550b3f5858fabcf37be89531e784">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Fragment; 4 DBl. und 3 Bl. (22 b. S.), davon ein DBl. beschnitten</li>
@@ -2310,7 +2310,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032339.html
+++ b/testing/expected-results/writings/A032339.html
@@ -460,9 +460,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 1, Nr. 148 (21. Juni 1817)</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 1, Nr. 148 (21. Juni 1817)</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_64a472c47dadab838b7d52ba26be644a">
+                                        <div class="collapse apparatus-details" id="source_356d1a630a8c7355f7036de2ce3298e6">
                                             
                                             
                                             <div>
@@ -642,7 +642,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032347.html
+++ b/testing/expected-results/writings/A032347.html
@@ -697,9 +697,9 @@
                                         
                                         <span>Dresden (D), Sächsische Landesbibliothek Staats- und Universitätsbibliothek Dresden (D-Dl)<br /><i>Signatur</i>: Mscr.Dresd.App.2075.342.1-28</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_54d2338aa62acf72e1d17dff186381b1"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_5864592fb8a296ea04ebafbc3c75016f"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_54d2338aa62acf72e1d17dff186381b1">
+                                        <div class="collapse apparatus-details" id="source_5864592fb8a296ea04ebafbc3c75016f">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>28 b.S., einzelne Zettel, nachträglich in der oberen rechten Ecke jeweils auf der recto-Seite gezählt (von 1 bis 26) (unklar bleibt, ob der fehlende Anfangsteil separat entand bzw. überliefert war)</li>
@@ -723,9 +723,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. V (Mappe XVIII), Abt. 4 B, Nr. 14 H</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_d822589278e5c2f01627627a3d880c55"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_307a4332ba036bec7e8c10014a74f36b"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_d822589278e5c2f01627627a3d880c55">
+                                        <div class="collapse apparatus-details" id="source_307a4332ba036bec7e8c10014a74f36b">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Abschrift von Friedrich Wilhelm Jähns (als Beilage zur Kopie des <a class="preview letters A045790" href="">Briefes</a> von Dusch an Max Maria von Weber vom 11. Dezember 1860)</li>
@@ -741,7 +741,7 @@
                                                             
                                                             <span id="Baser" class="tei_bibl">Friedrich Baser, <span class="tei_hi_italic">Mannheim-Heidelberger Freundschaft zur Zeit der Romantik. Karl Maria von Weber und Freiherr Alexander von Dusch</span>, in: <span class="tei_hi_italic">Die Musik</span>, Jg. 26, Nr. 4 (Januar 1934), S. 277–281 (Es handelt sich um eine gekürzte und offensichtlich teils eigenständig etwas umformulierte Wiedergabe, bei der nur die Abschnitte zu Weber ausgewertet wurden, nicht jene zu Meyerbeer).</span>
                                                               
-                                                            <div class="collapse" id="source_b4beb3d6cb4da22498c0b6652db3e360">
+                                                            <div class="collapse" id="source_7c089b071f3e5edf0c0eb7c805ea5020">
                                                                 
                                                             </div>
                                                         </div>
@@ -1965,7 +1965,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032352.html
+++ b/testing/expected-results/writings/A032352.html
@@ -637,11 +637,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">The Morning Chronicle</span>, Nr. 17654 (13. April 1826), S. 2r</span>
+                                        <span class="biblio-entry"><span class="journalTitle">The Morning Chronicle</span><span class="imprint">, Nr. 17654 (13. April 1826), S. 2r</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_9393106fb027b8313acd2f9967065016"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_75132b9f6d297b35ed28ac8d5c229f3f"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_9393106fb027b8313acd2f9967065016">
+                                        <div class="collapse apparatus-details" id="source_75132b9f6d297b35ed28ac8d5c229f3f">
                                             
                                             
                                             <div>
@@ -654,7 +654,7 @@
                                                             
                                                             <span id="JfLKLuM" class="tei_bibl">Wiedergabe des Beitrags in deutscher Übersetzung in: <span class="tei_hi_italic">Journal für Literatur, Kunst, Luxus und Mode</span>, Jg. 41, Nr. 34 (28. April 1826), S. 265–267</span>
                                                               
-                                                            <div class="collapse" id="source_d229629ad564c3e1b4b59b2f3b046ec2">
+                                                            <div class="collapse" id="source_95f3e83181a068656fa3b02889de2d45">
                                                                 
                                                             </div>
                                                         </div>
@@ -1234,7 +1234,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032361.html
+++ b/testing/expected-results/writings/A032361.html
@@ -476,9 +476,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Berlinische Nachrichten von Staats- und gelehrten Sachen</span>, Nr. 77 (28. Juni 1821)</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Berlinische Nachrichten von Staats- und gelehrten Sachen</span><span class="imprint">, Nr. 77 (28. Juni 1821)</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_3255de25bad6b8dfcbb54dbeb07a1213">
+                                        <div class="collapse apparatus-details" id="source_e77e4704a54abebd8d772495c029102c">
                                             
                                             
                                             <div>
@@ -658,7 +658,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032401.html
+++ b/testing/expected-results/writings/A032401.html
@@ -473,11 +473,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Außerordentliche Beilage Nr. 1 der Allgemeinen Zeitung</span>, Jg. 29, Nr. 146 (26. Mai 1826), S. 1f.</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Außerordentliche Beilage Nr. 1 der Allgemeinen Zeitung</span><span class="imprint">, Jg. 29, Nr. 146 (26. Mai 1826), S. 1f.</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_60a3a98894efd3225056c27f4f08abf8"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_df7380664d3923631e136f1ace0d2cc0"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_60a3a98894efd3225056c27f4f08abf8">
+                                        <div class="collapse apparatus-details" id="source_df7380664d3923631e136f1ace0d2cc0">
                                             
                                             
                                             <div>
@@ -490,7 +490,7 @@
                                                             
                                                             <span class="tei_bibl">wiederabgedruckt in: <span class="tei_hi_italic">Pernausches Wochen-Blatt</span>, 1826, Nr. 27 (3. Juli), S. 215</span>
                                                               
-                                                            <div class="collapse" id="source_0c0b91fa47e0f038ba3695c5c8d12dbe">
+                                                            <div class="collapse" id="source_24db1cb8cc92e6b964c72a6f14db979e">
                                                                 
                                                             </div>
                                                         </div>
@@ -722,7 +722,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032414.html
+++ b/testing/expected-results/writings/A032414.html
@@ -474,11 +474,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Münchener Politische Zeitung</span>, Jg. 26, Nr. 51 (1. März 1825), S. 289</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Münchener Politische Zeitung</span><span class="imprint">, Jg. 26, Nr. 51 (1. März 1825), S. 289</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_c40fca2ccfb37bcd0ed7513aec09be6d"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_af88424accdb14529387a1ed088f4c6e"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_c40fca2ccfb37bcd0ed7513aec09be6d">
+                                        <div class="collapse apparatus-details" id="source_af88424accdb14529387a1ed088f4c6e">
                                             
                                             
                                             <div>
@@ -491,7 +491,7 @@
                                                             
                                                             <span id="sammler" class="tei_bibl"><span class="tei_hi_italic">Der Sammler. Ein Unterhaltungsblatt</span>, Jg. 17, Nr. 30 (10. März 1825), S. 120 (fast wörtliche Übernahme ab dem Satz „Am besten und unzweifelhaftesten bewährt sich <span>[…]</span>“)</span>
                                                               
-                                                            <div class="collapse" id="source_5b6e11b96c6cfed561e3340d0c117f15">
+                                                            <div class="collapse" id="source_07c9f56ad39bc3cb19377243252852f4">
                                                                 
                                                             </div>
                                                         </div>
@@ -501,7 +501,7 @@
                                                             
                                                             <span id="KlagenfurterZeitung" class="tei_bibl"><span class="tei_hi_italic">Klagenfurter Zeitung</span>, Jg. 1825, Nr. 21 (30. März)</span>
                                                               
-                                                            <div class="collapse" id="source_5b28ada75cf85f4d249bfcf327decc89">
+                                                            <div class="collapse" id="source_d209e01797aad3e1587402efe7a3a6bb">
                                                                 
                                                             </div>
                                                         </div>
@@ -703,7 +703,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032457.html
+++ b/testing/expected-results/writings/A032457.html
@@ -523,9 +523,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Der Sammler.  Ein Unterhaltungsblatt</span>, Jg. 8, Nr. 132 (2. November 1816), S. 543f.</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Der Sammler.  Ein Unterhaltungsblatt</span><span class="imprint">, Jg. 8, Nr. 132 (2. November 1816), S. 543f.</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_9ebc81f644e55407201a6152ef365157">
+                                        <div class="collapse apparatus-details" id="source_620b0fe97175f60c9b14c3243f4571b1">
                                             
                                             
                                             <div>
@@ -713,7 +713,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032472.html
+++ b/testing/expected-results/writings/A032472.html
@@ -440,9 +440,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span>, Jg. 11, Nr. 276 (18. November 1817), S. 1103–1104</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span><span class="imprint">, Jg. 11, Nr. 276 (18. November 1817), S. 1103–1104</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_b0f5fe186520b02f4310ccdcf346cd17">
+                                        <div class="collapse apparatus-details" id="source_31bc34a9d4091b8c2ab20e1f2ee0b767">
                                             
                                             
                                             <div>
@@ -622,7 +622,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032486.html
+++ b/testing/expected-results/writings/A032486.html
@@ -450,9 +450,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Zeitung für die elegante Welt</span>, Jg. 16, Nr. 139 (18. Juli 1816), Sp. 1111–1112</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Zeitung für die elegante Welt</span><span class="imprint">, Jg. 16, Nr. 139 (18. Juli 1816), Sp. 1111–1112</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_f1840a06a9888f0553e603016c656565">
+                                        <div class="collapse apparatus-details" id="source_9f1d9551c06c6890419ffdbe950720e0">
                                             
                                             
                                             <div>
@@ -632,7 +632,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032507.html
+++ b/testing/expected-results/writings/A032507.html
@@ -580,9 +580,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span>, Jg. 18, Nr. 142 (14. Juni 1824), S. 567f.</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span><span class="imprint">, Jg. 18, Nr. 142 (14. Juni 1824), S. 567f.</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_f9cd15d286627d14cf88321a334ab1fd">
+                                        <div class="collapse apparatus-details" id="source_6a71b20ca64b60dc04ab13c5ba101f33">
                                             
                                             
                                             <div>
@@ -786,7 +786,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032508.html
+++ b/testing/expected-results/writings/A032508.html
@@ -469,11 +469,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Kjobenhavns kongelig alene privilegerede Adressecomtoirs Efterretninger</span>, Jg. 62, Nr. 233 (4. Oktober 1820)</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Kjobenhavns kongelig alene privilegerede Adressecomtoirs Efterretninger</span><span class="imprint">, Jg. 62, Nr. 233 (4. Oktober 1820)</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_cf7b6e132275b11cfab23f7193ad4ae5"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6692558d04336a0f9908101ec2af316d"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_cf7b6e132275b11cfab23f7193ad4ae5">
+                                        <div class="collapse apparatus-details" id="source_6692558d04336a0f9908101ec2af316d">
                                             
                                             
                                             <div>
@@ -486,7 +486,7 @@
                                                             
                                                             <span id="Efterretninger-1820-10-05" class="tei_bibl">wiederholt in <span class="tei_hi_italic">Kjobenhavns kongelig alene privilegerede Adressecomtoirs Efterretninger</span>, Jg. 62, Nr. 234 (5. Okt. 1820)</span>
                                                               
-                                                            <div class="collapse" id="source_d7f58c407147ec5b6e210943777c2d35">
+                                                            <div class="collapse" id="source_55d8d5c1c8ab60aae6ba26add6323105">
                                                                 
                                                             </div>
                                                         </div>
@@ -496,7 +496,7 @@
                                                             
                                                             <span id="Efterretninger-1820-10-06" class="tei_bibl">wiederholt in <span class="tei_hi_italic">Kjobenhavns kongelig alene privilegerede Adressecomtoirs Efterretninger</span>, Jg. 62, Nr. 235 (6. Okt. 1820)</span>
                                                               
-                                                            <div class="collapse" id="source_437ece77dadf8971ffb2e414651f32ca">
+                                                            <div class="collapse" id="source_bac92763ecdcfe807fa79fe06aeceb11">
                                                                 
                                                             </div>
                                                         </div>
@@ -506,7 +506,7 @@
                                                             
                                                             <span id="dagen239" class="tei_bibl">mit geringfügigen Änderungen ebenfalls abgedruckt in <span class="tei_hi_italic">Dagen</span>, Nr. 239 (6. Oktober 1820)</span>
                                                               
-                                                            <div class="collapse" id="source_4f37e19cc03a5787a51930441adef023">
+                                                            <div class="collapse" id="source_5aaed4a21b8fe78c4c495168cc884560">
                                                                 
                                                             </div>
                                                         </div>
@@ -694,7 +694,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032509.html
+++ b/testing/expected-results/writings/A032509.html
@@ -469,9 +469,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span>, Jg. 9, Nr. 197 (18. August 1815), S. 787–788</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Morgenblatt für gebildete Stände</span><span class="imprint">, Jg. 9, Nr. 197 (18. August 1815), S. 787–788</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_6c966dd91adc0b2b31e0dc9969c4ad38">
+                                        <div class="collapse apparatus-details" id="source_bdc832e6b71113f5029a8242540b37b5">
                                             
                                             
                                             <div>
@@ -651,7 +651,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032512.html
+++ b/testing/expected-results/writings/A032512.html
@@ -734,11 +734,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Königl. privilegirte Berlinische Zeitung</span>, Heft 138 (16. Juni 1867) Erste Beilage, Sonntags-Beilage Nr. 24, S. 93–95</span>
+                                        <span class="biblio-entry">, in: <span class="journalTitle">Königl. privilegirte Berlinische Zeitung</span><span class="imprint">, Heft 138 (16. Juni 1867) Erste Beilage, Sonntags-Beilage Nr. 24, S. 93–95</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_629751967f4239609606518bb39d617b"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_7310998162cf0caf7ebe32bc6645d7d9"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_629751967f4239609606518bb39d617b">
+                                        <div class="collapse apparatus-details" id="source_7310998162cf0caf7ebe32bc6645d7d9">
                                             
                                             
                                             <div>
@@ -751,7 +751,7 @@
                                                             
                                                             <span class="tei_bibl">Neue Berliner Musikzeitung, Jg. 21, Nr. 25 (19. Juni 1867), S. 195–197. Online unter <a href="https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527486/canvas/189/view">https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb10527486/canvas/189/view</a></span>
                                                               
-                                                            <div class="collapse" id="source_978ec10c8b6501739ad385d7fa3a9673">
+                                                            <div class="collapse" id="source_3b3d2b8edc089655776746899e48b155">
                                                                 
                                                             </div>
                                                         </div>
@@ -761,7 +761,7 @@
                                                             
                                                             <span class="tei_bibl">Zellner’s Blätter für Theater, Musik und bildende Kunst, Jg. 13, Nr. 51 (25. Juni 1867), S. 201–203 und Nr. 53 (2. Juli 1867), S. 209f. Online unter <a href="http://anno.onb.ac.at/cgi-content/anno?aid=mtk&amp;datum=18670625&amp;seite=1&amp;zoom=33">http://anno.onb.ac.at/cgi-content/anno?aid=mtk&amp;datum=18670625&amp;seite=1&amp;zoom=33</a> sowie <a href="https://anno.onb.ac.at/cgi-content/anno?aid=mtk&amp;datum=18670702&amp;seite=1&amp;zoom=33">https://anno.onb.ac.at/cgi-content/anno?aid=mtk&amp;datum=18670702&amp;seite=1&amp;zoom=33</a></span>
                                                               
-                                                            <div class="collapse" id="source_86f046ff3cdf9dec7859a24ac008fc6f">
+                                                            <div class="collapse" id="source_624e259bd91f8bb19be557d3a8388054">
                                                                 
                                                             </div>
                                                         </div>
@@ -1070,7 +1070,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032534.html
+++ b/testing/expected-results/writings/A032534.html
@@ -444,9 +444,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Wiener allgemeine Theaterzeitung und Unterhaltungsblatt für Freunde der Kunst, Literatur und des geselligen Lebens</span>, Jg. 7, Nr. 114 (21. Oktober 1814), S. 453–454</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Wiener allgemeine Theaterzeitung und Unterhaltungsblatt für Freunde der Kunst, Literatur und des geselligen Lebens</span><span class="imprint">, Jg. 7, Nr. 114 (21. Oktober 1814), S. 453–454</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_68896e4156ad0b1ffac6d209338e08a1">
+                                        <div class="collapse apparatus-details" id="source_72d03bef5e81a44d9292f0820513a0ae">
                                             
                                             
                                             <div>
@@ -647,7 +647,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032540.html
+++ b/testing/expected-results/writings/A032540.html
@@ -470,9 +470,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Rudolstädtisches Wochenblatt</span>, Jg. 44, Nr. 42 (21. September 1812), S. 162</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Rudolstädtisches Wochenblatt</span><span class="imprint">, Jg. 44, Nr. 42 (21. September 1812), S. 162</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_62036b58ff9823b9bf5f0cc5669b28c7">
+                                        <div class="collapse apparatus-details" id="source_2bb9e47d692cacb676338b34bdff9985">
                                             
                                             
                                             <div>
@@ -659,7 +659,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032606.html
+++ b/testing/expected-results/writings/A032606.html
@@ -619,9 +619,9 @@
                                         
                                         <span>Berlin (D), Archiv der Berlin-Brandenburgischen Akademie der Wissenschaften (D-Bbbaw)<br /><i>Signatur</i>: NL H. von Chézy 100</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_66ea7e508513e98e0e5f4e584ce29cad"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_4c1f24ee8116191abc3f5cc4e376d83e"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_66ea7e508513e98e0e5f4e584ce29cad">
+                                        <div class="collapse apparatus-details" id="source_4c1f24ee8116191abc3f5cc4e376d83e">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Fragment, 3 DBl. (12 b. S.)</li>
@@ -2816,7 +2816,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032615.html
+++ b/testing/expected-results/writings/A032615.html
@@ -682,9 +682,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Neue Zeitschrift für Musik</span>, Jg. 55, Bd. 83, Nr. 4 (25. Januar 1888), S. 44–45</span>
+                                        <span class="biblio-entry">, in: <span class="journalTitle">Neue Zeitschrift für Musik</span><span class="imprint">, Jg. 55, Bd. 83, Nr. 4 (25. Januar 1888), S. 44–45</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_40f9f76202dc7d7b7d26903c4638d3b6">
+                                        <div class="collapse apparatus-details" id="source_0a179589e337c924bde973e5da1664da">
                                             
                                             
                                             <div>
@@ -962,7 +962,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032629.html
+++ b/testing/expected-results/writings/A032629.html
@@ -471,9 +471,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Zeitung für die elegante Welt</span>, Jg. 25, Nr. 73 (15. April 1825), Sp. 583–584</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Zeitung für die elegante Welt</span><span class="imprint">, Jg. 25, Nr. 73 (15. April 1825), Sp. 583–584</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_d94460a8cab4918de42bd35ca8df86f0">
+                                        <div class="collapse apparatus-details" id="source_5cd87c43039f9a45dc5181e903f86e34">
                                             
                                             
                                             <div>
@@ -661,7 +661,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032640.html
+++ b/testing/expected-results/writings/A032640.html
@@ -432,9 +432,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Sächsische Vaterlands-Blätter</span>, Jg. 1, Nr. 63 (27. März 1841), S. 299</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Sächsische Vaterlands-Blätter</span><span class="imprint">, Jg. 1, Nr. 63 (27. März 1841), S. 299</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_6023043c2555ab03ca4aea4cc07c0e37">
+                                        <div class="collapse apparatus-details" id="source_394d5b60e1e29605c31d9b30c79ed839">
                                             
                                             
                                             <div>
@@ -622,7 +622,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032646.html
+++ b/testing/expected-results/writings/A032646.html
@@ -486,9 +486,9 @@
                                         
                                         <span>Berlin (D), Archiv der Berlin-Brandenburgischen Akademie der Wissenschaften (D-Bbbaw)<br /><i>Signatur</i>: NL H. von Chézy 101</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_72425cc664ad2e182416d8c1eef6705d"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_052230e5faa00ec3e8f72f5acafb2199"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_72425cc664ad2e182416d8c1eef6705d">
+                                        <div class="collapse apparatus-details" id="source_052230e5faa00ec3e8f72f5acafb2199">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>1 Bl. (2. b. S.)</li>
@@ -1000,7 +1000,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032654.html
+++ b/testing/expected-results/writings/A032654.html
@@ -420,9 +420,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Journal für Literatur, Kunst, Luxus und Mode</span>, Jg. 31 (September 1816), S. 579</span>
+                                        <span class="biblio-entry">, in: <span class="journalTitle">Journal für Literatur, Kunst, Luxus und Mode</span><span class="imprint">, Jg. 31 (September 1816), S. 579</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_9dcb27b1003a55df03e0fb6fb66822b9">
+                                        <div class="collapse apparatus-details" id="source_ed9f5edc1937195056883aac40f98439">
                                             
                                             
                                             <div>
@@ -602,7 +602,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032662.html
+++ b/testing/expected-results/writings/A032662.html
@@ -477,9 +477,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Sächsische Vaterlands-Blätter</span>, Jg. 1, Nr. 46 (16. Februar 1841), S. 224</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Sächsische Vaterlands-Blätter</span><span class="imprint">, Jg. 1, Nr. 46 (16. Februar 1841), S. 224</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_947b308d21ed63c02a1d40d4c61bfc08">
+                                        <div class="collapse apparatus-details" id="source_09621f9dcbb24ddc3870a67b385ee4a8">
                                             
                                             
                                             <div>
@@ -667,7 +667,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032667.html
+++ b/testing/expected-results/writings/A032667.html
@@ -436,11 +436,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Dresdner Anzeigen</span>, Nr. 36 (13. Februar 1812), S. 279–280</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Dresdner Anzeigen</span><span class="imprint">, Nr. 36 (13. Februar 1812), S. 279–280</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_6e58c2afffcae28f215f17923ab033e6"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_36df78f704471c290dc089573b9758c0"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_6e58c2afffcae28f215f17923ab033e6">
+                                        <div class="collapse apparatus-details" id="source_36df78f704471c290dc089573b9758c0">
                                             
                                             
                                             <div>
@@ -453,7 +453,7 @@
                                                             
                                                             <span class="tei_bibl">wiederholt in <span class="tei_hi_italic">Dresdner Anzeigen für Jedermann</span>, Nr. 37 (14. Februar 1812), Sp. 290-291 (mit der Änderung: "Die heute, als den 14. Februar d. J. angesetzte" und Datum "Dresden, am 14. Febr. 1812."</span>
                                                               
-                                                            <div class="collapse" id="source_76d62335a95f9a5ee3554f5142de4ae5">
+                                                            <div class="collapse" id="source_504b3bbe93d5e0f23b760c1f492fe985">
                                                                 
                                                             </div>
                                                         </div>
@@ -659,7 +659,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032678.html
+++ b/testing/expected-results/writings/A032678.html
@@ -456,7 +456,7 @@
                                         
                                         <span class="tei_bibl"><span class="tei_hi_italic">Rheinische Musen</span>, Jg. 1, Bd. 1 (1794), H. 2, Nr. 6, S. 139f.</span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_3132d3286d3ffb31989e993a9b5dc9e1">
+                                        <div class="collapse apparatus-details" id="source_508e9928caf77b7d0c8281289e519850">
                                             
                                             
                                             <div>
@@ -687,7 +687,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032688.html
+++ b/testing/expected-results/writings/A032688.html
@@ -463,9 +463,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung</span>, Jg. 27, Nr. 12 (23. März 1825), Sp. 196</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung</span><span class="imprint">, Jg. 27, Nr. 12 (23. März 1825), Sp. 196</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_717a6bb55622ca86694f49411e8f32bd">
+                                        <div class="collapse apparatus-details" id="source_348bc81bd07ab290440ff9fc94f211b7">
                                             
                                             
                                             <div>
@@ -665,7 +665,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032753.html
+++ b/testing/expected-results/writings/A032753.html
@@ -443,9 +443,9 @@
                                         
                                         <span>Berlin (D), Staatsbibliothek zu Berlin – Preußischer Kulturbesitz, Musikabteilung (D-B)<br /><i>Signatur</i>: Weberiana Cl. V [Mappe XVIII], Abt. 4 B, Nr. 14 E. B</span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_2c3579a215d046cf5c30802bca3355de"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_2cc1820711c5385678d60aa8e5a1f64d"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_2c3579a215d046cf5c30802bca3355de">
+                                        <div class="collapse apparatus-details" id="source_2cc1820711c5385678d60aa8e5a1f64d">
                                             <h4 class="media-heading">Quellenbeschreibung</h4>
                                                     <ul>
                                                         <li>Auszug aus Millers Autobiographie, notiert von F. W. Jähns</li>
@@ -461,7 +461,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="preview biblio A110145" data-ref=""><span class="tei_hi_italic">Weberiana</span> 13</span>, S. 32f.</span>
                                                               
-                                                            <div class="collapse" id="source_36a7e9ae5ed2efab964bd935f746c1b2">
+                                                            <div class="collapse" id="source_a0f02d00ce7af9dde2b5c3997df89426">
                                                                 
                                                             </div>
                                                         </div>
@@ -661,7 +661,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032763.html
+++ b/testing/expected-results/writings/A032763.html
@@ -726,9 +726,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Neue Zeitschrift für Musik</span>, Jg. 55, Bd. 83, Nr. 3 (18. Januar 1888), S. 32–33</span>
+                                        <span class="biblio-entry">, in: <span class="journalTitle">Neue Zeitschrift für Musik</span><span class="imprint">, Jg. 55, Bd. 83, Nr. 3 (18. Januar 1888), S. 32–33</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_aac15d60f07bdc1089d37b9fc371b685">
+                                        <div class="collapse apparatus-details" id="source_78f87d52529b48995183eb3150ac845c">
                                             
                                             
                                             <div>
@@ -1009,7 +1009,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032828.html
+++ b/testing/expected-results/writings/A032828.html
@@ -1469,9 +1469,9 @@
                                         <strong><span>Textzeuge</span>:</strong>
                                         
                                         <span class="biblio-entry"><span class="journalTitle">„Ei, dem alten Herrn, Zoll’ ich Achtung gern“.
-                            Festschrift für Joachim Veit zum 60. Geburtstag </span> (2016), S. 757–770</span>
+                            Festschrift für Joachim Veit zum 60. Geburtstag </span><span class="imprint"> (2016), S. 757–770</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_40400fd9a4e6e877826b846e1cc9bc5e">
+                                        <div class="collapse apparatus-details" id="source_e03debce852907d30f472dd82ba30641">
                                             
                                             
                                             <div>
@@ -1651,7 +1651,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032859.html
+++ b/testing/expected-results/writings/A032859.html
@@ -2938,9 +2938,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Weberiana. Mitteilungen der Internationalen Carl-Maria-von-Weber-Gesellschaft e. V.</span>, Heft 26 (Sommer 2016), S. 5–50</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Weberiana. Mitteilungen der Internationalen Carl-Maria-von-Weber-Gesellschaft e. V.</span><span class="imprint">, Heft 26 (Sommer 2016), S. 5–50</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_04ba8652bc810377654d512fb97ed6c7">
+                                        <div class="collapse apparatus-details" id="source_5f3da1cc2edf108e32c1befeacc77fad">
                                             
                                             
                                             <div>
@@ -3120,7 +3120,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032893.html
+++ b/testing/expected-results/writings/A032893.html
@@ -610,9 +610,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Blätter für Musik, Theater und Kunst</span>, Jg. 1, Nr. 58 (21. August 1855), S. 229–230</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Blätter für Musik, Theater und Kunst</span><span class="imprint">, Jg. 1, Nr. 58 (21. August 1855), S. 229–230</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_56734489159852d4054c950b865d1215">
+                                        <div class="collapse apparatus-details" id="source_9fd741bfab24d713f640c0bdc0dbcdbd">
                                             
                                             
                                             <div>
@@ -799,7 +799,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032913.html
+++ b/testing/expected-results/writings/A032913.html
@@ -484,9 +484,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 7, Nr. 280 (22. November 1823), S. 1120</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 7, Nr. 280 (22. November 1823), S. 1120</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_0dd5ef2fd180b28a003e7c196b35096f">
+                                        <div class="collapse apparatus-details" id="source_28cc6979c682d0e0a1260472888e260b">
                                             
                                             
                                             <div>
@@ -680,7 +680,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032918.html
+++ b/testing/expected-results/writings/A032918.html
@@ -3749,9 +3749,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Weberiana. Mitteilungen der Internationalen Carl-Maria-von-Weber-Gesellschaft e. V.</span>, Heft 14 (Sommer 2004), S. 35–91</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Weberiana. Mitteilungen der Internationalen Carl-Maria-von-Weber-Gesellschaft e. V.</span><span class="imprint">, Heft 14 (Sommer 2004), S. 35–91</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_2454adb2b8b962b06a0975f33fd00c88">
+                                        <div class="collapse apparatus-details" id="source_b2a02ce9909966cd92220a47f24a8074">
                                             
                                             
                                             <div>
@@ -3945,7 +3945,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A032933.html
+++ b/testing/expected-results/writings/A032933.html
@@ -776,9 +776,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Neue Freie Presse. Morgenblatt</span>, Nr. 8017 (21. Dezember 1886), S. 1–3</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Neue Freie Presse. Morgenblatt</span><span class="imprint">, Nr. 8017 (21. Dezember 1886), S. 1–3</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_6e989181d2ebe7b2f35192b9ea0d69c7">
+                                        <div class="collapse apparatus-details" id="source_ee2a573cfe7d2572471c9604d80b5986">
                                             
                                             
                                             <div>
@@ -1046,7 +1046,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A033070.html
+++ b/testing/expected-results/writings/A033070.html
@@ -3262,9 +3262,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Weberiana. Mitteilungen der Internationalen Carl-Maria-von-Weber-Gesellschaft e. V.</span>, Heft 23 (Sommer 2013), S. 17–63</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Weberiana. Mitteilungen der Internationalen Carl-Maria-von-Weber-Gesellschaft e. V.</span><span class="imprint">, Heft 23 (Sommer 2013), S. 17–63</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_cbc92673b3636f28130f5b684171dae5">
+                                        <div class="collapse apparatus-details" id="source_9ab9a086292a12a395ea5e7cd10bfda4">
                                             
                                             
                                             <div>
@@ -3444,7 +3444,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A033217.html
+++ b/testing/expected-results/writings/A033217.html
@@ -2346,9 +2346,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Weberiana. Mitteilungen der Internationalen Carl-Maria-von-Weber-Gesellschaft e. V.</span>, Heft 16 (Sommer 2006), S. 29–62</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Weberiana. Mitteilungen der Internationalen Carl-Maria-von-Weber-Gesellschaft e. V.</span><span class="imprint">, Heft 16 (Sommer 2006), S. 29–62</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_c7fb3a064a6c199146d89d85fcf946e9">
+                                        <div class="collapse apparatus-details" id="source_583a2bd57e050866b94c91b270332c87">
                                             
                                             
                                             <div>
@@ -2542,7 +2542,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A033311.html
+++ b/testing/expected-results/writings/A033311.html
@@ -408,9 +408,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span>, Jg. 5, Nr. 114 (12. Mai 1821), Bl. 2v</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Abend-Zeitung</span><span class="imprint">, Jg. 5, Nr. 114 (12. Mai 1821), Bl. 2v</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_2b14c3ef7dfd6f6d050d17865615227d">
+                                        <div class="collapse apparatus-details" id="source_c1e9698b9b498d74af821cdf132042e5">
                                             
                                             
                                             <div>
@@ -586,7 +586,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A033339.html
+++ b/testing/expected-results/writings/A033339.html
@@ -468,11 +468,11 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Berlinische Nachrichten von Staats- und gelehrten Sachen</span>, Nr. 173 (26. Juli 1824)</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Berlinische Nachrichten von Staats- und gelehrten Sachen</span><span class="imprint">, Nr. 173 (26. Juli 1824)</span></span>
                                         <span>
-                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_144852077a8eedf1442510bbd44b0239"></a>                                                                                                                                                                               
+                                            <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_ffbd934551296ecfa3837c10014611af"></a>                                                                                                                                                                               
                                         </span>                                      
-                                        <div class="collapse apparatus-details" id="source_144852077a8eedf1442510bbd44b0239">
+                                        <div class="collapse apparatus-details" id="source_ffbd934551296ecfa3837c10014611af">
                                             
                                             
                                             <div>
@@ -485,7 +485,7 @@
                                                             
                                                             <span class="tei_bibl"><a class="preview writings A031616" href=""><span class="tei_hi_italic">Magdeburgische Zeitung</span>, Nr. 90 (27. Juli 1824)</a> (mit kleineren Abweichungen, dort mit Datierung „vom 23. July“)</span>
                                                               
-                                                            <div class="collapse" id="source_144262d92438d710b110a2dde8204c66">
+                                                            <div class="collapse" id="source_0c0c0ced8ee1e928c1699ba0144cc203">
                                                                 
                                                             </div>
                                                         </div>
@@ -495,7 +495,7 @@
                                                             
                                                             <span class="tei_bibl"><span class="tei_hi_italic">Leipziger Zeitung</span>, Nr. 177 (29. Juli 1824), S. 1955f. (mit kleineren Abweichungen, dort mit Datierung „den 23. July“)</span>
                                                               
-                                                            <div class="collapse" id="source_504d984a302a57f7e75593f4aa8ae5e1">
+                                                            <div class="collapse" id="source_b992a2459275958d6551620a0f4d0391">
                                                                 
                                                             </div>
                                                         </div>
@@ -505,7 +505,7 @@
                                                             
                                                             <span class="tei_bibl"><a class="preview writings A031483" href=""><span class="tei_hi_italic">Hallisches patriotisches Wochenblatt zur Beförderung gemeinnütziger Kenntnisse und wohlthätiger Zwecke</span>, Jg. 25, Nr. 33 (14. August 1824), S. 769–771 </a> (mit kleineren Abweichungen)</span>
                                                               
-                                                            <div class="collapse" id="source_81dc5f8c315a4cfaa4665738e3540851">
+                                                            <div class="collapse" id="source_280a7d60a4c8eae3c62136f421916ec9">
                                                                 
                                                             </div>
                                                         </div>
@@ -700,7 +700,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A033440.html
+++ b/testing/expected-results/writings/A033440.html
@@ -434,9 +434,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Königlich privilegirte Berlinische Zeitung von Staats- und gelehrten Sachen</span>, Nr. 63 (26. Mai 1812)</span>
+                                        <span class="biblio-entry">, in: <span class="journalTitle">Königlich privilegirte Berlinische Zeitung von Staats- und gelehrten Sachen</span><span class="imprint">, Nr. 63 (26. Mai 1812)</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_a79388ecb0a604518a9fa55499817f0e">
+                                        <div class="collapse apparatus-details" id="source_ae6204db65c1406908ca8ef28a8d133b">
                                             
                                             
                                             <div>
@@ -623,7 +623,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A033458.html
+++ b/testing/expected-results/writings/A033458.html
@@ -529,9 +529,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Berlinische Nachrichten von Staats- und gelehrten Sachen</span>, Nr. 41 (4. April 1816)</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Berlinische Nachrichten von Staats- und gelehrten Sachen</span><span class="imprint">, Nr. 41 (4. April 1816)</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_39a6d88f7b27ec1795d16e0d63c1fb02">
+                                        <div class="collapse apparatus-details" id="source_6212973bdaa042cfd3e6d91d58746d62">
                                             
                                             
                                             <div>
@@ -711,7 +711,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A033468.html
+++ b/testing/expected-results/writings/A033468.html
@@ -572,9 +572,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Berlinische Nachrichten von Staats- und gelehrten Sachen</span>, Nr. 45 (5. März 1816)</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Berlinische Nachrichten von Staats- und gelehrten Sachen</span><span class="imprint">, Nr. 45 (5. März 1816)</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_06b106fd576dbfa713449e8eea23ab67">
+                                        <div class="collapse apparatus-details" id="source_aa67a539f354fd61ef674833399e2ea0">
                                             
                                             
                                             <div>
@@ -754,7 +754,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/expected-results/writings/A033469.html
+++ b/testing/expected-results/writings/A033469.html
@@ -448,9 +448,9 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="journalTitle">Journal des Luxus und der Moden</span>, Bd. 34, Nr. 1 (Januar 1819), S. 31</span>
+                                        <span class="biblio-entry"><span class="journalTitle">Journal des Luxus und der Moden</span><span class="imprint">, Bd. 34, Nr. 1 (Januar 1819), S. 31</span></span>
                                                                               
-                                        <div class="collapse apparatus-details" id="source_759fdae626eb6e925a1e86b62bce6ced">
+                                        <div class="collapse apparatus-details" id="source_391a334db208a257f3390affafae5193">
                                             
                                             
                                             <div>
@@ -630,7 +630,6 @@
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/datatables.net-bs4/js/dataTables.bootstrap4.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/lib/fullcalendar/index.global.min.js"></script>
         <script type="text/javascript" src="/exist/apps/WeGA-WebApp/resources/js/wega.js"></script>
-        
         
         
         

--- a/testing/xqsuite/biblio-tests.xqm
+++ b/testing/xqsuite/biblio-tests.xqm
@@ -85,6 +85,7 @@ declare
 declare 
     %test:args('A112915')         %test:assertXPath("$result//xhtml:span[@class='title'] and $result//xhtml:span[@class='author'] and $result//xhtml:span[@class='journalTitle']")
     %test:args('A112660')         %test:assertEquals("<xhtml:div xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:span class='author'>Kurt Mey</xhtml:span>, <xhtml:span class='title'>Richard Wagners Webertrauermarsch</xhtml:span>, in: <xhtml:span class='journalTitle'>Die Musik</xhtml:span>, Bd.&#160;22, Jg.&#160;6, Heft&#160;12 (März 1907), S.&#160;331–336</xhtml:div>")
+    %test:args('A111869')         %test:assertEquals("<xhtml:div xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:span class='author'>Carl Mennicke</xhtml:span>, <xhtml:span class='title'>Unbekannte Schriften von Carl Maria von Weber</xhtml:span></xhtml:div>")
     function bt:test-printArticleCitation($a as xs:string) as element() {
         let $doc := crud:doc($a)
         return
@@ -146,6 +147,14 @@ declare
         let $doc := crud:doc($a)
         return
             bibl:printCitation($doc//tei:biblStruct, <xhtml:div/>, 'de')
+};
+
+declare
+    %test:args('A111869')         %test:assertXPath("count($result) eq 3 and count($result/xhtml:span[@class='journalTitle'][.='Blätter für Haus- und Kirchenmusik']) eq 3")
+    function bt:test-printJournalCitationsByImprint($a as xs:string) as element()+ {
+        let $doc := crud:doc($a)
+        return
+            bibl:printJournalCitationsByImprint($doc//tei:monogr, <xhtml:li/>, 'de')
 };
 
 declare %private function bt:normalize-hrefs($nodes as node()*) as node()* {

--- a/testing/xqsuite/biblio-tests.xqm
+++ b/testing/xqsuite/biblio-tests.xqm
@@ -92,6 +92,14 @@ declare
 };
 
 declare 
+    %test:args('A112067')         %test:assertEquals("<xhtml:div xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:span class='author'>Heinrich Dorn</xhtml:span>, <xhtml:span class='title'>Aus meinem Leben. Im Elfenreich</xhtml:span></xhtml:div>")
+    function bt:test-multipleImprints($a as xs:string) as element() {
+        let $doc := crud:doc($a)
+        return
+            bibl:printArticleCitation($doc/tei:biblStruct, <xhtml:div/>, 'de')
+};
+
+declare 
     %test:args('A110876')         %test:assertEquals("<xhtml:div xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:span class='author'>Karl Robert Brachtel</xhtml:span>,  [Rezension] <xhtml:span class='title'><a class='preview biblio A110900' href='A007979/Bibliographie/A110900.html'>Hans Hoffmann: „Carl Maria von Weber – Leben und Werk“, Druck- und Verlagsgesellschaft, Husum 1978</a></xhtml:span>, in: <xhtml:span class='journalTitle'>Das Orchester</xhtml:span>, Jg.&#160;27 (1979), Heft&#160;10, S.&#160;774</xhtml:div>")
     function bt:test-printReview($a as xs:string) as node()* {
         let $doc := crud:doc($a)

--- a/testing/xqsuite/biblio-tests.xqm
+++ b/testing/xqsuite/biblio-tests.xqm
@@ -51,7 +51,7 @@ declare
 
 declare 
     %test:args('A111038')         %test:assertEquals("„Ei, dem alten Herrn zoll’ ich Achtung gern’“. Festschrift für Joachim Veit zum 60. Geburtstag (2016), S. 89–99")
-    %test:args('A113127')         %test:assertEquals("Salzburger Volksblatt, Jg. 28, Nr. 95 (28. April 1898), S. 3, Jg. 28, Nr. 96 (29. April 1898), S. 3")
+    %test:args('A113127')         %test:assertEquals("Salzburger Volksblatt, Jg. 28, Nr. 95, 96 (28. und 29. April 1898), S. 3")
     %test:args('A110998')         %test:assertEquals("Schlesien. Eine Vierteljahresschrift für Kunst, Wissenschaft und Volkstum, Jg. 19 (1974), Nr. 3, S. 158–162")
     function bt:test-printJournalCitation($a as xs:string) as xs:string {
         let $doc := crud:doc($a)
@@ -85,7 +85,7 @@ declare
 declare 
     %test:args('A112915')         %test:assertXPath("$result//xhtml:span[@class='title'] and $result//xhtml:span[@class='author'] and $result//xhtml:span[@class='journalTitle']")
     %test:args('A112660')         %test:assertEquals("<xhtml:div xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:span class='author'>Kurt Mey</xhtml:span>, <xhtml:span class='title'>Richard Wagners Webertrauermarsch</xhtml:span>, in: <xhtml:span class='journalTitle'>Die Musik</xhtml:span><xhtml:span class='imprint'>, Bd.&#160;22, Jg.&#160;6, Heft&#160;12 (März 1907), S.&#160;331–336</xhtml:span></xhtml:div>")
-    %test:args('A111869')         %test:assertEquals("<xhtml:div xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:span class='author'>Carl Mennicke</xhtml:span>, <xhtml:span class='title'>Unbekannte Schriften von Carl Maria von Weber</xhtml:span>, in: <xhtml:span class='journalTitleForMultipleImprints'>Blätter für Haus- und Kirchenmusik</xhtml:span><xhtml:span class='imprintSection'>, Jg.&#160;14, Nr.&#160;4 (1. Januar 1910), S.&#160;52–54</xhtml:span><xhtml:span class='imprintSection'>, Jg.&#160;14, Nr.&#160;5 (1. Februar 1910), S.&#160;71–73</xhtml:span><xhtml:span class='imprintSection'>, Jg.&#160;14, Nr.&#160;6 (1. März 1910), S.&#160;86–91</xhtml:span></xhtml:div>")
+    %test:args('A111869')         %test:assertEquals("<xhtml:div xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:span class='author'>Carl Mennicke</xhtml:span>, <xhtml:span class='title'>Unbekannte Schriften von Carl Maria von Weber</xhtml:span>, in: <xhtml:span class='journalTitleForMultipleImprints'>Blätter für Haus- und Kirchenmusik</xhtml:span><xhtml:span class='imprintSection'>, Jg. 14, Nr. 4 (1. Januar 1910), S. 52–54</xhtml:span><xhtml:span class='imprintSection'>, Jg. 14, Nr. 5 (2. Februar 1910), S. 71–73</xhtml:span><xhtml:span class='imprintSection'>, Jg. 14, Nr. 4-6 (3. März 1910), S. 86–91</xhtml:span></xhtml:div>")
     function bt:test-printArticleCitation($a as xs:string) as element() {
         let $doc := crud:doc($a)
         return
@@ -151,7 +151,7 @@ declare
 
 declare
     %test:args('A111869')         %test:assertXPath("count($result/xhtml:li) eq 3 and count($result/xhtml:li/xhtml:span[@class='journalTitle'][.='Blätter für Haus- und Kirchenmusik']) eq 3")
-    %test:args('A111869')         %test:assertEquals("<xhtml:ul xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:li><xhtml:span class='journalTitle'>Blätter für Haus- und Kirchenmusik</xhtml:span><xhtml:span class='imprintSection'>, Jg. 14, Nr. 4 (1. Januar 1910), S. 52–54</xhtml:span></xhtml:li><xhtml:li xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:span class='journalTitle'>Blätter für Haus- und Kirchenmusik</xhtml:span><xhtml:span class='imprintSection'>, Jg. 14, Nr. 5 (1. Februar 1910), S. 71–73</xhtml:span></xhtml:li><xhtml:li xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:span class='journalTitle'>Blätter für Haus- und Kirchenmusik</xhtml:span><xhtml:span class='imprintSection'>, Jg. 14, Nr. 6 (1. März 1910), S. 86–91</xhtml:span></xhtml:li></xhtml:ul>")
+    %test:args('A111869')         %test:assertEquals("<xhtml:ul xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:li><xhtml:span class='journalTitle'>Blätter für Haus- und Kirchenmusik</xhtml:span><xhtml:span class='imprintSection'>, Jg. 14, Nr. 4 (1. Januar 1910), S. 52–54</xhtml:span></xhtml:li><xhtml:li><xhtml:span class='journalTitle'>Blätter für Haus- und Kirchenmusik</xhtml:span><xhtml:span class='imprintSection'>, Jg. 14, Nr. 5 (2. Februar 1910), S. 71–73</xhtml:span></xhtml:li><xhtml:li><xhtml:span class='journalTitle'>Blätter für Haus- und Kirchenmusik</xhtml:span><xhtml:span class='imprintSection'>, Jg. 14, Nr. 4-6 (3. März 1910), S. 86–91</xhtml:span></xhtml:li></xhtml:ul>")
     function bt:test-printJournalCitationPerImprint($a as xs:string) as element()+ {
         let $doc := crud:doc($a)
         return

--- a/testing/xqsuite/biblio-tests.xqm
+++ b/testing/xqsuite/biblio-tests.xqm
@@ -154,7 +154,7 @@ declare
     function bt:test-printJournalCitationsByImprint($a as xs:string) as element()+ {
         let $doc := crud:doc($a)
         return
-            bibl:printJournalCitationsByImprint($doc//tei:monogr, <xhtml:li/>, 'de')
+            bibl:printJournalCitationPerImprint($doc//tei:monogr, <xhtml:li/>, 'de')
 };
 
 declare %private function bt:normalize-hrefs($nodes as node()*) as node()* {

--- a/testing/xqsuite/biblio-tests.xqm
+++ b/testing/xqsuite/biblio-tests.xqm
@@ -92,14 +92,6 @@ declare
 };
 
 declare 
-    %test:args('A112067')         %test:assertEquals("<xhtml:div xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:span class='author'>Heinrich Dorn</xhtml:span>, <xhtml:span class='title'>Aus meinem Leben. Im Elfenreich</xhtml:span></xhtml:div>")
-    function bt:test-multipleImprints($a as xs:string) as element() {
-        let $doc := crud:doc($a)
-        return
-            bibl:printArticleCitation($doc/tei:biblStruct, <xhtml:div/>, 'de')
-};
-
-declare 
     %test:args('A110876')         %test:assertEquals("<xhtml:div xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:span class='author'>Karl Robert Brachtel</xhtml:span>,  [Rezension] <xhtml:span class='title'><a class='preview biblio A110900' href='A007979/Bibliographie/A110900.html'>Hans Hoffmann: „Carl Maria von Weber – Leben und Werk“, Druck- und Verlagsgesellschaft, Husum 1978</a></xhtml:span>, in: <xhtml:span class='journalTitle'>Das Orchester</xhtml:span>, Jg.&#160;27 (1979), Heft&#160;10, S.&#160;774</xhtml:div>")
     function bt:test-printReview($a as xs:string) as node()* {
         let $doc := crud:doc($a)

--- a/testing/xqsuite/biblio-tests.xqm
+++ b/testing/xqsuite/biblio-tests.xqm
@@ -51,7 +51,7 @@ declare
 
 declare 
     %test:args('A111038')         %test:assertEquals("„Ei, dem alten Herrn zoll’ ich Achtung gern’“. Festschrift für Joachim Veit zum 60. Geburtstag (2016), S. 89–99")
-    %test:args('A113127')         %test:assertEquals("Salzburger Volksblatt, Jg. 28, Nr. 95, 96 (28. und 29. April 1898), S. 3")
+    %test:args('A113127')         %test:assertEquals("Salzburger Volksblatt, Jg. 28, Nr. 95 (28. April 1898), S. 3, Jg. 28, Nr. 96 (29. April 1898), S. 3")
     %test:args('A110998')         %test:assertEquals("Schlesien. Eine Vierteljahresschrift für Kunst, Wissenschaft und Volkstum, Jg. 19 (1974), Nr. 3, S. 158–162")
     function bt:test-printJournalCitation($a as xs:string) as xs:string {
         let $doc := crud:doc($a)
@@ -84,8 +84,8 @@ declare
 
 declare 
     %test:args('A112915')         %test:assertXPath("$result//xhtml:span[@class='title'] and $result//xhtml:span[@class='author'] and $result//xhtml:span[@class='journalTitle']")
-    %test:args('A112660')         %test:assertEquals("<xhtml:div xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:span class='author'>Kurt Mey</xhtml:span>, <xhtml:span class='title'>Richard Wagners Webertrauermarsch</xhtml:span>, in: <xhtml:span class='journalTitle'>Die Musik</xhtml:span>, Bd.&#160;22, Jg.&#160;6, Heft&#160;12 (März 1907), S.&#160;331–336</xhtml:div>")
-    %test:args('A111869')         %test:assertEquals("<xhtml:div xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:span class='author'>Carl Mennicke</xhtml:span>, <xhtml:span class='title'>Unbekannte Schriften von Carl Maria von Weber</xhtml:span></xhtml:div>")
+    %test:args('A112660')         %test:assertEquals("<xhtml:div xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:span class='author'>Kurt Mey</xhtml:span>, <xhtml:span class='title'>Richard Wagners Webertrauermarsch</xhtml:span>, in: <xhtml:span class='journalTitle'>Die Musik</xhtml:span><xhtml:span class='imprint'>, Bd.&#160;22, Jg.&#160;6, Heft&#160;12 (März 1907), S.&#160;331–336</xhtml:span></xhtml:div>")
+    %test:args('A111869')         %test:assertEquals("<xhtml:div xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:span class='author'>Carl Mennicke</xhtml:span>, <xhtml:span class='title'>Unbekannte Schriften von Carl Maria von Weber</xhtml:span>, in: <xhtml:span class='journalTitleForMultipleImprints'>Blätter für Haus- und Kirchenmusik</xhtml:span><xhtml:span class='imprintSection'>, Jg.&#160;14, Nr.&#160;4 (1. Januar 1910), S.&#160;52–54</xhtml:span><xhtml:span class='imprintSection'>, Jg.&#160;14, Nr.&#160;5 (1. Februar 1910), S.&#160;71–73</xhtml:span><xhtml:span class='imprintSection'>, Jg.&#160;14, Nr.&#160;6 (1. März 1910), S.&#160;86–91</xhtml:span></xhtml:div>")
     function bt:test-printArticleCitation($a as xs:string) as element() {
         let $doc := crud:doc($a)
         return
@@ -93,7 +93,7 @@ declare
 };
 
 declare 
-    %test:args('A110876')         %test:assertEquals("<xhtml:div xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:span class='author'>Karl Robert Brachtel</xhtml:span>,  [Rezension] <xhtml:span class='title'><a class='preview biblio A110900' href='A007979/Bibliographie/A110900.html'>Hans Hoffmann: „Carl Maria von Weber – Leben und Werk“, Druck- und Verlagsgesellschaft, Husum 1978</a></xhtml:span>, in: <xhtml:span class='journalTitle'>Das Orchester</xhtml:span>, Jg.&#160;27 (1979), Heft&#160;10, S.&#160;774</xhtml:div>")
+    %test:args('A110876')         %test:assertEquals("<xhtml:div xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:span class='author'>Karl Robert Brachtel</xhtml:span>,  [Rezension] <xhtml:span class='title'><a class='preview biblio A110900' href='A007979/Bibliographie/A110900.html'>Hans Hoffmann: „Carl Maria von Weber – Leben und Werk“, Druck- und Verlagsgesellschaft, Husum 1978</a></xhtml:span>, in: <xhtml:span class='journalTitle'>Das Orchester</xhtml:span><xhtml:span class='imprint'>, Jg.&#160;27 (1979), Heft&#160;10, S.&#160;774</xhtml:span></xhtml:div>")
     function bt:test-printReview($a as xs:string) as node()* {
         let $doc := crud:doc($a)
         return
@@ -130,7 +130,7 @@ declare
     function bt:test-NZfM-biblScope($a as xs:string) as text()* {
         let $doc := crud:doc($a)
         return
-            bibl:printJournalCitation($doc//tei:monogr, <xhtml:div/>, 'de')/node()[last()]
+            bibl:printJournalCitation($doc//tei:monogr, <xhtml:div/>, 'de')/node()[last()]/text()
 };
 
 declare
@@ -150,11 +150,12 @@ declare
 };
 
 declare
-    %test:args('A111869')         %test:assertXPath("count($result) eq 3 and count($result/xhtml:span[@class='journalTitle'][.='Blätter für Haus- und Kirchenmusik']) eq 3")
-    function bt:test-printJournalCitationsByImprint($a as xs:string) as element()+ {
+    %test:args('A111869')         %test:assertXPath("count($result/xhtml:li) eq 3 and count($result/xhtml:li/xhtml:span[@class='journalTitle'][.='Blätter für Haus- und Kirchenmusik']) eq 3")
+    %test:args('A111869')         %test:assertEquals("<xhtml:ul xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:li><xhtml:span class='journalTitle'>Blätter für Haus- und Kirchenmusik</xhtml:span><xhtml:span class='imprintSection'>, Jg. 14, Nr. 4 (1. Januar 1910), S. 52–54</xhtml:span></xhtml:li><xhtml:li xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:span class='journalTitle'>Blätter für Haus- und Kirchenmusik</xhtml:span><xhtml:span class='imprintSection'>, Jg. 14, Nr. 5 (1. Februar 1910), S. 71–73</xhtml:span></xhtml:li><xhtml:li xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:span class='journalTitle'>Blätter für Haus- und Kirchenmusik</xhtml:span><xhtml:span class='imprintSection'>, Jg. 14, Nr. 6 (1. März 1910), S. 86–91</xhtml:span></xhtml:li></xhtml:ul>")
+    function bt:test-printJournalCitationPerImprint($a as xs:string) as element()+ {
         let $doc := crud:doc($a)
         return
-            bibl:printJournalCitationPerImprint($doc//tei:monogr, <xhtml:li/>, 'de')
+            <xhtml:ul>{bibl:printJournalCitationPerImprint($doc//tei:monogr, <xhtml:li/>, 'de')}</xhtml:ul>
 };
 
 declare %private function bt:normalize-hrefs($nodes as node()*) as node()* {


### PR DESCRIPTION
This will handle articles with multiple imprints, omit the journal title from the citation and add a list of all journal and issues in which the text was published.

Here an example:
<img width="622" height="347" alt="image" src="https://github.com/user-attachments/assets/f89c7aa2-e771-40e6-bdfa-bab0991d216a" />

And one example where we even have links to the texts and might think about adding the links to the actual issue titles in the future:
<img width="812" height="1004" alt="image" src="https://github.com/user-attachments/assets/f4aff9c8-1f4e-49d7-a841-45db0efda036" />

