### PR TITLE
add musical-symbols as fallback font for preview paragraphs

### DIFF
--- a/resources/sass/components/_popover.scss
+++ b/resources/sass/components/_popover.scss
@@ -86,7 +86,7 @@
     }
     p {
         margin-bottom: 5px;
-        font-family: $font-family-sans-serif;
+        font-family: $font-family-sans-serif, musical-symbols;
     }
     span.tei_lemma {
         margin-bottom: 6px;


### PR DESCRIPTION
This should fix the rendering problem of musical symbols explained in #423.

Apparently Chrome and Firefox have a fallback for musical symbols, while Safari doesn't. (At least I could only recreate the issue with Safari.) I added `musical-symbols` to the font-family for `.popover-body p` since the summary is flattened to plain text aswell, so this should work for the whole popover content.
I couldn't find any false positives so far and hope that this should do the trick.