### PR TITLE
omit interlinking `, in: `when rendering journals without a corresponding article

### DIFF
--- a/modules/bibl.xqm
+++ b/modules/bibl.xqm
@@ -124,7 +124,7 @@ declare function bibl:printArticleCitation($biblStruct as element(tei:biblStruct
             if(exists($authors)) then ($authors, ', ') else (), 
             if($biblStruct[@type='review']) then '[' || lang:get-language-string('review', $lang) || '] ' else (),
             if($articleTitle) then (bibl:printTitles($articleTitle, ())) else (),
-            if($journalCitation) then (', in: ') else (),
+            if(exists($articleTitle) and exists($journalCitation)) then (', in: ') else (),
             $journalCitation/xhtml:span,
             $journalCitation/text(),
             $note

--- a/testing/expected-results/writings/A031201.html
+++ b/testing/expected-results/writings/A031201.html
@@ -506,7 +506,7 @@
                                     <div>
                                         <strong><span>2. Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry"><span class="author">ohne Verfasserangabe</span>,  , in: <span class="journalTitle">Musicalische Zeitung für die österreichischen Staaten</span><span class="imprint">, Jg. 2, Nr. 2 (14. Januar 1813), S. 5–6</span><a class="noteMarker biblioNote" data-toggle="popover" data-ref="#C_22">*</a>
+                                        <span class="biblio-entry"><span class="author">ohne Verfasserangabe</span>,  <span class="journalTitle">Musicalische Zeitung für die österreichischen Staaten</span><span class="imprint">, Jg. 2, Nr. 2 (14. Januar 1813), S. 5–6</span><a class="noteMarker biblioNote" data-toggle="popover" data-ref="#C_22">*</a>
                                                     <div id="C_22" data-title="Bemerkung" style="display:none;">Siehe auch Nr. 3 (21. Januar 1813), S. 9–10.</div></span>
                                                                               
                                         <div class="collapse apparatus-details" id="source_49c46ac66f4cb943996f6c325605a790">

--- a/testing/expected-results/writings/A031425.html
+++ b/testing/expected-results/writings/A031425.html
@@ -488,7 +488,7 @@
                                                     <li>
                                                         <div>
                                                             
-                                                            <span class="biblio-entry">, in: <span class="journalTitle">Allgemeine Musikalische Zeitung (Intelligenzblatt)</span><span class="imprint">, Jg. 26, Nr. 7 (August 1824) bis auf orthographische Unterschiede und Sperrungen identische Version; Preisangabe hier auch zusätzlich in 5 Thlr. 20 Gr., Sp. 30–32</span></span>
+                                                            <span class="biblio-entry"><span class="journalTitle">Allgemeine Musikalische Zeitung (Intelligenzblatt)</span><span class="imprint">, Jg. 26, Nr. 7 (August 1824) bis auf orthographische Unterschiede und Sperrungen identische Version; Preisangabe hier auch zusätzlich in 5 Thlr. 20 Gr., Sp. 30–32</span></span>
                                                               
                                                             <div class="collapse" id="source_0256ded1edad87f224a5f793a1532b8d">
                                                                 

--- a/testing/expected-results/writings/A031691.html
+++ b/testing/expected-results/writings/A031691.html
@@ -454,7 +454,7 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry">, in: <span class="journalTitle">Kaiserlich Königlich privilegirte Prager Zeitung</span><span class="imprint">, Jg. 1, Nr. 16 (17. April 1814), S. 61</span></span>
+                                        <span class="biblio-entry"><span class="journalTitle">Kaiserlich Königlich privilegirte Prager Zeitung</span><span class="imprint">, Jg. 1, Nr. 16 (17. April 1814), S. 61</span></span>
                                                                               
                                         <div class="collapse apparatus-details" id="source_a20dde7d5745051f7b46d7a0d0804753">
                                             

--- a/testing/expected-results/writings/A032512.html
+++ b/testing/expected-results/writings/A032512.html
@@ -734,7 +734,7 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry">, in: <span class="journalTitle">Königl. privilegirte Berlinische Zeitung</span><span class="imprint">, Heft 138 (16. Juni 1867) Erste Beilage, Sonntags-Beilage Nr. 24, S. 93–95</span></span>
+                                        <span class="biblio-entry"><span class="journalTitle">Königl. privilegirte Berlinische Zeitung</span><span class="imprint">, Heft 138 (16. Juni 1867) Erste Beilage, Sonntags-Beilage Nr. 24, S. 93–95</span></span>
                                         <span>
                                             <a data-toggle="collapse" aria-expanded="false" title="Details" class="collapseMarker collapsed" role="button" href="#source_7310998162cf0caf7ebe32bc6645d7d9"></a>                                                                                                                                                                               
                                         </span>                                      

--- a/testing/expected-results/writings/A032615.html
+++ b/testing/expected-results/writings/A032615.html
@@ -682,7 +682,7 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry">, in: <span class="journalTitle">Neue Zeitschrift für Musik</span><span class="imprint">, Jg. 55, Bd. 83, Nr. 4 (25. Januar 1888), S. 44–45</span></span>
+                                        <span class="biblio-entry"><span class="journalTitle">Neue Zeitschrift für Musik</span><span class="imprint">, Jg. 55, Bd. 83, Nr. 4 (25. Januar 1888), S. 44–45</span></span>
                                                                               
                                         <div class="collapse apparatus-details" id="source_0a179589e337c924bde973e5da1664da">
                                             

--- a/testing/expected-results/writings/A032654.html
+++ b/testing/expected-results/writings/A032654.html
@@ -420,7 +420,7 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry">, in: <span class="journalTitle">Journal für Literatur, Kunst, Luxus und Mode</span><span class="imprint">, Jg. 31 (September 1816), S. 579</span></span>
+                                        <span class="biblio-entry"><span class="journalTitle">Journal für Literatur, Kunst, Luxus und Mode</span><span class="imprint">, Jg. 31 (September 1816), S. 579</span></span>
                                                                               
                                         <div class="collapse apparatus-details" id="source_ed9f5edc1937195056883aac40f98439">
                                             

--- a/testing/expected-results/writings/A032763.html
+++ b/testing/expected-results/writings/A032763.html
@@ -726,7 +726,7 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry">, in: <span class="journalTitle">Neue Zeitschrift für Musik</span><span class="imprint">, Jg. 55, Bd. 83, Nr. 3 (18. Januar 1888), S. 32–33</span></span>
+                                        <span class="biblio-entry"><span class="journalTitle">Neue Zeitschrift für Musik</span><span class="imprint">, Jg. 55, Bd. 83, Nr. 3 (18. Januar 1888), S. 32–33</span></span>
                                                                               
                                         <div class="collapse apparatus-details" id="source_78f87d52529b48995183eb3150ac845c">
                                             

--- a/testing/expected-results/writings/A033440.html
+++ b/testing/expected-results/writings/A033440.html
@@ -434,7 +434,7 @@
                                     <div>
                                         <strong><span>Textzeuge</span>:</strong>
                                         
-                                        <span class="biblio-entry">, in: <span class="journalTitle">Königlich privilegirte Berlinische Zeitung von Staats- und gelehrten Sachen</span><span class="imprint">, Nr. 63 (26. Mai 1812)</span></span>
+                                        <span class="biblio-entry"><span class="journalTitle">Königlich privilegirte Berlinische Zeitung von Staats- und gelehrten Sachen</span><span class="imprint">, Nr. 63 (26. Mai 1812)</span></span>
                                                                               
                                         <div class="collapse apparatus-details" id="source_ae6204db65c1406908ca8ef28a8d133b">
                                             

--- a/testing/xqsuite/biblio-tests.xqm
+++ b/testing/xqsuite/biblio-tests.xqm
@@ -101,6 +101,15 @@ declare
             bibl:printArticleCitation($doc/tei:biblStruct, <xhtml:div/>, 'de')
 };
 
+declare
+    %test:args('A031425')         %test:assertXPath("$result/xhtml:span[1][@class='journalTitle'][. = 'Allgemeine Musikalische Zeitung (Intelligenzblatt)'] and not($result/node()[1][self::text()[contains(., ', in:')]])")
+    function bt:test-printCitation-journal-without-article-title($a as xs:string) as element() {
+        let $doc := crud:doc($a)
+        let $biblStruct := $doc//tei:relatedItem/tei:biblStruct[tei:monogr/tei:title = 'Allgemeine Musikalische Zeitung (Intelligenzblatt)'][1]
+        return
+            bibl:printCitation($biblStruct, <xhtml:div/>, 'de')
+};
+
 declare 
     %test:args('A110876')         %test:assertEquals("<xhtml:div xmlns:xhtml='http://www.w3.org/1999/xhtml'><xhtml:span class='author'>Karl Robert Brachtel</xhtml:span>,  [Rezension] <xhtml:span class='title'><a class='preview biblio A110900' href='A007979/Bibliographie/A110900.html'>Hans Hoffmann: „Carl Maria von Weber – Leben und Werk“, Druck- und Verlagsgesellschaft, Husum 1978</a></xhtml:span>, in: <xhtml:span class='journalTitle'>Das Orchester</xhtml:span><xhtml:span class='imprint'>, Jg.&#160;27 (1979), Heft&#160;10, S.&#160;774</xhtml:span></xhtml:div>")
     function bt:test-printReview($a as xs:string) as node()* {


### PR DESCRIPTION
This should fix the problem of #695.

I also added a unit test for this case and updated the expected results. The action test is failing due to the wikipedia problem, but locally all tests run through.