### PR TITLE
update WeGA-WebApp-Mirador to v0.6.0

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -63,7 +63,7 @@
     
     <target name="wega-mirador" depends="init">
         <description>Update javascript libraries via yarn</description>
-        <get src="https://github.com/Edirom/WeGA-WebApp-Mirador/releases/download/v0.5.0/WeGA-WebApp-Mirador.zip" dest="${tmp.dir}" skipexisting="yes"/>
+        <get src="https://github.com/Edirom/WeGA-WebApp-Mirador/releases/download/v0.6.0/WeGA-WebApp-Mirador.zip" dest="${tmp.dir}" skipexisting="yes"/>
         <mkdir dir="${dist.dir}/resources/lib/wega-mirador"/>
         <unzip src="${tmp.dir}/WeGA-WebApp-Mirador.zip" dest="${dist.dir}/resources/lib/wega-mirador">
             <patternset>


### PR DESCRIPTION
This simply updates the WeGA-WebApp-Mirador dependency to v0.6.0 and introduces Mirador v4.2.4