### PR TITLE
set engine and type in package.json

### DIFF
--- a/.github/workflows/artifacts.yml
+++ b/.github/workflows/artifacts.yml
@@ -15,10 +15,10 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-      - name: Set up Node 25
+      - name: Set up Node 26
         uses: actions/setup-node@v6
         with:
-          node-version: 25
+          node-version: 26
       - name: Build with Ant
         run: ant clean xar
       - name: Archive xar package

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "author": "Peter Stadler <stadlerpeter@yahoo.fr>",
   "license": "(BSD-2-Clause OR CC-BY-4.0)",
   "private": false,
+  "engines": {
+    "node": ">= 26.0.0"
+  },
+  "type": "module",
   "dependencies": {
     "@fortawesome/fontawesome-free": "^7.2.0",
     "Easy-Responsive-Tabs-to-Accordion": "https://github.com/peterstadler/Easy-Responsive-Tabs-to-Accordion#develop",


### PR DESCRIPTION
… to make the dependencies and prerequisites more clear.

##  fix 1
with the engine setting older node versions will fail at the `ant yarn` stage:
```sh
yarn:
     [exec] yarn install v1.22.22
     [exec] [1/5] Validating package.json...
     [exec] info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
     [exec] error WeGA-WebApp@4.14.0: The engine "node" is incompatible with this module. Expected version ">= 26.0.0". Got "24.18.0"
     [exec] error Found incompatible module.

BUILD FAILED
/data/build.xml:52: exec returned: 1
```

## fix 2
Setting the `type` information responds to the warning at the `ant webpack` stage:
```sh
webpack:
     [exec] (node:33713) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///Users/pstadler/repos/WeGA-WebApp/webpack.config.js is not specified and it doesn't parse as CommonJS.
     [exec] Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
     [exec] To eliminate this warning, add "type": "module" to /Users/pstadler/repos/WeGA-WebApp/package.json.
     …
```