### PR TITLE
remove JavaScript from Wikipedia Ajax response

### DIFF
--- a/templates/ajax/wikipedia.html
+++ b/templates/ajax/wikipedia.html
@@ -2,8 +2,4 @@
     <h2>Wikipedia</h2>
     <div data-template="app:wikipedia-text">Wikipedia Text</div>
     <p class="linkAppendix" data-template="app:wikipedia-disclaimer">Wikipedia Disclaimer</p>
-    <script type="text/javascript">
-        $('.toggle-toc-item').on('click', toggleTocItems);
-        $('.toggle-toc-item').each(toggleTocItems);
-    </script>
 </div>


### PR DESCRIPTION
a) this is not working anymore since we've switched to js module 
b) this is not needed anymore since Wikipedia has changed its TOC for articles